### PR TITLE
Update to provider due to launch of Xanadu device

### DIFF
--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -10,13 +10,11 @@ from braket.device_schema import (
     GateModelQpuParadigmProperties,
     DeviceActionType,
 )
-from braket.device_schema.dwave import DwaveDeviceCapabilities
 from braket.device_schema.ionq import IonqDeviceCapabilities
 from braket.device_schema.oqc import OqcDeviceCapabilities
 from braket.device_schema.rigetti import (
     RigettiDeviceCapabilities,
 )
-from braket.device_schema.xanadu import XanaduDeviceCapabilities
 from braket.device_schema.simulators import (
     GateModelSimulatorDeviceCapabilities,
     GateModelSimulatorParadigmProperties,
@@ -303,9 +301,6 @@ def aws_device_to_target(device: AwsDevice) -> Target:
                             simulator_instruction_props[(dst, src)] = None
             target.add_instruction(instruction, simulator_instruction_props)
 
-    # annealing devices
-    elif isinstance(properties, DwaveDeviceCapabilities):
-        raise NotImplementedError("Dwave devices are not supported yet.")
     else:
         raise QiskitBraketException(
             f"Cannot convert to target. "

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -16,6 +16,7 @@ from braket.device_schema.oqc import OqcDeviceCapabilities
 from braket.device_schema.rigetti import (
     RigettiDeviceCapabilities,
 )
+from braket.device_schema.xanadu import XanaduDeviceCapabilities
 from braket.device_schema.simulators import (
     GateModelSimulatorDeviceCapabilities,
     GateModelSimulatorParadigmProperties,

--- a/qiskit_braket_provider/providers/braket_provider.py
+++ b/qiskit_braket_provider/providers/braket_provider.py
@@ -38,9 +38,8 @@ class AWSBraketProvider(ProviderV1):
         supported_devices = [
             d
             for d in devices
-            if not (
-                isinstance(d.properties, DwaveDeviceCapabilities)
-                or isinstance(d.properties, XanaduDeviceCapabilities)
+            if not isinstance(
+                d.properties, (DwaveDeviceCapabilities, XanaduDeviceCapabilities)
             )
         ]
         backends = []

--- a/qiskit_braket_provider/providers/braket_provider.py
+++ b/qiskit_braket_provider/providers/braket_provider.py
@@ -2,6 +2,7 @@
 
 from braket.aws import AwsDevice
 from braket.device_schema.dwave import DwaveDeviceCapabilities
+from braket.device_schema.xanadu import XanaduDeviceCapabilities
 from qiskit.providers import ProviderV1
 
 from .braket_backend import AWSBraketBackend, BraketLocalBackend
@@ -35,7 +36,7 @@ class AWSBraketProvider(ProviderV1):
         # filter by supported devices
         # gate models are only supported
         supported_devices = [
-            d for d in devices if not isinstance(d.properties, DwaveDeviceCapabilities)
+            d for d in devices if not (isinstance(d.properties, DwaveDeviceCapabilities) or isinstance(d.properties,XanaduDeviceCapabilities))
         ]
         backends = []
         for device in supported_devices:

--- a/qiskit_braket_provider/providers/braket_provider.py
+++ b/qiskit_braket_provider/providers/braket_provider.py
@@ -36,7 +36,12 @@ class AWSBraketProvider(ProviderV1):
         # filter by supported devices
         # gate models are only supported
         supported_devices = [
-            d for d in devices if not (isinstance(d.properties, DwaveDeviceCapabilities) or isinstance(d.properties,XanaduDeviceCapabilities))
+            d
+            for d in devices
+            if not (
+                isinstance(d.properties, DwaveDeviceCapabilities)
+                or isinstance(d.properties, XanaduDeviceCapabilities)
+            )
         ]
         backends = []
         for device in supported_devices:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 certifi>=2021.5.30
 qiskit-aer>=0.10.2
 qiskit-terra>=0.19.2
-amazon-braket-sdk>=1.18.0
+amazon-braket-sdk>=1.24.0
 retrying==1.3.3
 
 setuptools>=40.1.0


### PR DESCRIPTION
With the launch of the Borealis Xanadu device on Braket (https://aws.amazon.com/blogs/quantum-computing/explore-quantum-computational-advantage-with-xanadus-borealis-device-on-amazon-braket/) the provider needs to be modified to handle the new schema and ignore the photonic device.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary
An adjustment is needed to account for and filter out the newly launched photonic device Borealis from Xanadu, https://aws.amazon.com/blogs/quantum-computing/explore-quantum-computational-advantage-with-xanadus-borealis-device-on-amazon-braket/.

### Details and comments
The schema imports have been updated and the device is filtered out as it is not a universal gate quantum computer.
