### PR TITLE
Update Amazon Braket user agent 

### DIFF
--- a/qiskit_braket_provider/providers/braket_backend.py
+++ b/qiskit_braket_provider/providers/braket_backend.py
@@ -5,6 +5,7 @@ import datetime
 import logging
 from abc import ABC
 from typing import Iterable, Union, List
+import pkg_resources
 
 from braket.aws import AwsDevice, AwsQuantumTaskBatch, AwsQuantumTask
 from braket.circuits import Circuit
@@ -171,6 +172,9 @@ class AWSBraketBackend(BraketBackend):
             backend_version=backend_version,
             **fields,
         )
+        pkg_version = pkg_resources.get_distribution("qiskit-braket-provider").version
+        user_agent = f"QiskitBraketProvider/{pkg_version}"
+        device.aws_session.add_braket_user_agent(user_agent)
         self._device = device
         self._target = aws_device_to_target(device=device)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 certifi>=2021.5.30
 qiskit-aer>=0.10.2
 qiskit-terra>=0.19.2
-amazon-braket-sdk>=1.24.0
+amazon-braket-sdk>=1.25.0
 retrying==1.3.3
 
 setuptools>=40.1.0

--- a/tests/providers/test_braket_backend.py
+++ b/tests/providers/test_braket_backend.py
@@ -2,6 +2,7 @@
 import unittest
 from unittest import TestCase
 from unittest.mock import Mock
+import pkg_resources
 
 from qiskit import QuantumCircuit, transpile, BasicAer
 from qiskit.algorithms import VQE, VQEResult
@@ -36,6 +37,11 @@ class TestAWSBraketBackend(TestCase):
         self.assertTrue(backend)
         self.assertIsInstance(backend.target, Target)
         self.assertIsNone(backend.max_circuits)
+        user_agent = (
+            f"QiskitBraketProvider/"
+            f"{pkg_resources.get_distribution('qiskit-braket-provider').version}"
+        )
+        device.aws_session.add_braket_user_agent.assert_called_with(user_agent)
         with self.assertRaises(NotImplementedError):
             backend.drive_channel(0)
         with self.assertRaises(NotImplementedError):

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ commands =
   black --check {posargs} .
   pylint -rn qiskit_braket_provider tests
   nbqa pylint docs/ --disable=pointless-statement,missing-module-docstring,invalid-name,expression-not-assigned,duplicate-code,import-error
-  mypy .
+  mypy --install-types --non-interactive .
 
 [testenv:black]
 envdir = .tox/lint


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
This change populates the QiskitBraketProvider user agent version information for Amazon Braket.


### Details and comments
* Adds the QiskitBraketProvider user agent version information to the AwsSession tied to the AwsDevice.
* Updated mypy command in tox.ini to include any types (as recommended [here](https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports))

