### PR TITLE
Add ECR gate to mappers

### DIFF
--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -29,6 +29,7 @@ from qiskit.circuit.library import (
     CSwapGate,
     CYGate,
     CZGate,
+    ECRGate,
     IGate,
     RXGate,
     RYGate,
@@ -86,6 +87,7 @@ qiskit_to_braket_gate_names_mapping = {
     "cp": "cphaseshift",
     "rxx": "xx",
     "ryy": "yy",
+    "ecr": "ecr"
 }
 
 
@@ -124,6 +126,7 @@ qiskit_gate_names_to_braket_gates: Dict[str, Callable] = {
     "cswap": lambda: [gates.CSwap()],
     "rxx": lambda angle: [gates.XX(angle)],
     "ryy": lambda angle: [gates.YY(angle)],
+    "ecr": lambda: [gates.ECR()]
 }
 
 
@@ -156,6 +159,7 @@ qiskit_gate_name_to_braket_gate_mapping: Dict[str, Optional[QiskitInstruction]] 
     "yy": RYYGate(Parameter("theta")),
     "z": ZGate(),
     "zz": RZZGate(Parameter("theta")),
+    "ecr": ECRGate()
 }
 
 

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -87,7 +87,7 @@ qiskit_to_braket_gate_names_mapping = {
     "cp": "cphaseshift",
     "rxx": "xx",
     "ryy": "yy",
-    "ecr": "ecr"
+    "ecr": "ecr",
 }
 
 
@@ -126,7 +126,7 @@ qiskit_gate_names_to_braket_gates: Dict[str, Callable] = {
     "cswap": lambda: [gates.CSwap()],
     "rxx": lambda angle: [gates.XX(angle)],
     "ryy": lambda angle: [gates.YY(angle)],
-    "ecr": lambda: [gates.ECR()]
+    "ecr": lambda: [gates.ECR()],
 }
 
 
@@ -159,7 +159,7 @@ qiskit_gate_name_to_braket_gate_mapping: Dict[str, Optional[QiskitInstruction]] 
     "yy": RYYGate(Parameter("theta")),
     "z": ZGate(),
     "zz": RZZGate(Parameter("theta")),
-    "ecr": ECRGate()
+    "ecr": ECRGate(),
 }
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

This adds ECR gate to mappers in the `adapters.py` module. Without this addition, running circuits containing the ECR gate through any of the AWS backends is impossible.

### Details and comments

No unit tests were added since there are already tests checking all the mappers. There are also no specific tests for other gates, so I wanted to stay consistent.
