### PR TITLE
Adjust provider after launch of QuEra

### DIFF
--- a/qiskit_braket_provider/providers/braket_provider.py
+++ b/qiskit_braket_provider/providers/braket_provider.py
@@ -3,6 +3,7 @@
 from braket.aws import AwsDevice
 from braket.device_schema.dwave import DwaveDeviceCapabilities
 from braket.device_schema.xanadu import XanaduDeviceCapabilities
+from braket.device_schema.quera import QueraDeviceCapabilities
 from qiskit.providers import ProviderV1
 
 from .braket_backend import AWSBraketBackend, BraketLocalBackend
@@ -39,7 +40,12 @@ class AWSBraketProvider(ProviderV1):
             d
             for d in devices
             if not isinstance(
-                d.properties, (DwaveDeviceCapabilities, XanaduDeviceCapabilities)
+                d.properties,
+                (
+                    DwaveDeviceCapabilities,
+                    XanaduDeviceCapabilities,
+                    QueraDeviceCapabilities,
+                ),
             )
         ]
         backends = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 certifi>=2021.5.30
 qiskit-aer>=0.10.2
 qiskit-terra>=0.19.2
-amazon-braket-sdk>=1.25.0
+amazon-braket-sdk>=1.33.0
 retrying==1.3.3
 
 setuptools>=40.1.0


### PR DESCRIPTION
Adjusting the Braket provider to work correctly after launch of QuEra.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes. (Test coverage remains unchanged)
- [ ] I have updated the documentation accordingly. (Inline with existing handling of DWave and Xanadu)
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Braket launched QuEra. This change factors in that launch.


### Details and comments
This change is to filter out QuEra among the providers in qiskit. QuEra is an analogue quantum computer, not a universal gate quantum computer.
