### PR TITLE
Fix result shots

### DIFF
--- a/qiskit_braket_provider/providers/braket_job.py
+++ b/qiskit_braket_provider/providers/braket_job.py
@@ -24,7 +24,7 @@ def retry_if_result_none(result):
     wrap_exception=True,
 )
 def _get_result_from_aws_tasks(
-    tasks: Union[List[LocalQuantumTask], List[AwsQuantumTask]], shots: int
+    tasks: Union[List[LocalQuantumTask], List[AwsQuantumTask]]
 ) -> Optional[List[ExperimentResult]]:
     """Returns experiment results of AWS tasks.
 
@@ -55,7 +55,7 @@ def _get_result_from_aws_tasks(
             return None
 
         experiment_result = ExperimentResult(
-            shots=shots,
+            shots=result.task_metadata.shots,
             success=True,
             status=task.state(),
             data=data,
@@ -107,9 +107,7 @@ class AWSBraketJob(JobV1):
         return
 
     def result(self) -> Result:
-        experiment_results = _get_result_from_aws_tasks(
-            tasks=self._tasks, shots=self.shots
-        )
+        experiment_results = _get_result_from_aws_tasks(tasks=self._tasks)
         return Result(
             backend_name=self._backend,
             backend_version=self._backend.version,

--- a/tests/providers/mocks.py
+++ b/tests/providers/mocks.py
@@ -114,14 +114,14 @@ MOCK_GATE_MODEL_SIMULATOR_TN = {
 
 MOCK_GATE_MODEL_QUANTUM_TASK_RESULT = GateModelQuantumTaskResult(
     task_metadata=TaskMetadata(
-        **{"id": str(uuid.uuid4()), "deviceId": "default", "shots": 2}
+        **{"id": str(uuid.uuid4()), "deviceId": "default", "shots": 3}
     ),
     additional_metadata=None,
-    measurements=[np.array([0, 1]), np.array([1, 0])],
+    measurements=np.array([[0, 1], [0, 1], [1, 0]]),
     measured_qubits=[0, 1],
     result_types=None,
     values=None,
-    measurement_counts=Counter({"01": 1, "10": 1}),
+    measurement_counts=Counter({"01": 2, "10": 1}),
 )
 
 MOCK_LOCAL_QUANTUM_TASK = LocalQuantumTask(MOCK_GATE_MODEL_QUANTUM_TASK_RESULT)

--- a/tests/providers/test_braket_job.py
+++ b/tests/providers/test_braket_job.py
@@ -33,8 +33,8 @@ class TestAWSBraketJob(TestCase):
         job = self._get_job()
 
         self.assertEqual(job.result().job_id, "AwesomeId")
-        self.assertEqual(job.result().results[0].data.counts, {"01": 1, "10": 1})
-        self.assertEqual(job.result().results[0].data.memory, ["10", "01"])
+        self.assertEqual(job.result().results[0].data.counts, {"01": 1, "10": 2})
+        self.assertEqual(job.result().results[0].data.memory, ["10", "10", "01"])
         self.assertEqual(job.result().results[0].status, "COMPLETED")
-        self.assertEqual(job.result().results[0].shots, 2)
-        self.assertEqual(job.result().get_memory(), ["10", "01"])
+        self.assertEqual(job.result().results[0].shots, 3)
+        self.assertEqual(job.result().get_memory(), ["10", "10", "01"])

--- a/tests/providers/test_braket_job.py
+++ b/tests/providers/test_braket_job.py
@@ -1,6 +1,6 @@
 """Tests for AWS Braket job."""
 
-from unittest import TestCase, expectedFailure
+from unittest import TestCase
 
 from qiskit.providers import JobStatus
 
@@ -36,15 +36,5 @@ class TestAWSBraketJob(TestCase):
         self.assertEqual(job.result().results[0].data.counts, {"01": 1, "10": 1})
         self.assertEqual(job.result().results[0].data.memory, ["10", "01"])
         self.assertEqual(job.result().results[0].status, "COMPLETED")
-        self.assertEqual(job.result().get_memory(), ["10", "01"])
-
-    @expectedFailure
-    def test_result_shots(self):
-        """
-        Test result shots.
-
-        Expected to fail because shots is not extracted from the job.tasks.
-        """
-        job = self._get_job()
-
         self.assertEqual(job.result().results[0].shots, 2)
+        self.assertEqual(job.result().get_memory(), ["10", "01"])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
This PR updates the way we construct ExperimentResult by filling the `shots` field by the value extracted from task metadata. 

### Details and comments
This changes the private API: `_get_result_from_aws_tasks` does not require the `shots` arguments anymore. 

It also reverts a change from #68 (where measurements was wrongly changed to list(array)). 
