### PR TITLE
Add function for Braket-to-Qiskit quantum circuit conversion

### DIFF
--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -6,6 +6,7 @@ from braket.circuits import (
     Circuit,
     FreeParameter,
     Instruction,
+    Gate,
     gates,
     result_types,
     observables,
@@ -395,6 +396,36 @@ def convert_qiskit_to_braket_circuit(circuit: QuantumCircuit) -> Circuit:
                     target=[circuit.find_bit(i).index for i in qiskit_gates[1]],
                 )
                 quantum_circuit += instruction
+    return quantum_circuit
+
+
+def from_braket_circuit(circuit: Circuit) -> QuantumCircuit:
+    """Return a Qiskit quantum circuit from a Braket quantum circuit.
+     Args:
+            circuit (Circuit): Braket Quantum Circuit
+
+    Returns:
+        QuantumCircuit: Qiskit circuit
+    """
+    num_qubits = circuit.qubit_count
+    quantum_circuit = QuantumCircuit(num_qubits)
+    quantum_circuit.metadata = {"instructions": [], "result_types": []}
+    for instruction in circuit.instructions:
+        quantum_circuit.metadata["instructions"].append(instruction)
+        operator = instruction.operator
+        if isinstance(operator, Gate):
+            qiskit_instr = _op_to_instruction(operator.name)
+            if hasattr(operator, "angle"):
+                qiskit_instr.params = [
+                    Parameter(operator.angle.name)
+                    if isinstance(operator.angle, FreeParameter)
+                    else operator.angle
+                ]
+            quantum_circuit.append(qiskit_instr, instruction.target)
+    if circuit.result_types == []:
+        quantum_circuit.measure_active()
+    else:
+        quantum_circuit.metadata["result_types"] = circuit.result_types
     return quantum_circuit
 
 


### PR DESCRIPTION
### Summary
I implemented the function `from_braket_circuit(circuit: Circuit) -> QuantumCircuit` as a first attempt for Braket-to-Qiskit quantum circuit conversion, discussed in issue #88.

### Details and comments
If this is the right approach, I will work also on the following requirements (by @kshitijc):
> * The implementation should be accompanied by unit tests with full coverage.
> * The implementation method should be accompanied by an example in [this folder](https://github.com/qiskit-community/qiskit-braket-provider/tree/main/docs/how_tos).