### PR TITLE
[UnitaryHack] Enable qiskit transpilation discontinous qubit indices

### DIFF
--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -251,11 +251,12 @@ def convert_continuous_qubit_indices(connectivity_graph: dict) -> dict:
         the resultant continous qubit indices output will be:
             {1: [2, 3], 2: [1, 3], 3: [1, 2]}
     """
-    # Creates indices list and maps them to a continuous list
+    # Creates list of existing qubit indices which are discontinuous.
     indices = [int(key) for key in connectivity_graph.keys()]
     indices.sort()
+    # Creates a list of continuous indices for number of qubits.
     map_list = list(range(len(indices)))
-    # Creates a dictionary to remap the discountinous indices sto the continuous ones.
+    # Creates a dictionary to remap the discountinous indices to the continuous ones.
     mapper = dict(zip(indices, map_list))
     # Performs the remapping from the discontinous to the continuous indices.
     continous_connectivity_graph = {

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -307,17 +307,17 @@ def aws_device_to_target(device: AwsDevice) -> Target:
                                 connectivity_graph (dict): connectivity graph from Aspen. For example
                                 if qubit 1 is connected to qubit 2 and 3, and qubit 2 is connected to
                                 qubit 3, the connectivity graph will be
-                                {1: [2, 3], 2: [1, 3], 3: [1, 2]}
+                                {"1": ["2", "3"], "2": ["3"]}
 
                             Returns:
                                 dict: Connectivity graph with continuous indices. For example for an
-                                input connectivity graph with discontinuous indices (qubit 1, 2 and then
-                                qubit 7) as shown here:
-                                    {1: [2, 7], 2: [1, 7], 7: [1, 2]},
-                                the qubit index 7 will be mapped to qubit index 3 for the qiskit
-                                transpilation step. Thereby the resultant continous qubit indices output
-                                will be:
-                                    {1: [2, 3], 2: [1, 3], 3: [1, 2]}
+                                input connectivity graph with discontinuous indices (qubit 1, 2, 3 and
+                                then qubit 7, qubit 8) as shown here:
+                                    {"1": ["2", "3"], "7": ["8"]}
+                                the qubit index 7, 8 will be mapped to qubit index 4, 5 resp for the
+                                qiskit transpilation step. Thereby the resultant continous qubit
+                                indices output will be:
+                                    {"1": ["2", "3"], "4": ["5"]}
                             """
                             # Creates list of existing qubit indices which are discontinuous.
                             indices = [int(key) for key in connectivity_graph.keys()]

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -239,20 +239,30 @@ def convert_continuous_qubit_indices(connectivity_graph: dict) -> dict:
     This function converts the discontinous connectivity graph from Aspen to a continuous one.
 
     Args:
-        connectivity_graph (dict): connectivity graph from Aspen
+        connectivity_graph (dict): connectivity graph from Aspen. For example if qubit 1 is connected
+        to qubit 2 and 3, and qubit 2 is connected to qubit 3, the connectivity graph will be
+        {1: [2, 3], 2: [1, 3], 3: [1, 2]}
 
     Returns:
-        dict: Connectivity graph
+        dict: Connectivity graph with continuous indices. For example for an input connectivity graph
+        with discontinuous indices (qubit 1, 2 and then qubit 7) as shown here:
+            {1: [2, 7], 2: [1, 7], 7: [1, 2]},
+        the qubit index 7 will be mapped to qubit index 3 for the qiskit transpilation step. Thereby
+        the resultant continous qubit indices output will be:
+            {1: [2, 3], 2: [1, 3], 3: [1, 2]}
     """
+    # Creates indices list and maps them to a continuous list
     indices = [int(key) for key in connectivity_graph.keys()]
     indices.sort()
-    map_list = list(range(0, indices[-1] + 1))
+    map_list = list(range(len(indices)))
+    # Creates a dictionary to remap the discountinous indices sto the continuous ones.
     mapper = dict(zip(indices, map_list))
-    final_dict = {
+    # Performs the remapping from the discontinous to the continuous indices.
+    continous_connectivity_graph = {
         mapper[int(k)]: [mapper[int(v)] for v in val]
         for k, val in connectivity_graph.items()
     }
-    return final_dict
+    return continous_connectivity_graph
 
 
 def aws_device_to_target(device: AwsDevice) -> Target:

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -233,39 +233,6 @@ def local_simulator_to_target(simulator: LocalSimulator) -> Target:
     return target
 
 
-def convert_continuous_qubit_indices(connectivity_graph: dict) -> dict:
-    """Aspen qubit indices are discontinuous (label between x0 and x7, x being the number of the
-    octagon) while the Qiskit transpiler creates and/or handles coupling maps with continuous indices.
-    This function converts the discontinous connectivity graph from Aspen to a continuous one.
-
-    Args:
-        connectivity_graph (dict): connectivity graph from Aspen. For example if qubit 1 is connected
-        to qubit 2 and 3, and qubit 2 is connected to qubit 3, the connectivity graph will be
-        {1: [2, 3], 2: [1, 3], 3: [1, 2]}
-
-    Returns:
-        dict: Connectivity graph with continuous indices. For example for an input connectivity graph
-        with discontinuous indices (qubit 1, 2 and then qubit 7) as shown here:
-            {1: [2, 7], 2: [1, 7], 7: [1, 2]},
-        the qubit index 7 will be mapped to qubit index 3 for the qiskit transpilation step. Thereby
-        the resultant continous qubit indices output will be:
-            {1: [2, 3], 2: [1, 3], 3: [1, 2]}
-    """
-    # Creates list of existing qubit indices which are discontinuous.
-    indices = [int(key) for key in connectivity_graph.keys()]
-    indices.sort()
-    # Creates a list of continuous indices for number of qubits.
-    map_list = list(range(len(indices)))
-    # Creates a dictionary to remap the discountinous indices to the continuous ones.
-    mapper = dict(zip(indices, map_list))
-    # Performs the remapping from the discontinous to the continuous indices.
-    continous_connectivity_graph = {
-        mapper[int(k)]: [mapper[int(v)] for v in val]
-        for k, val in connectivity_graph.items()
-    }
-    return continous_connectivity_graph
-
-
 def aws_device_to_target(device: AwsDevice) -> Target:
     """Converts properties of Braket device into Qiskit Target object.
 
@@ -327,6 +294,41 @@ def aws_device_to_target(device: AwsDevice) -> Target:
                 # building coupling map for device with connectivity graph
                 else:
                     if isinstance(properties, RigettiDeviceCapabilities):
+
+                        def convert_continuous_qubit_indices(
+                            connectivity_graph: dict,
+                        ) -> dict:
+                            """Aspen qubit indices are discontinuous (label between x0 and x7, x being the number of the
+                            octagon) while the Qiskit transpiler creates and/or handles coupling maps with continuous indices.
+                            This function converts the discontinous connectivity graph from Aspen to a continuous one.
+
+                            Args:
+                                connectivity_graph (dict): connectivity graph from Aspen. For example if qubit 1 is connected
+                                to qubit 2 and 3, and qubit 2 is connected to qubit 3, the connectivity graph will be
+                                {1: [2, 3], 2: [1, 3], 3: [1, 2]}
+
+                            Returns:
+                                dict: Connectivity graph with continuous indices. For example for an input connectivity graph
+                                with discontinuous indices (qubit 1, 2 and then qubit 7) as shown here:
+                                    {1: [2, 7], 2: [1, 7], 7: [1, 2]},
+                                the qubit index 7 will be mapped to qubit index 3 for the qiskit transpilation step. Thereby
+                                the resultant continous qubit indices output will be:
+                                    {1: [2, 3], 2: [1, 3], 3: [1, 2]}
+                            """
+                            # Creates list of existing qubit indices which are discontinuous.
+                            indices = [int(key) for key in connectivity_graph.keys()]
+                            indices.sort()
+                            # Creates a list of continuous indices for number of qubits.
+                            map_list = list(range(len(indices)))
+                            # Creates a dictionary to remap the discountinous indices to the continuous ones.
+                            mapper = dict(zip(indices, map_list))
+                            # Performs the remapping from the discontinous to the continuous indices.
+                            continous_connectivity_graph = {
+                                mapper[int(k)]: [mapper[int(v)] for v in val]
+                                for k, val in connectivity_graph.items()
+                            }
+                            return continous_connectivity_graph
+
                         connectivity.connectivityGraph = (
                             convert_continuous_qubit_indices(
                                 connectivity.connectivityGraph

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -305,19 +305,21 @@ def aws_device_to_target(device: AwsDevice) -> Target:
 
                             Args:
                                 connectivity_graph (dict): connectivity graph from Aspen. For example
-                                if qubit 1 is connected to qubit 2 and 3, and qubit 2 is connected to
-                                qubit 3, the connectivity graph will be
-                                {"1": ["2", "3"], "2": ["3"]}
+                                4 qubit system, the connectivity graph will be:
+                                    {"0": ["1", "2", "7"], "1": ["0","2","7"], "2": ["0","1","7"],
+                                    "7": ["0","1","2"]}
 
                             Returns:
                                 dict: Connectivity graph with continuous indices. For example for an
-                                input connectivity graph with discontinuous indices (qubit 1, 2, 3 and
-                                then qubit 7, qubit 8) as shown here:
-                                    {"1": ["2", "3"], "7": ["8"]}
-                                the qubit index 7, 8 will be mapped to qubit index 4, 5 resp for the
-                                qiskit transpilation step. Thereby the resultant continous qubit
-                                indices output will be:
-                                    {"1": ["2", "3"], "4": ["5"]}
+                                input connectivity graph with discontinuous indices (qubit 0, 1, 2 and
+                                then qubit 7) as shown here:
+                                    {"0": ["1", "2", "7"], "1": ["0","2","7"], "2": ["0","1","7"],
+                                    "7": ["0","1","2"]}
+                                the qubit index 7 will be mapped to qubit index 3 for the qiskit
+                                transpilation step. Thereby the resultant continous qubit indices
+                                output will be:
+                                    {"0": ["1", "2", "3"], "1": ["0","2","3"], "2": ["0","1","3"],
+                                    "3": ["0","1","2"]}
                             """
                             # Creates list of existing qubit indices which are discontinuous.
                             indices = [int(key) for key in connectivity_graph.keys()]

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -298,21 +298,25 @@ def aws_device_to_target(device: AwsDevice) -> Target:
                         def convert_continuous_qubit_indices(
                             connectivity_graph: dict,
                         ) -> dict:
-                            """Aspen qubit indices are discontinuous (label between x0 and x7, x being the number of the
-                            octagon) while the Qiskit transpiler creates and/or handles coupling maps with continuous indices.
-                            This function converts the discontinous connectivity graph from Aspen to a continuous one.
+                            """Aspen qubit indices are discontinuous (label between x0 and x7, x being
+                            the number of the octagon) while the Qiskit transpiler creates and/or
+                            handles coupling maps with continuous indices. This function converts the
+                            discontinous connectivity graph from Aspen to a continuous one.
 
                             Args:
-                                connectivity_graph (dict): connectivity graph from Aspen. For example if qubit 1 is connected
-                                to qubit 2 and 3, and qubit 2 is connected to qubit 3, the connectivity graph will be
+                                connectivity_graph (dict): connectivity graph from Aspen. For example
+                                if qubit 1 is connected to qubit 2 and 3, and qubit 2 is connected to
+                                qubit 3, the connectivity graph will be
                                 {1: [2, 3], 2: [1, 3], 3: [1, 2]}
 
                             Returns:
-                                dict: Connectivity graph with continuous indices. For example for an input connectivity graph
-                                with discontinuous indices (qubit 1, 2 and then qubit 7) as shown here:
+                                dict: Connectivity graph with continuous indices. For example for an
+                                input connectivity graph with discontinuous indices (qubit 1, 2 and then
+                                qubit 7) as shown here:
                                     {1: [2, 7], 2: [1, 7], 7: [1, 2]},
-                                the qubit index 7 will be mapped to qubit index 3 for the qiskit transpilation step. Thereby
-                                the resultant continous qubit indices output will be:
+                                the qubit index 7 will be mapped to qubit index 3 for the qiskit
+                                transpilation step. Thereby the resultant continous qubit indices output
+                                will be:
                                     {1: [2, 3], 2: [1, 3], 3: [1, 2]}
                             """
                             # Creates list of existing qubit indices which are discontinuous.
@@ -320,7 +324,7 @@ def aws_device_to_target(device: AwsDevice) -> Target:
                             indices.sort()
                             # Creates a list of continuous indices for number of qubits.
                             map_list = list(range(len(indices)))
-                            # Creates a dictionary to remap the discountinous indices to the continuous ones.
+                            # Creates a dictionary to remap the discountinous indices to continuous.
                             mapper = dict(zip(indices, map_list))
                             # Performs the remapping from the discontinous to the continuous indices.
                             continous_connectivity_graph = {

--- a/tests/providers/mocks.py
+++ b/tests/providers/mocks.py
@@ -1,6 +1,7 @@
 """Mocks for testing."""
 
 from collections import Counter
+import copy
 
 import uuid
 import numpy as np
@@ -12,6 +13,7 @@ from braket.device_schema.rigetti import RigettiDeviceCapabilities
 
 
 RIGETTI_ARN = "arn:aws:braket:::device/qpu/rigetti/Aspen-10"
+RIGETTI_ASPEN_ARN = "arn:aws:braket:::device/qpu/rigetti/Aspen-M-3"
 SV1_ARN = "arn:aws:braket:::device/quantum-simulator/amazon/sv1"
 TN1_ARN = "arn:aws:braket:::device/quantum-simulator/amazon/tn1"
 RIGETTI_REGION = "us-west-1"
@@ -62,6 +64,34 @@ RIGETTI_MOCK_GATE_MODEL_QPU = {
     "deviceStatus": "OFFLINE",
     "deviceArn": RIGETTI_ARN,
     "deviceCapabilities": RIGETTI_MOCK_GATE_MODEL_QPU_CAPABILITIES.json(),
+}
+
+RIGETTI_MOCK_M_3_QPU_CAPABILITIES_JSON = copy.deepcopy(
+    RIGETTI_MOCK_GATE_MODEL_QPU_CAPABILITIES_JSON
+)
+RIGETTI_MOCK_M_3_QPU_CAPABILITIES_JSON["action"]["braket.ir.openqasm.program"][
+    "supportedOperations"
+] = ["RX", "RZ", "CP", "CZ", "XY"]
+RIGETTI_MOCK_M_3_QPU_CAPABILITIES_JSON["paradigm"]["qubitCount"] = 4
+RIGETTI_MOCK_M_3_QPU_CAPABILITIES_JSON["paradigm"]["connectivity"][
+    "connectivityGraph"
+] = {
+    "0": ["1", "2", "7"],
+    "1": ["0", "2", "7"],
+    "2": ["0", "1", "7"],
+    "7": ["0", "1", "2"],
+}
+RIGETTI_MOCK_M_3_QPU_CAPABILITIES = RigettiDeviceCapabilities.parse_obj(
+    RIGETTI_MOCK_M_3_QPU_CAPABILITIES_JSON
+)
+
+MOCK_RIGETTI_GATE_MODEL_M_3_QPU = {
+    "deviceName": "Aspen-M-3",
+    "deviceType": "QPU",
+    "providerName": "provider1",
+    "deviceStatus": "ONLINE",
+    "deviceArn": RIGETTI_ASPEN_ARN,
+    "deviceCapabilities": RIGETTI_MOCK_M_3_QPU_CAPABILITIES.json(),
 }
 
 MOCK_GATE_MODEL_SIMULATOR_CAPABILITIES_JSON = {

--- a/tests/providers/mocks.py
+++ b/tests/providers/mocks.py
@@ -2,6 +2,7 @@
 
 from collections import Counter
 import copy
+from typing import Dict
 
 import uuid
 import numpy as np
@@ -66,7 +67,7 @@ RIGETTI_MOCK_GATE_MODEL_QPU = {
     "deviceCapabilities": RIGETTI_MOCK_GATE_MODEL_QPU_CAPABILITIES.json(),
 }
 
-RIGETTI_MOCK_M_3_QPU_CAPABILITIES_JSON = copy.deepcopy(
+RIGETTI_MOCK_M_3_QPU_CAPABILITIES_JSON: Dict = copy.deepcopy(
     RIGETTI_MOCK_GATE_MODEL_QPU_CAPABILITIES_JSON
 )
 RIGETTI_MOCK_M_3_QPU_CAPABILITIES_JSON["action"]["braket.ir.openqasm.program"][

--- a/tests/providers/test_braket_provider.py
+++ b/tests/providers/test_braket_provider.py
@@ -4,9 +4,9 @@ from unittest import TestCase
 from unittest.mock import Mock
 
 from braket.aws import AwsDeviceType
-from qiskit import transpile
+from qiskit import circuit as qiskit_circuit
 from qiskit.circuit.random import random_circuit
-
+from qiskit.compiler import transpile
 from qiskit_braket_provider.providers import AWSBraketProvider
 from qiskit_braket_provider.providers.braket_backend import (
     BraketBackend,
@@ -68,4 +68,18 @@ class TestAWSBraketProvider(TestCase):
             circuit, backend=state_vector_backend, seed_transpiler=42
         )
         result = state_vector_backend.run(transpiled_circuit, shots=10)
+        self.assertTrue(result)
+
+    @unittest.skip("Call to external service")
+    def test_real_device_discontinous_qubit_indices_qiskit_transpilation(self):
+        """Tests circuit transpilation on real device with discontinous qubit indices."""
+        provider = AWSBraketProvider()
+        device = provider.get_backend("Aspen-M-3")
+
+        circ = qiskit_circuit.QuantumCircuit(3)
+        circ.h(0)
+        circ.cx(0, 1)
+        circ.cx(1, 2)
+
+        result = transpile(circ, device)
         self.assertTrue(result)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
closes #91 


### Details and comments
Enables qiskit transpilation for Rigetti devices on the qubit coupling map level. If the issues with Rigetti Aspen backend not transpiling QC circuit by converting the discontinous qubit indices into continous one. 
