### PR TITLE
Python versions: move from python 3.7 and add support for 3.11

### DIFF
--- a/.github/workflows/test_latest_versions.yml
+++ b/.github/workflows/test_latest_versions.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, '3.10']
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
     keywords="qiskit braket sdk quantum",
     packages=setuptools.find_packages(),
     install_requires=install_requires,
-    python_requires=">=3.7",
+    python_requires=">=3.8.2",
     version=version,
     classifiers=[
         "Intended Audience :: Developers",
@@ -39,10 +39,10 @@ setuptools.setup(
         "Operating System :: MacOS",
         "Operating System :: POSIX :: Linux",
         "Operating System :: Microsoft :: Windows",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Scientific/Engineering :: Physics",
     ],
 )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary:

This PR addresses issue #117 and #119 and enhances the testing capabilities across multiple Python versions, specifically 3.8, 3.9, 3.10, and 3.11.


### Key Changes:

- Modified `.github/workflows/test_latest_versions.yml` to include the following matrix configuration:
```
matrix:
        python-version: ["3.8", "3.9", "3.10", "3.11"]
```

- Modified `./setup.py` to include the following:
```
    classifiers=[
        ....
        "Programming Language :: Python :: 3.8",
        "Programming Language :: Python :: 3.9",
        "Programming Language :: Python :: 3.10",
        "Programming Language :: Python :: 3.11",
        "Topic :: Scientific/Engineering :: Physics",
    ],
```
and
```
python_requires=">=3.8.2",
```

