### PR TITLE
Remove `retrying` dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,9 @@ __pycache__
 
 venv/
 .idea/
+*.iml
 .vscode/
+*.DS_Store
 
 # Distribution / packaging
 .Python

--- a/qiskit_braket_provider/providers/braket_backend.py
+++ b/qiskit_braket_provider/providers/braket_backend.py
@@ -114,9 +114,7 @@ class BraketLocalBackend(BraketBackend):
         try:
             for circuit in circuits:
                 task: LocalQuantumTask = self._aws_device.run(
-                    task_specification=circuit, shots=shots,
-                    poll_timeout_seconds=int(os.environ.get("QISKIT_BRAKET_PROVIDER_MAX_DELAY", 60000)),
-                    poll_interval_seconds=int(os.environ.get("QISKIT_BRAKET_PROVIDER_WAIT_TIME", 2000))
+                    task_specification=circuit, **options
                 )
                 tasks.append(task)
 

--- a/qiskit_braket_provider/providers/braket_backend.py
+++ b/qiskit_braket_provider/providers/braket_backend.py
@@ -106,7 +106,9 @@ class BraketLocalBackend(BraketBackend):
             [run_input] if isinstance(run_input, QuantumCircuit) else list(run_input)
         )
         circuits: List[Circuit] = list(convert_qiskit_to_braket_circuits(convert_input))
-        shots = options["shots"] if "shots" in options else 1024
+        if "shots" not in options:
+            options["shots"] = 1024
+        shots = options["shots"]
         if shots == 0:
             circuits = list(map(lambda x: x.state_vector(), circuits))
         tasks = []

--- a/qiskit_braket_provider/providers/braket_backend.py
+++ b/qiskit_braket_provider/providers/braket_backend.py
@@ -106,16 +106,14 @@ class BraketLocalBackend(BraketBackend):
             [run_input] if isinstance(run_input, QuantumCircuit) else list(run_input)
         )
         circuits: List[Circuit] = list(convert_qiskit_to_braket_circuits(convert_input))
-        if "shots" not in options:
-            options["shots"] = 1024
-        shots = options["shots"]
+        shots = options["shots"] if "shots" in options else 1024
         if shots == 0:
             circuits = list(map(lambda x: x.state_vector(), circuits))
         tasks = []
         try:
             for circuit in circuits:
                 task: LocalQuantumTask = self._aws_device.run(
-                    task_specification=circuit, **options
+                    task_specification=circuit, shots=shots
                 )
                 tasks.append(task)
 

--- a/qiskit_braket_provider/providers/braket_backend.py
+++ b/qiskit_braket_provider/providers/braket_backend.py
@@ -3,6 +3,7 @@
 
 import datetime
 import logging
+import os
 from abc import ABC
 from typing import Iterable, Union, List
 
@@ -113,7 +114,9 @@ class BraketLocalBackend(BraketBackend):
         try:
             for circuit in circuits:
                 task: LocalQuantumTask = self._aws_device.run(
-                    task_specification=circuit, shots=shots
+                    task_specification=circuit, shots=shots,
+                    poll_timeout_seconds=int(os.environ.get("QISKIT_BRAKET_PROVIDER_MAX_DELAY", 60000)),
+                    poll_interval_seconds=int(os.environ.get("QISKIT_BRAKET_PROVIDER_WAIT_TIME", 2000))
                 )
                 tasks.append(task)
 

--- a/qiskit_braket_provider/providers/braket_backend.py
+++ b/qiskit_braket_provider/providers/braket_backend.py
@@ -3,7 +3,6 @@
 
 import datetime
 import logging
-import os
 from abc import ABC
 from typing import Iterable, Union, List
 

--- a/qiskit_braket_provider/providers/braket_job.py
+++ b/qiskit_braket_provider/providers/braket_job.py
@@ -33,32 +33,31 @@ def _get_result_from_aws_tasks(
 
     # For each task the results is get and filled into an ExperimentResult object
     for task in tasks:
-        if task.state() in AwsQuantumTask.RESULTS_READY_STATES:
-            result: GateModelQuantumTaskResult = task.result()
-
-            if result.task_metadata.shots == 0:
-                statevector = result.values[
-                    result._result_types_indices[
-                        "{'type': <Type.statevector: 'statevector'>}"
-                    ]
-                ]
-                data = ExperimentResultData(
-                    statevector=statevector,
-                )
-            else:
-                counts = {
-                    k[::-1]: v for k, v in dict(result.measurement_counts).items()
-                }  # convert to little-endian
-
-                data = ExperimentResultData(
-                    counts=counts,
-                    memory=[
-                        "".join(shot_result[::-1].astype(str))
-                        for shot_result in result.measurements
-                    ],
-                )
-        else:
+        result: GateModelQuantumTaskResult = task.result()
+        if not result:
             return None
+
+        if result.task_metadata.shots == 0:
+            statevector = result.values[
+                result._result_types_indices[
+                    "{'type': <Type.statevector: 'statevector'>}"
+                ]
+            ]
+            data = ExperimentResultData(
+                statevector=statevector,
+            )
+        else:
+            counts = {
+                k[::-1]: v for k, v in dict(result.measurement_counts).items()
+            }  # convert to little-endian
+
+            data = ExperimentResultData(
+                counts=counts,
+                memory=[
+                    "".join(shot_result[::-1].astype(str))
+                    for shot_result in result.measurements
+                ],
+            )
 
         experiment_result = ExperimentResult(
             shots=result.task_metadata.shots,

--- a/qiskit_braket_provider/providers/braket_job.py
+++ b/qiskit_braket_provider/providers/braket_job.py
@@ -1,5 +1,4 @@
 """AWS Braket job."""
-import os
 from datetime import datetime
 from typing import List, Optional, Union
 from warnings import warn

--- a/qiskit_braket_provider/providers/braket_job.py
+++ b/qiskit_braket_provider/providers/braket_job.py
@@ -11,7 +11,6 @@ from braket.tasks.local_quantum_task import LocalQuantumTask
 from qiskit.providers import BackendV2, JobStatus, JobV1
 from qiskit.result import Result
 from qiskit.result.models import ExperimentResult, ExperimentResultData
-from retrying import retry
 
 
 def retry_if_result_none(result):
@@ -19,12 +18,6 @@ def retry_if_result_none(result):
     return result is None
 
 
-@retry(
-    retry_on_result=retry_if_result_none,
-    stop_max_delay=int(os.environ.get("QISKIT_BRAKET_PROVIDER_MAX_DELAY", 60000)),
-    wait_fixed=int(os.environ.get("QISKIT_BRAKET_PROVIDER_WAIT_TIME", 2000)),
-    wrap_exception=True,
-)
 def _get_result_from_aws_tasks(
     tasks: Union[List[LocalQuantumTask], List[AwsQuantumTask]]
 ) -> Optional[List[ExperimentResult]]:

--- a/qiskit_braket_provider/version.py
+++ b/qiskit_braket_provider/version.py
@@ -1,2 +1,2 @@
 """Qiskit-Braket provider version."""
-__version__ = "0.0.4"
+__version__ = "0.0.5"

--- a/qiskit_braket_provider/version.py
+++ b/qiskit_braket_provider/version.py
@@ -1,2 +1,2 @@
 """Qiskit-Braket provider version."""
-__version__ = "0.0.5"
+__version__ = "0.0.6"

--- a/qiskit_braket_provider/version.py
+++ b/qiskit_braket_provider/version.py
@@ -1,2 +1,2 @@
 """Qiskit-Braket provider version."""
-__version__ = "0.0.6"
+__version__ = "0.0.4"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ certifi>=2021.5.30
 qiskit-aer>=0.10.2
 qiskit-terra>=0.19.2
 amazon-braket-sdk>=1.56.0
-retrying==1.3.3
 
 setuptools>=40.1.0
 numpy>=1.3

--- a/tests/providers/test_adapter.py
+++ b/tests/providers/test_adapter.py
@@ -1,6 +1,5 @@
 """Tests for Qiskti to Braket adapter."""
 from unittest import TestCase
-import pytest
 
 from braket.circuits import Circuit, FreeParameter, observables
 from braket.devices import LocalSimulator

--- a/tests/providers/test_adapter.py
+++ b/tests/providers/test_adapter.py
@@ -201,32 +201,28 @@ class TestAdapter(TestCase):
                 parameter_bindings = dict(zip(parameters, parameter_values))
                 qiskit_circuit = qiskit_circuit.assign_parameters(parameter_bindings)
 
-            if standard_gate.name != "cu":
-                with self.subTest(f"Circuit with {standard_gate.name} gate."):
-                    braket_job = backend.run(qiskit_circuit, shots=1000)
-                    braket_result = braket_job.result().get_counts()
+            with self.subTest(f"Circuit with {standard_gate.name} gate."):
+                braket_job = backend.run(qiskit_circuit, shots=1000)
+                braket_result = braket_job.result().get_counts()
 
-                    qiskit_job = execute(qiskit_circuit, aer_backend, shots=1000)
-                    qiskit_result = qiskit_job.result().get_counts()
+                qiskit_job = execute(qiskit_circuit, aer_backend, shots=1000)
+                qiskit_result = qiskit_job.result().get_counts()
 
-                    combined_results = combine_dicts(
-                        {k: float(v) / 1000.0 for k, v in braket_result.items()},
-                        qiskit_result,
+                combined_results = combine_dicts(
+                    {k: float(v) / 1000.0 for k, v in braket_result.items()},
+                    qiskit_result,
+                )
+
+                for key, values in combined_results.items():
+                    percent_diff = abs(
+                        ((float(values[0]) - values[1]) / values[0]) * 100
                     )
-
-                    for key, values in combined_results.items():
-                        percent_diff = abs(
-                            ((float(values[0]) - values[1]) / values[0]) * 100
-                        )
-                        abs_diff = abs(values[0] - values[1])
-                        self.assertTrue(
-                            percent_diff < 10 or abs_diff < 0.05,
-                            f"Key {key} with percent difference {percent_diff} "
-                            f"and absolute difference {abs_diff}. Original values {values}",
-                        )
-            else:
-                with pytest.raises(TypeError):
-                    convert_qiskit_to_braket_circuit(qiskit_circuit)
+                    abs_diff = abs(values[0] - values[1])
+                    self.assertTrue(
+                        percent_diff < 10 or abs_diff < 0.05,
+                        f"Key {key} with percent difference {percent_diff} "
+                        f"and absolute difference {abs_diff}. Original values {values}",
+                    )
 
     def test_exponential_gate_decomp(self):
         """Tests adapter translation of exponential gates"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Removes usages of `retrying`, since this functionality is already accomplished by passing in `poll_timeout_seconds` and `poll_interval_seconds`.

### Details and comments

This fixes #125.

This change also adds `CUGate` back into the adapter tests, since it appears to get translated properly now.

