### PR TITLE
fix a misused 2-qubit sample result type

### DIFF
--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -8,7 +8,6 @@ from braket.circuits import (
     FreeParameter,
     Instruction,
     gates,
-    result_types,
     observables,
 )
 from braket.device_schema import (

--- a/tests/providers/test_adapter.py
+++ b/tests/providers/test_adapter.py
@@ -339,15 +339,20 @@ class TestAdapter(TestCase):
         self.assertEqual(braket_circuit, expected_braket_circuit)
 
     def test_multiple_registers(self):
-        qregA = QuantumRegister(2, "qregA")
-        qregB = QuantumRegister(1, "qregB")
+        """
+        Tests the use of multiple registers.
+
+        Confirming that #51 has been fixed.
+        """
+        qreg_a = QuantumRegister(2, "qreg_a")
+        qreg_b = QuantumRegister(1, "qreg_b")
         creg = ClassicalRegister(2, "creg")
-        qiskit_circuit = QuantumCircuit(qregA, qregB, creg)
-        qiskit_circuit.h(qregA[0])
-        qiskit_circuit.cnot(qregA[0], qregB[0])
-        qiskit_circuit.x(qregA[1])
-        qiskit_circuit.measure(qregA[0], creg[1])
-        qiskit_circuit.measure(qregB[0], creg[0])
+        qiskit_circuit = QuantumCircuit(qreg_a, qreg_b, creg)
+        qiskit_circuit.h(qreg_a[0])
+        qiskit_circuit.cnot(qreg_a[0], qreg_b[0])
+        qiskit_circuit.x(qreg_a[1])
+        qiskit_circuit.measure(qreg_a[0], creg[1])
+        qiskit_circuit.measure(qreg_b[0], creg[0])
         braket_circuit = convert_qiskit_to_braket_circuit(qiskit_circuit)
 
         expected_braket_circuit = (

--- a/tests/providers/test_adapter.py
+++ b/tests/providers/test_adapter.py
@@ -302,7 +302,7 @@ class TestAdapter(TestCase):
         qiskit_circuit = QuantumCircuit(2, 2)
         qiskit_circuit.h(0)
         qiskit_circuit.cnot(0, 1)
-        qiskit_circuit.measure(0, 1)
+        qiskit_circuit.measure(0, 0)
         braket_circuit = convert_qiskit_to_braket_circuit(qiskit_circuit)
 
         circuits = (

--- a/tests/providers/test_adapter.py
+++ b/tests/providers/test_adapter.py
@@ -302,7 +302,25 @@ class TestAdapter(TestCase):
         qiskit_circuit = QuantumCircuit(2, 2)
         qiskit_circuit.h(0)
         qiskit_circuit.cnot(0, 1)
-        qiskit_circuit.measure(0, 0)
+        qiskit_circuit.measure(0, 1)
+        braket_circuit = convert_qiskit_to_braket_circuit(qiskit_circuit)
+
+        circuits = (
+            Circuit()  # pylint: disable=no-member
+            .h(0)
+            .cnot(0, 1)
+            .sample(observable=observables.Z(), target=0)
+        )
+
+        self.assertEqual(braket_circuit, circuits)
+
+    def test_sample_result_type_different_indices(self):
+        """Tests sample result type with observables Z"""
+
+        qiskit_circuit = QuantumCircuit(2, 2)
+        qiskit_circuit.h(0)
+        qiskit_circuit.cnot(0, 1)
+        qiskit_circuit.measure(0, 1)
         braket_circuit = convert_qiskit_to_braket_circuit(qiskit_circuit)
 
         circuits = (

--- a/tests/providers/test_adapter.py
+++ b/tests/providers/test_adapter.py
@@ -315,7 +315,13 @@ class TestAdapter(TestCase):
         self.assertEqual(braket_circuit, circuits)
 
     def test_sample_result_type_different_indices(self):
-        """Tests sample result type with observables Z"""
+        """
+        Tests the translation of a measure instruction.
+
+        We test that the issue #132 has been fixed. The qubit index
+        can be different from the classical bit index. The classical bit
+        is ignored during the translation.
+        """
 
         qiskit_circuit = QuantumCircuit(2, 2)
         qiskit_circuit.h(0)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Measure instructions were wrongly translated. We now construct a 1-qubit sampling instruction.


### Details and comments

We were translating a 1-qubit measure instruction into a 2-qubit ZZ observable sampling instruction (using the classical register index for the second qubit). This PR uses the right instruction and renames most of the variables in the function to be clearer.

Fixes #132. 
