### PR TITLE
raise type error for bad adapter circuit conversion input type

### DIFF
--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -416,6 +416,11 @@ def convert_qiskit_to_braket_circuit(circuit: QuantumCircuit) -> Circuit:
     Returns:
         Circuit: Braket circuit
     """
+    if not isinstance(circuit, QuantumCircuit):
+        raise TypeError(
+            f"Expected a qiskit.QuantumCircuit, got {type(circuit)} instead"
+        )
+
     quantum_circuit = Circuit()
     if not (
         {gate.name for gate, _, _ in circuit.data}.issubset(translatable_qiskit_gates)

--- a/tests/providers/test_adapter.py
+++ b/tests/providers/test_adapter.py
@@ -1,6 +1,8 @@
 """Tests for Qiskti to Braket adapter."""
 from unittest import TestCase
+from unittest.mock import Mock
 
+import pytest
 from braket.circuits import Circuit, FreeParameter, observables
 from braket.devices import LocalSimulator
 
@@ -133,6 +135,16 @@ standard_gates = [
 
 class TestAdapter(TestCase):
     """Tests adapter."""
+
+    def test_raise_type_error_for_bad_input(self):
+        """Test raising TypeError if adapter does not receive a qiskit.QuantumCircuit."""
+        circuit = Mock()
+
+        message = (
+            "Expected a qiskit.QuantumCircuit, got <class 'unittest.mock.Mock'> instead"
+        )
+        with pytest.raises(TypeError, match=message):
+            convert_qiskit_to_braket_circuit(circuit)
 
     def test_state_preparation_01(self):
         """Tests state_preparation handling of Adapter"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

More descriptive error message for bad conversion function input.

Before:

```python
from qiskit_braket_provider.providers.adapter import convert_qiskit_to_braket_circuit

convert_qiskit_to_braket_circuit("abc")
# AttributeError: 'Circuit' object has no attribute 'data'
```
```python
from unittest.mock import Mock

bad_input = Mock()
bad_input.data = []

convert_qiskit_to_braket_circuit(fake)
# TypeError: '>' not supported between instances of 'Mock' and 'float'
```
etc.

Now:

```python
convert_qiskit_to_braket_circuit(input)
# TypeError: 'Expected a qiskit.QuantumCircuit, got <type(input)> instead'
```

