### PR TITLE
Enable use of qiskit ParameterExpressions for circuit conversion: qiskit to braket

### DIFF
--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -3,7 +3,6 @@ from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union
 import warnings
 
 from braket.aws import AwsDevice
-from qiskit.circuit import ParameterExpression
 from braket.circuits import (
     Circuit,
     FreeParameter,
@@ -30,7 +29,7 @@ from numpy import pi
 
 from qiskit import QuantumCircuit, transpile
 from qiskit.circuit import Instruction as QiskitInstruction
-from qiskit.circuit import Measure, Parameter
+from qiskit.circuit import Measure, Parameter, ParameterExpression
 from qiskit.circuit.library import (
     CCXGate,
     CPhaseGate,

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -3,6 +3,7 @@ from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union
 import warnings
 
 from braket.aws import AwsDevice
+from qiskit.circuit import ParameterExpression
 from braket.circuits import (
     Circuit,
     FreeParameter,
@@ -451,6 +452,8 @@ def convert_qiskit_to_braket_circuit(circuit: QuantumCircuit) -> Circuit:
             for i, param in enumerate(params):
                 if isinstance(param, Parameter):
                     params[i] = FreeParameter(param.name)
+                elif isinstance(param, ParameterExpression): # Enables users to use ParameterVector elements
+                    params[i] = FreeParameter(name=list(param._names.keys())[0]) # Name of the parameter is stored as a dict key
 
             for gate in qiskit_gate_names_to_braket_gates[gate_name](*params):
                 instruction = Instruction(


### PR DESCRIPTION
### Summary

- Users that work with a qiskit circuit that was parameterized using a qiskit ParameterExpression can now convert their qiskit circuit to a braket circuit using the ``convert_qiskit_to_braket_circuit`` function.


### Details

- A qiskit ParameterExpression could be for example a qiskit Parameter object with a constant (i.e., float) offset. This could can be relevant is one uses a constant baseline for a rotation value on which a variable Parameter then gets added.

This could look something like this for a parametrized CNOT gate in qiskit:

```
q_reg = QuantumRegister(2)
my_qc = QuantumCircuit(q_reg, name="custom_cx")

baseline = np.pi * np.array([0.1, 0.3, 0.7, 0.3, -0.4, 0.4, -0.3])
params = ParameterVector(name='a', length=7)

my_qc.u(
    baseline[0] + params[0], # This would constitute a qiskit ParameterExpression
    baseline[1] + params[1],
    baseline[2] + params[2],
    q_reg[0],
)
my_qc.u(
    baseline[3] + params[3],
    baseline[4] + params[4],
    baseline[5] + params[5],
    q_reg[1],
)
my_qc.rzx(baseline[6] + params[6], q_reg[0], q_reg[1])
```