### PR TITLE
Remove execute method

### DIFF
--- a/tests/providers/test_adapter.py
+++ b/tests/providers/test_adapter.py
@@ -6,7 +6,13 @@ from braket.devices import LocalSimulator
 
 import numpy as np
 
-from qiskit import QuantumCircuit, BasicAer, QuantumRegister, ClassicalRegister
+from qiskit import (
+    QuantumCircuit,
+    BasicAer,
+    QuantumRegister,
+    ClassicalRegister,
+    transpile,
+)
 from qiskit.circuit import Parameter
 from qiskit.circuit.library import PauliEvolutionGate
 from qiskit.quantum_info import SparsePauliOp
@@ -204,7 +210,8 @@ class TestAdapter(TestCase):
                 braket_job = backend.run(qiskit_circuit, shots=1000)
                 braket_result = braket_job.result().get_counts()
 
-                qiskit_job = aer_backend.run(qiskit_circuit, shots=1000)
+                transpiled_circuit = transpile(qiskit_circuit, backend=aer_backend)
+                qiskit_job = aer_backend.run(transpiled_circuit, shots=1000)
                 qiskit_result = qiskit_job.result().get_counts()
 
                 combined_results = combine_dicts(
@@ -243,7 +250,8 @@ class TestAdapter(TestCase):
         braket_job = backend.run(qiskit_circuit, shots=1000)
         braket_result = braket_job.result().get_counts()
 
-        qiskit_job = aer_backend.run(qiskit_circuit, shots=1000)
+        transpiled_circuit = transpile(qiskit_circuit, backend=aer_backend)
+        qiskit_job = aer_backend.run(transpiled_circuit, shots=1000)
         qiskit_result = qiskit_job.result().get_counts()
 
         combined_results = combine_dicts(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Execute(circuit, backend) is deprecated and is being removed from Qiskit. We update how circuits should be simulated in the tests.

### Details and comments
Closes #131
