### PR TITLE
bugfix: Handle `meas_level` from backend.run

### DIFF
--- a/qiskit_braket_provider/providers/braket_backend.py
+++ b/qiskit_braket_provider/providers/braket_backend.py
@@ -37,7 +37,7 @@ class BraketBackend(BackendV2, ABC):
     def __repr__(self):
         return f"BraketBackend[{self.name}]"
 
-    def _validate_meas_level(self, meas_level: enum.Enum | int):
+    def _validate_meas_level(self, meas_level: Union[enum.Enum, int]):
         if isinstance(meas_level, enum.Enum):
             meas_level = meas_level.value
         if meas_level != 2:

--- a/qiskit_braket_provider/providers/braket_backend.py
+++ b/qiskit_braket_provider/providers/braket_backend.py
@@ -41,7 +41,10 @@ class BraketBackend(BackendV2, ABC):
         if isinstance(meas_level, enum.Enum):
             meas_level = meas_level.value
         if meas_level != 2:
-            raise QiskitBraketException(f"Device {self.name} only supports classified measurement results, received meas_level={meas_level}.")
+            raise QiskitBraketException(
+                f"Device {self.name} only supports classified measurement "
+                f"results, received meas_level={meas_level}."
+            )
 
 
 class BraketLocalBackend(BraketBackend):

--- a/qiskit_braket_provider/providers/braket_backend.py
+++ b/qiskit_braket_provider/providers/braket_backend.py
@@ -3,6 +3,7 @@
 
 import datetime
 import logging
+import enum
 from abc import ABC
 from typing import Iterable, Union, List
 
@@ -35,6 +36,12 @@ class BraketBackend(BackendV2, ABC):
 
     def __repr__(self):
         return f"BraketBackend[{self.name}]"
+
+    def _validate_meas_level(self, meas_level: enum.Enum | int):
+        if isinstance(meas_level, enum.Enum):
+            meas_level = meas_level.value
+        if meas_level != 2:
+            raise QiskitBraketException(f"Device {self.name} only supports classified measurement results, received meas_level={meas_level}.")
 
 
 class BraketLocalBackend(BraketBackend):
@@ -109,6 +116,9 @@ class BraketLocalBackend(BraketBackend):
         shots = options["shots"] if "shots" in options else 1024
         if shots == 0:
             circuits = list(map(lambda x: x.state_vector(), circuits))
+        if "meas_level" in options:
+            self._validate_meas_level(options["meas_level"])
+            del options["meas_level"]
         tasks = []
         try:
             for circuit in circuits:
@@ -277,6 +287,10 @@ class AWSBraketBackend(BraketBackend):
             circuits = run_input
         else:
             raise QiskitBraketException(f"Unsupported input type: {type(run_input)}")
+
+        if "meas_level" in options:
+            self._validate_meas_level(options["meas_level"])
+            del options["meas_level"]
 
         braket_circuits = list(convert_qiskit_to_braket_circuits(circuits))
 

--- a/tests/providers/test_adapter.py
+++ b/tests/providers/test_adapter.py
@@ -10,11 +10,11 @@ import numpy as np
 
 from qiskit import (
     QuantumCircuit,
-    BasicAer,
     QuantumRegister,
     ClassicalRegister,
     transpile,
 )
+from qiskit.providers.basicaer import BasicAer
 from qiskit.circuit import Parameter
 from qiskit.circuit.library import PauliEvolutionGate
 from qiskit.quantum_info import SparsePauliOp

--- a/tests/providers/test_braket_backend.py
+++ b/tests/providers/test_braket_backend.py
@@ -156,7 +156,7 @@ class TestAWSBraketBackend(TestCase):
         circuit.h(0)
         circuit.measure(0, 0)
         with self.assertRaises(exception.QiskitBraketException):
-            backend.run(circuit, shots=10, meas_level=0)
+            backend.run(circuit, shots=10, meas_level=1)
 
     def test_vqe(self):
         """Tests VQE."""

--- a/tests/providers/test_braket_backend.py
+++ b/tests/providers/test_braket_backend.py
@@ -6,7 +6,8 @@ from unittest.mock import Mock, patch
 
 from botocore import errorfactory
 from braket.aws.queue_information import QueueDepthInfo, QueueType
-from qiskit import QuantumCircuit, transpile, BasicAer
+from qiskit import QuantumCircuit, transpile
+from qiskit.providers.basicaer import BasicAer
 
 from qiskit.algorithms.minimum_eigensolvers import VQE, VQEResult
 

--- a/tests/providers/test_braket_backend.py
+++ b/tests/providers/test_braket_backend.py
@@ -20,7 +20,7 @@ from qiskit.result import Result
 from qiskit.transpiler import Target
 from qiskit.primitives import BackendEstimator
 
-from qiskit_braket_provider import AWSBraketProvider, version
+from qiskit_braket_provider import AWSBraketProvider, version, exception
 from qiskit_braket_provider.providers import AWSBraketBackend, BraketLocalBackend
 from qiskit_braket_provider.providers.adapter import aws_device_to_target
 from tests.providers.mocks import (
@@ -140,6 +140,23 @@ class TestAWSBraketBackend(TestCase):
         self.assertEqual(statevector[1], 0.0 + 0.0j)
         self.assertEqual(statevector[2], 0.0 + 0.0j)
         self.assertEqual(statevector[3], 1.0 + 0.0j)
+
+    def test_meas_level_2(self):
+        """Check that there's no error for asking for classified measurement results."""
+        backend = BraketLocalBackend(name="default")
+        circuit = QuantumCircuit(1, 1)
+        circuit.h(0)
+        circuit.measure(0, 0)
+        backend.run(circuit, shots=10, meas_level=2)
+
+    def test_meas_level_1(self):
+        """Check that there's an exception for asking for raw measurement results."""
+        backend = BraketLocalBackend(name="default")
+        circuit = QuantumCircuit(1, 1)
+        circuit.h(0)
+        circuit.measure(0, 0)
+        with self.assertRaises(exception.QiskitBraketException):
+            backend.run(circuit, shots=10, meas_level=0)
 
     def test_vqe(self):
         """Tests VQE."""


### PR DESCRIPTION
### Summary

Validate meas_level if it is supplied to run, and if it's valid, remove it. AwsQuantumTask does not accept `meas_level` argument.

Note:
meas_level=0 is raw results, an array of complex values (think sampled data collected from an ADC)
meas_level=1 is kerneled results, so a single complex value
meas_level=2 is classified results, 0 or 1

meas_level is also often supplied as an enum. For example: https://github.com/Qiskit-Extensions/qiskit-experiments/blob/f22bb7b67893a1b75f7d0f1fecdb0bd63284e244/qiskit_experiments/framework/base_experiment.py#L454

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


