### PR TITLE
Prevent Qiskit 1.0 upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 certifi>=2021.5.30
-qiskit-aer>=0.10.2
-qiskit-terra>=0.19.2
+qiskit>=0.34.2, <1.0
 amazon-braket-sdk>=1.56.0
 
 setuptools>=40.1.0

--- a/tests/providers/test_adapter.py
+++ b/tests/providers/test_adapter.py
@@ -348,7 +348,7 @@ class TestAdapter(TestCase):
 
         qiskit_circuit = QuantumCircuit(2, 2)
         qiskit_circuit.h(0)
-        qiskit_circuit.cnot(0, 1)
+        qiskit_circuit.cx(0, 1)
         qiskit_circuit.measure(0, 0)
         braket_circuit = to_braket(qiskit_circuit)
 
@@ -372,7 +372,7 @@ class TestAdapter(TestCase):
 
         qiskit_circuit = QuantumCircuit(2, 2)
         qiskit_circuit.h(0)
-        qiskit_circuit.cnot(0, 1)
+        qiskit_circuit.cx(0, 1)
         qiskit_circuit.measure(0, 1)
         braket_circuit = to_braket(qiskit_circuit)
 
@@ -396,7 +396,7 @@ class TestAdapter(TestCase):
         creg = ClassicalRegister(2, "creg")
         qiskit_circuit = QuantumCircuit(qreg_a, qreg_b, creg)
         qiskit_circuit.h(qreg_a[0])
-        qiskit_circuit.cnot(qreg_a[0], qreg_b[0])
+        qiskit_circuit.cx(qreg_a[0], qreg_b[0])
         qiskit_circuit.x(qreg_a[1])
         qiskit_circuit.measure(qreg_a[0], creg[1])
         qiskit_circuit.measure(qreg_b[0], creg[0])

--- a/tests/providers/test_braket_backend.py
+++ b/tests/providers/test_braket_backend.py
@@ -259,7 +259,7 @@ class TestAWSBraketBackend(TestCase):
         """
         device = AWSBraketProvider().get_backend("Aspen-M-2")
         circuit = QuantumCircuit(2)
-        circuit.cnot(0, 1)
+        circuit.cx(0, 1)
 
         with self.assertRaises(errorfactory.ClientError):
             device.run(circuit, verbatim=True, disable_qubit_rewiring=True)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Prevent upgrade to qiskit 1.0 which will have breaking changes.


### Details and comments
using the qiskit metapackage instead of terra/aer. 
use cx instead of cnot as qsikit 0.46 added deprecation messges.
