### PR TITLE
Skip transpilation for verbatim circuits

### DIFF
--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -485,6 +485,11 @@ def to_braket(
     if circuit.global_phase > _EPS:
         braket_circuit.gphase(circuit.global_phase)
 
+    if verbatim:
+        return Circuit(braket_circuit.result_types).add_verbatim_box(
+            Circuit(braket_circuit.instructions)
+        )
+
     return braket_circuit
 
 
@@ -588,18 +593,3 @@ def _create_gate(
     else:
         raise TypeError(f'Braket gate "{gate_name}" not supported in Qiskit')
     return gate_cls(*gate_params)
-
-
-def wrap_circuits_in_verbatim_box(circuits: list[Circuit]) -> Iterable[Circuit]:
-    """Convert each Braket circuit an equivalent one wrapped in verbatim box.
-
-    Args:
-           circuits (List(Circuit): circuits to be wrapped in verbatim box.
-    Returns:
-           Circuits wrapped in verbatim box, comprising the same instructions
-           as the original one and with result types preserved.
-    """
-    return [
-        Circuit(circuit.result_types).add_verbatim_box(Circuit(circuit.instructions))
-        for circuit in circuits
-    ]

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -404,11 +404,15 @@ def aws_device_to_target(device: AwsDevice) -> Target:
     return target
 
 
-def to_braket(circuit: QuantumCircuit, gateset: Iterable[str] = None) -> Circuit:
+def to_braket(
+    circuit: QuantumCircuit, gateset: Optional[Iterable[str]] = None
+) -> Circuit:
     """Return a Braket quantum circuit from a Qiskit quantum circuit.
      Args:
             circuit (QuantumCircuit): Qiskit quantum circuit
-            gateset (Iterable[str]): The gateset to transpile to
+            gateset (Optional[Iterable[str]]): The gateset to transpile to.
+                If `None`, the transpiler will use all gates defined in the Braket SDK.
+                Default: `None`.
 
     Returns:
         Circuit: Braket circuit

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -405,7 +405,9 @@ def aws_device_to_target(device: AwsDevice) -> Target:
 
 
 def to_braket(
-    circuit: QuantumCircuit, gateset: Optional[Iterable[str]] = None
+    circuit: QuantumCircuit,
+    gateset: Optional[Iterable[str]] = None,
+    verbatim: bool = False,
 ) -> Circuit:
     """Return a Braket quantum circuit from a Qiskit quantum circuit.
      Args:
@@ -413,6 +415,8 @@ def to_braket(
             gateset (Optional[Iterable[str]]): The gateset to transpile to.
                 If `None`, the transpiler will use all gates defined in the Braket SDK.
                 Default: `None`.
+            verbatim (bool): Whether to translate the circuit without any modification, in other
+                words without transpiling it. Default: False.
 
     Returns:
         Circuit: Braket circuit
@@ -422,10 +426,8 @@ def to_braket(
         raise TypeError(f"Expected a QuantumCircuit, got {type(circuit)} instead.")
 
     braket_circuit = Circuit()
-    if not (
-        {gate.name for gate, _, _ in circuit.data}.issubset(
-            _TRANSLATABLE_QISKIT_GATE_NAMES
-        )
+    if not verbatim and not {gate.name for gate, _, _ in circuit.data}.issubset(
+        gateset
     ):
         circuit = transpile(circuit, basis_gates=gateset, optimization_level=0)
 

--- a/qiskit_braket_provider/providers/braket_backend.py
+++ b/qiskit_braket_provider/providers/braket_backend.py
@@ -92,7 +92,7 @@ class BraketLocalBackend(BraketBackend):
         self.backend_name = name
         self._local_device = LocalSimulator(backend=self.backend_name)
         self._target = local_simulator_to_target(self._local_device)
-        self.status = self._device.status
+        self.status = self._local_device.status
 
     @property
     def target(self):

--- a/qiskit_braket_provider/providers/braket_backend.py
+++ b/qiskit_braket_provider/providers/braket_backend.py
@@ -22,7 +22,6 @@ from .adapter import (
     BRAKET_TO_QISKIT_NAMES,
     local_simulator_to_target,
     to_braket,
-    wrap_circuits_in_verbatim_box,
     get_controlled_gateset,
 )
 from .braket_job import AmazonBraketTask
@@ -333,8 +332,6 @@ class AWSBraketBackend(BraketBackend):
 
         verbatim = options.pop("verbatim", False)
         braket_circuits = [to_braket(circ, gateset, verbatim) for circ in circuits]
-        if verbatim:
-            braket_circuits = wrap_circuits_in_verbatim_box(braket_circuits)
 
         batch_task: AwsQuantumTaskBatch = self._device.run_batch(
             braket_circuits, **options

--- a/qiskit_braket_provider/providers/braket_backend.py
+++ b/qiskit_braket_provider/providers/braket_backend.py
@@ -331,9 +331,9 @@ class AWSBraketBackend(BraketBackend):
             self._validate_meas_level(options["meas_level"])
             del options["meas_level"]
 
-        braket_circuits = [to_braket(circ, gateset) for circ in circuits]
-
-        if options.pop("verbatim", False):
+        verbatim = options.pop("verbatim", False)
+        braket_circuits = [to_braket(circ, gateset, verbatim) for circ in circuits]
+        if verbatim:
             braket_circuits = wrap_circuits_in_verbatim_box(braket_circuits)
 
         batch_task: AwsQuantumTaskBatch = self._device.run_batch(

--- a/qiskit_braket_provider/providers/braket_backend.py
+++ b/qiskit_braket_provider/providers/braket_backend.py
@@ -5,13 +5,13 @@ import logging
 import enum
 from abc import ABC
 from collections.abc import Iterable
-from typing import Union
+from typing import Optional, Union
 
 from braket.aws import AwsDevice, AwsQuantumTaskBatch, AwsQuantumTask
 from braket.aws.queue_information import QueueDepthInfo
 from braket.circuits import Circuit
 from braket.device_schema import DeviceActionType
-from braket.devices import LocalSimulator
+from braket.devices import Device, LocalSimulator
 from braket.ir.openqasm.modifiers import Control
 from braket.tasks.local_quantum_task import LocalQuantumTask
 from qiskit import QuantumCircuit
@@ -41,6 +41,10 @@ class BraketBackend(BackendV2, ABC):
     def __repr__(self):
         return f"BraketBackend[{self.name}]"
 
+    @property
+    def _device(self) -> Device:
+        raise NotImplementedError
+
     def _validate_meas_level(self, meas_level: Union[enum.Enum, int]):
         if isinstance(meas_level, enum.Enum):
             meas_level = meas_level.value
@@ -49,6 +53,23 @@ class BraketBackend(BackendV2, ABC):
                 f"Device {self.name} only supports classified measurement "
                 f"results, received meas_level={meas_level}."
             )
+
+    def _get_gateset(self) -> Optional[set[str]]:
+        action = self._device.properties.action.get(DeviceActionType.OPENQASM)
+        if not action:
+            return None
+        gateset = {
+            BRAKET_TO_QISKIT_NAMES[op.lower()]
+            for op in action.supportedOperations
+            if op.lower() in BRAKET_TO_QISKIT_NAMES
+        }
+        max_control = 0
+        for modifier in action.supportedModifiers:
+            if isinstance(modifier, Control):
+                max_control = modifier.max_qubits
+                break
+        gateset.update(get_controlled_gateset(max_control))
+        return gateset
 
 
 class BraketLocalBackend(BraketBackend):
@@ -70,9 +91,9 @@ class BraketLocalBackend(BraketBackend):
         """
         super().__init__(name=name, **fields)
         self.backend_name = name
-        self._aws_device = LocalSimulator(backend=self.backend_name)
-        self._target = local_simulator_to_target(self._aws_device)
-        self.status = self._aws_device.status
+        self._local_device = LocalSimulator(backend=self.backend_name)
+        self._target = local_simulator_to_target(self._local_device)
+        self.status = self._device.status
 
     @property
     def target(self):
@@ -95,6 +116,10 @@ class BraketLocalBackend(BraketBackend):
     @property
     def meas_map(self) -> list[list[int]]:
         raise NotImplementedError(f"Measurement map is not supported by {self.name}.")
+
+    @property
+    def _device(self) -> Device:
+        return self._local_device
 
     def qubit_properties(
         self, qubit: Union[int, list[int]]
@@ -119,18 +144,7 @@ class BraketLocalBackend(BraketBackend):
         convert_input = (
             [run_input] if isinstance(run_input, QuantumCircuit) else list(run_input)
         )
-        action = self._aws_device.properties.action[DeviceActionType.OPENQASM]
-        gateset = {
-            BRAKET_TO_QISKIT_NAMES[op.lower()]
-            for op in action.supportedOperations
-            if op.lower() in BRAKET_TO_QISKIT_NAMES
-        }
-        max_control = 0
-        for modifier in action.supportedModifiers:
-            if isinstance(modifier, Control):
-                max_control = modifier.max_qubits
-                break
-        gateset.update(get_controlled_gateset(max_control))
+        gateset = self._get_gateset()
         circuits: list[Circuit] = [to_braket(circ, gateset) for circ in convert_input]
         shots = options["shots"] if "shots" in options else 1024
         if shots == 0:
@@ -141,7 +155,7 @@ class BraketLocalBackend(BraketBackend):
         tasks = []
         try:
             for circuit in circuits:
-                task: LocalQuantumTask = self._aws_device.run(
+                task: LocalQuantumTask = self._device.run(
                     task_specification=circuit, shots=shots
                 )
                 tasks.append(task)
@@ -206,7 +220,7 @@ class AWSBraketBackend(BraketBackend):
         )
         user_agent = f"QiskitBraketProvider/{version.__version__}"
         device.aws_session.add_braket_user_agent(user_agent)
-        self._device = device
+        self._aws_device = device
         self._target = aws_device_to_target(device=device)
 
     def retrieve_job(self, task_id: str) -> AmazonBraketTask:
@@ -233,6 +247,10 @@ class AWSBraketBackend(BraketBackend):
     @property
     def max_circuits(self):
         return None
+
+    @property
+    def _device(self) -> Device:
+        return self._aws_device
 
     @classmethod
     def _default_options(cls):
@@ -307,11 +325,13 @@ class AWSBraketBackend(BraketBackend):
         else:
             raise QiskitBraketException(f"Unsupported input type: {type(run_input)}")
 
+        gateset = self._get_gateset()
+
         if "meas_level" in options:
             self._validate_meas_level(options["meas_level"])
             del options["meas_level"]
 
-        braket_circuits = [to_braket(circuit) for circuit in circuits]
+        braket_circuits = [to_braket(circ, gateset) for circ in circuits]
 
         if options.pop("verbatim", False):
             braket_circuits = wrap_circuits_in_verbatim_box(braket_circuits)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Circuits are no longer translated when `verbatim` argument is passed to `run`.

### Details and comments

Also expands the supported gates check to both `BraketLocalBackend` and `AWSBraketBackend`.
