### PR TITLE
Move gateset construction to adapter

### DIFF
--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -448,9 +448,7 @@ def aws_device_to_target(device: AwsDevice) -> Target:
 
 def to_braket(
     circuit: QuantumCircuit,
-    basis_gates: Optional[
-        Iterable[str]
-    ] = None,  # TODO: Use backend instead of basis_gates
+    basis_gates: Optional[Iterable[str]] = None,
     verbatim: bool = False,
 ) -> Circuit:
     """Return a Braket quantum circuit from a Qiskit quantum circuit.

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -26,6 +26,7 @@ from braket.device_schema.simulators import (
     GateModelSimulatorParadigmProperties,
 )
 from braket.devices import LocalSimulator
+from braket.ir.openqasm.modifiers import Control
 
 from numpy import pi
 
@@ -37,7 +38,7 @@ import qiskit.circuit.library as qiskit_gates
 from qiskit.transpiler import InstructionProperties, Target
 from qiskit_braket_provider.exception import QiskitBraketException
 
-BRAKET_TO_QISKIT_NAMES = {
+_BRAKET_TO_QISKIT_NAMES = {
     "u": "u",
     "phaseshift": "p",
     "cnot": "cx",
@@ -75,7 +76,7 @@ _ARBITRARY_CONTROLLED_GATES = {"mcx"}
 
 _EPS = 1e-10  # global variable used to chop very small numbers to zero
 
-GATE_NAME_TO_BRAKET_GATE: dict[str, Callable] = {
+_GATE_NAME_TO_BRAKET_GATE: dict[str, Callable] = {
     "u1": lambda lam: [braket_gates.PhaseShift(lam)],
     "u2": lambda phi, lam: [
         braket_gates.PhaseShift(lam),
@@ -135,12 +136,12 @@ _QISKIT_CONTROLLED_GATE_NAMES_TO_BRAKET_GATES: dict[str, Callable] = {
 }
 
 _TRANSLATABLE_QISKIT_GATE_NAMES = (
-    set(GATE_NAME_TO_BRAKET_GATE.keys())
+    set(_GATE_NAME_TO_BRAKET_GATE.keys())
     .union(set(_QISKIT_CONTROLLED_GATE_NAMES_TO_BRAKET_GATES))
     .union({"measure", "barrier", "reset"})
 )
 
-GATE_NAME_TO_QISKIT_GATE: dict[str, Optional[QiskitInstruction]] = {
+_GATE_NAME_TO_QISKIT_GATE: dict[str, Optional[QiskitInstruction]] = {
     "u": qiskit_gates.UGate(Parameter("theta"), Parameter("phi"), Parameter("lam")),
     "u1": qiskit_gates.U1Gate(Parameter("theta")),
     "u2": qiskit_gates.U2Gate(Parameter("theta"), Parameter("lam")),
@@ -175,7 +176,30 @@ GATE_NAME_TO_QISKIT_GATE: dict[str, Optional[QiskitInstruction]] = {
 }
 
 
-def get_controlled_gateset(max_qubits: Optional[int] = None) -> set[str]:
+def gateset_from_properties(properties: OpenQASMDeviceActionProperties) -> set[str]:
+    """Returns the gateset supported by a Braket device with the given properties
+
+    Args:
+        properties (OpenQASMDeviceActionProperties): The action properties of the Braket device.
+
+    Returns:
+        set[str]: The names of the gates supported by the device
+    """
+    gateset = {
+        _BRAKET_TO_QISKIT_NAMES[op.lower()]
+        for op in properties.supportedOperations
+        if op.lower() in _BRAKET_TO_QISKIT_NAMES
+    }
+    max_control = 0
+    for modifier in properties.supportedModifiers:
+        if isinstance(modifier, Control):
+            max_control = modifier.max_qubits
+            break
+    gateset.update(_get_controlled_gateset(max_control))
+    return gateset
+
+
+def _get_controlled_gateset(max_qubits: Optional[int] = None) -> set[str]:
     """Returns the Qiskit gates expressible as controlled versions of existing Braket gates
 
     This set can be filtered by the maximum number of control qubits.
@@ -209,7 +233,7 @@ def local_simulator_to_target(simulator: LocalSimulator) -> Target:
     target = Target()
 
     instructions = [
-        inst for inst in GATE_NAME_TO_QISKIT_GATE.values() if inst is not None
+        inst for inst in _GATE_NAME_TO_QISKIT_GATE.values() if inst is not None
     ]
     properties = simulator.properties
     paradigm: GateModelSimulatorParadigmProperties = properties.paradigm
@@ -265,7 +289,7 @@ def aws_device_to_target(device: AwsDevice) -> Target:
         instructions: list[QiskitInstruction] = []
 
         for operation in action_properties.supportedOperations:
-            instruction = GATE_NAME_TO_QISKIT_GATE.get(operation.lower(), None)
+            instruction = _GATE_NAME_TO_QISKIT_GATE.get(operation.lower(), None)
             if instruction is not None:
                 # TODO: remove when target will be supporting > 2 qubit gates  # pylint:disable=fixme
                 if instruction.num_qubits <= 2:
@@ -363,7 +387,7 @@ def aws_device_to_target(device: AwsDevice) -> Target:
         instructions = []
 
         for operation in simulator_action_properties.supportedOperations:
-            instruction = GATE_NAME_TO_QISKIT_GATE.get(operation.lower(), None)
+            instruction = _GATE_NAME_TO_QISKIT_GATE.get(operation.lower(), None)
             if instruction is not None:
                 # TODO: remove when target will be supporting > 2 qubit gates  # pylint:disable=fixme
                 if instruction.num_qubits <= 2:
@@ -406,13 +430,15 @@ def aws_device_to_target(device: AwsDevice) -> Target:
 
 def to_braket(
     circuit: QuantumCircuit,
-    gateset: Optional[Iterable[str]] = None,
+    basis_gates: Optional[
+        Iterable[str]
+    ] = None,  # TODO: Use backend instead of basis_gates
     verbatim: bool = False,
 ) -> Circuit:
     """Return a Braket quantum circuit from a Qiskit quantum circuit.
      Args:
             circuit (QuantumCircuit): Qiskit quantum circuit
-            gateset (Optional[Iterable[str]]): The gateset to transpile to.
+            basis_gates (Optional[Iterable[str]]): The gateset to transpile to.
                 If `None`, the transpiler will use all gates defined in the Braket SDK.
                 Default: `None`.
             verbatim (bool): Whether to translate the circuit without any modification, in other
@@ -421,15 +447,15 @@ def to_braket(
     Returns:
         Circuit: Braket circuit
     """
-    gateset = gateset or _TRANSLATABLE_QISKIT_GATE_NAMES
+    basis_gates = basis_gates or _TRANSLATABLE_QISKIT_GATE_NAMES
     if not isinstance(circuit, QuantumCircuit):
         raise TypeError(f"Expected a QuantumCircuit, got {type(circuit)} instead.")
 
     braket_circuit = Circuit()
     if not verbatim and not {gate.name for gate, _, _ in circuit.data}.issubset(
-        gateset
+        basis_gates
     ):
-        circuit = transpile(circuit, basis_gates=gateset, optimization_level=0)
+        circuit = transpile(circuit, basis_gates=basis_gates, optimization_level=0)
 
     # handle qiskit to braket conversion
     for circuit_instruction in circuit.data:
@@ -475,7 +501,7 @@ def to_braket(
                 )
                 braket_circuit += instruction
             else:
-                for gate in GATE_NAME_TO_BRAKET_GATE[gate_name](*params):
+                for gate in _GATE_NAME_TO_BRAKET_GATE[gate_name](*params):
                     instruction = Instruction(
                         operator=gate,
                         target=[circuit.find_bit(qubit).index for qubit in qubits],
@@ -587,7 +613,7 @@ def to_qiskit(circuit: Circuit) -> QuantumCircuit:
 def _create_gate(
     gate_name: str, gate_params: list[Union[float, Parameter]]
 ) -> Instruction:
-    gate_instance = GATE_NAME_TO_QISKIT_GATE.get(gate_name, None)
+    gate_instance = _GATE_NAME_TO_QISKIT_GATE.get(gate_name, None)
     if gate_instance is not None:
         gate_cls = gate_instance.__class__
     else:

--- a/qiskit_braket_provider/providers/braket_backend.py
+++ b/qiskit_braket_provider/providers/braket_backend.py
@@ -128,8 +128,8 @@ class BraketLocalBackend(BraketBackend):
         convert_input = (
             [run_input] if isinstance(run_input, QuantumCircuit) else list(run_input)
         )
-        gateset = self._get_gateset()
         verbatim = options.pop("verbatim", False)
+        gateset = self._get_gateset() if not verbatim else None
         circuits: list[Circuit] = [
             to_braket(circ, gateset, verbatim) for circ in convert_input
         ]
@@ -313,13 +313,12 @@ class AWSBraketBackend(BraketBackend):
         else:
             raise QiskitBraketException(f"Unsupported input type: {type(run_input)}")
 
-        gateset = self._get_gateset()
-
         if "meas_level" in options:
             self._validate_meas_level(options["meas_level"])
             del options["meas_level"]
 
         verbatim = options.pop("verbatim", False)
+        gateset = self._get_gateset() if not verbatim else None
         braket_circuits = [to_braket(circ, gateset, verbatim) for circ in circuits]
 
         batch_task: AwsQuantumTaskBatch = self._device.run_batch(

--- a/tests/providers/test_adapter.py
+++ b/tests/providers/test_adapter.py
@@ -27,9 +27,9 @@ from qiskit_braket_provider.providers.adapter import (
     to_braket,
     convert_qiskit_to_braket_circuit,
     convert_qiskit_to_braket_circuits,
-    GATE_NAME_TO_BRAKET_GATE,
-    GATE_NAME_TO_QISKIT_GATE,
-    get_controlled_gateset,
+    _GATE_NAME_TO_BRAKET_GATE,
+    _GATE_NAME_TO_QISKIT_GATE,
+    _get_controlled_gateset,
 )
 from qiskit_braket_provider.providers.braket_backend import BraketLocalBackend
 
@@ -288,12 +288,12 @@ class TestAdapter(TestCase):
 
         self.assertEqual(
             list(sorted(qiskit_to_braket_gate_names.keys())),
-            list(sorted(GATE_NAME_TO_BRAKET_GATE.keys())),
+            list(sorted(_GATE_NAME_TO_BRAKET_GATE.keys())),
         )
 
         self.assertEqual(
             list(sorted(qiskit_to_braket_gate_names.values())),
-            list(sorted(GATE_NAME_TO_QISKIT_GATE.keys())),
+            list(sorted(_GATE_NAME_TO_QISKIT_GATE.keys())),
         )
 
     def test_type_error_on_bad_input(self):
@@ -438,12 +438,12 @@ class TestAdapter(TestCase):
         max1 = {"ch", "cs", "csdg", "csx", "crx", "cry", "crz", "ccz"}
         max3 = max1.union({"c3sx"})
         unlimited = max3.union({"mcx"})
-        assert get_controlled_gateset(0) == set()
-        assert get_controlled_gateset(1) == max1
-        assert get_controlled_gateset(2) == max1
-        assert get_controlled_gateset(3) == max3
-        assert get_controlled_gateset(4) == max3
-        assert get_controlled_gateset() == unlimited
+        assert _get_controlled_gateset(0) == set()
+        assert _get_controlled_gateset(1) == max1
+        assert _get_controlled_gateset(2) == max1
+        assert _get_controlled_gateset(3) == max3
+        assert _get_controlled_gateset(4) == max3
+        assert _get_controlled_gateset() == unlimited
 
 
 class TestFromBraket(TestCase):
@@ -465,7 +465,7 @@ class TestFromBraket(TestCase):
         gate_set = [attr for attr in dir(Gate) if attr[0].isupper()]
 
         for gate_name in gate_set:
-            if gate_name.lower() not in GATE_NAME_TO_QISKIT_GATE:
+            if gate_name.lower() not in _GATE_NAME_TO_QISKIT_GATE:
                 continue
 
             gate = getattr(Gate, gate_name)
@@ -483,7 +483,7 @@ class TestFromBraket(TestCase):
 
             expected_qiskit_circuit = QuantumCircuit(op.qubit_count)
             expected_qiskit_circuit.append(
-                GATE_NAME_TO_QISKIT_GATE.get(gate_name.lower()), target
+                _GATE_NAME_TO_QISKIT_GATE.get(gate_name.lower()), target
             )
             expected_qiskit_circuit.measure_all()
             expected_qiskit_circuit = expected_qiskit_circuit.assign_parameters(

--- a/tests/providers/test_adapter.py
+++ b/tests/providers/test_adapter.py
@@ -350,7 +350,7 @@ class TestAdapter(TestCase):
 
         self.assertEqual(
             set(qiskit_to_braket_gate_names.values()),
-            set(_GATE_NAME_TO_BRAKET_GATE.keys()),
+            set(_GATE_NAME_TO_QISKIT_GATE.keys()),
         )
 
     def test_type_error_on_bad_input(self):
@@ -564,7 +564,7 @@ class TestFromBraket(TestCase):
         for gate_name in gate_set:
             gate = getattr(Gate, gate_name)
             value = 0.1
-            qiskit_gate_cls = GATE_NAME_TO_QISKIT_GATE.get(gate_name.lower()).__class__
+            qiskit_gate_cls = _GATE_NAME_TO_QISKIT_GATE.get(gate_name.lower()).__class__
             qiskit_value = 0.1 / (2 * np.pi)
             if issubclass(gate, AngledGate):
                 op = gate(value)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Put gateset construction in a more logical place and made constants and methods private as needed.

### Details and comments

Also skip gateset construction when running circuits verbatim.