### PR TITLE
Include all gates in simulator targets

### DIFF
--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -300,7 +300,7 @@ def _qpu_target(
     for operation in action_properties.supportedOperations:
         instruction = _GATE_NAME_TO_QISKIT_GATE.get(operation.lower(), None)
 
-        # TODO: Add 3+ qubit gates when target supports them  # pylint:disable=fixme
+        # TODO: Add 3+ qubit gates when Target supports them  # pylint:disable=fixme
         if instruction and instruction.num_qubits <= 2:
             if instruction.num_qubits == 1:
                 target.add_instruction(

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -301,6 +301,21 @@ def aws_device_to_target(device: AwsDevice) -> Target:
     )
 
 
+def _simulator_target(target: Target, properties: GateModelSimulatorDeviceCapabilities):
+    target.num_qubits = properties.paradigm.qubitCount
+    action = (
+        properties.action.get(DeviceActionType.OPENQASM)
+        if properties.action.get(DeviceActionType.OPENQASM)
+        else properties.action.get(DeviceActionType.JAQCD)
+    )
+    for operation in action.supportedOperations:
+        instruction = _GATE_NAME_TO_QISKIT_GATE.get(operation.lower(), None)
+        if instruction:
+            target.add_instruction(instruction)
+    target.add_instruction(Measure())
+    return target
+
+
 def _build_2q_instruction_properties(connectivity, qubit_count, properties):
     instruction_props = {}
 
@@ -324,21 +339,6 @@ def _build_2q_instruction_properties(connectivity, qubit_count, properties):
                 instruction_props[(int(src), int(dst))] = None
 
     return instruction_props
-
-
-def _simulator_target(target: Target, properties: GateModelSimulatorDeviceCapabilities):
-    target.num_qubits = properties.paradigm.qubitCount
-    action = (
-        properties.action.get(DeviceActionType.OPENQASM)
-        if properties.action.get(DeviceActionType.OPENQASM)
-        else properties.action.get(DeviceActionType.JAQCD)
-    )
-    for operation in action.supportedOperations:
-        instruction = _GATE_NAME_TO_QISKIT_GATE.get(operation.lower(), None)
-        if instruction:
-            target.add_instruction(instruction)
-    target.add_instruction(Measure())
-    return target
 
 
 def _convert_aspen_qubit_indices(connectivity_graph: dict) -> dict:

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -302,7 +302,7 @@ def _qpu_target(
         if instruction:
             target.add_instruction(
                 instruction,
-                _build_instruction_properties(
+                _qpu_instruction_properties(
                     instruction, qubit_count, connectivity, properties
                 ),
             )
@@ -311,7 +311,7 @@ def _qpu_target(
     return target
 
 
-def _build_instruction_properties(instruction, qubit_count, connectivity, properties):
+def _qpu_instruction_properties(instruction, qubit_count, connectivity, properties):
     if instruction.num_qubits == 1:
         return {(i,): None for i in range(qubit_count)}
     elif instruction.num_qubits == 2:

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -300,7 +300,7 @@ def _qpu_target(
     for operation in action_properties.supportedOperations:
         instruction = _GATE_NAME_TO_QISKIT_GATE.get(operation.lower(), None)
 
-        # TODO: Add 3+ qubit gates when Target supports them  # pylint:disable=fixme
+        # TODO: Add 3+ qubit gates once Target supports them  # pylint:disable=fixme
         if instruction and instruction.num_qubits <= 2:
             if instruction.num_qubits == 1:
                 target.add_instruction(

--- a/qiskit_braket_provider/providers/braket_job.py
+++ b/qiskit_braket_provider/providers/braket_job.py
@@ -1,4 +1,5 @@
 """AWS Braket job."""
+
 from datetime import datetime
 from typing import List, Optional, Union
 from warnings import warn

--- a/qiskit_braket_provider/version.py
+++ b/qiskit_braket_provider/version.py
@@ -1,2 +1,3 @@
 """Qiskit-Braket provider version."""
+
 __version__ = "0.0.5"

--- a/tests/providers/test_adapter.py
+++ b/tests/providers/test_adapter.py
@@ -1,4 +1,5 @@
 """Tests for Qiskit to Braket adapter."""
+
 from unittest import TestCase
 from unittest.mock import Mock, patch
 

--- a/tests/providers/test_braket_backend.py
+++ b/tests/providers/test_braket_backend.py
@@ -318,4 +318,4 @@ class TestAWSBackendTarget(TestCase):
         self.assertEqual(target.num_qubits, 30)
         self.assertEqual(len(target.operations), 2)
         self.assertEqual(len(target.instructions), 60)
-        self.assertIn("Target for AWS Device", target.description)
+        self.assertIn("Target for Amazon Braket device", target.description)

--- a/tests/providers/test_braket_backend.py
+++ b/tests/providers/test_braket_backend.py
@@ -1,4 +1,5 @@
 """Tests for AWS Braket backends."""
+
 import unittest
 from typing import Dict, List
 from unittest import TestCase

--- a/tests/providers/test_braket_provider.py
+++ b/tests/providers/test_braket_provider.py
@@ -1,4 +1,5 @@
 """Tests for AWS Braket provider."""
+
 from unittest import TestCase
 from unittest.mock import Mock, patch
 import uuid


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

* Simulator targets now include all gates, regardless of qubit count
* Major refactor to make code more readable, with functions being extracted as appropriate
* Adds the device qubit count to the target.

### Details and comments

Prior to this change, simulator targets and QPU targets alike were limited to up to 2q gates. Although no Braket devices are subject to these restrictions, this restriction still makes sense for QPUs because there is no analog of coupling map (and corresponding properties) for 3+ qubits. However, Braket simulators do not have a notion of coupling map, and gates can be applied to any qubit without impacting result quality. As such, this change removes this restriction for simulators.