### PR TITLE
Properly substitute symbolic parameters

### DIFF
--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -526,7 +526,7 @@ def _create_qiskit_gate(
     gate_cls = gate_instance.__class__
     new_gate_params = []
     for param_expression, value in zip(gate_instance.params, gate_params):
-        # Assumes that each Qiksit gate has one free parameter per expression
+        # Assumes that each Qiskit gate has one free parameter per expression
         param = list(param_expression.parameters)[0]
         assigned = param_expression.assign(param, value)
         new_gate_params.append(assigned)

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -521,18 +521,15 @@ def _create_qiskit_gate(
     gate_name: str, gate_params: list[Union[float, Parameter]]
 ) -> Instruction:
     gate_instance = _GATE_NAME_TO_QISKIT_GATE.get(gate_name, None)
+    if gate_instance is None:
+        raise TypeError(f'Braket gate "{gate_name}" not supported in Qiskit')
+    gate_cls = gate_instance.__class__
     new_gate_params = []
     for param_expression, value in zip(gate_instance.params, gate_params):
+        # Assumes that each Qiksit gate has one free parameter per expression
         param = list(param_expression.parameters)[0]
-        if isinstance(value, Parameter):
-            new_gate_params.append(value)
-        else:
-            bound_param_expression = param_expression.bind({param: value})
-            new_gate_params.append(bound_param_expression)
-    if gate_instance is not None:
-        gate_cls = gate_instance.__class__
-    else:
-        raise TypeError(f'Braket gate "{gate_name}" not supported in Qiskit')
+        assigned = param_expression.assign(param, value)
+        new_gate_params.append(assigned)
     return gate_cls(*new_gate_params)
 
 

--- a/tests/providers/test_adapter.py
+++ b/tests/providers/test_adapter.py
@@ -549,8 +549,8 @@ class TestFromBraket(TestCase):
                 expected_qiskit_circuit = expected_qiskit_circuit.assign_parameters(
                     dict(
                         zip(
-                            # Need to use gate parameters because
-                            # circuit parameters are sorted alphabetically
+                            # Need to use qiskit_gate.parameters because
+                            # qiskit_circuit.parameters is sorted alphabetically
                             [list(expr.parameters)[0] for expr in qiskit_gate.params],
                             params_qiskit[: len(qiskit_gate.params)],
                         )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

`to_qiskit` now substitutes the parameter in a Qiskit gate's parameter expression instead of replacing the entire expression wholesale.

### Details and comments

