### PR TITLE
Optimize the number of queries to the service

### DIFF
--- a/qiskit_braket_provider/providers/braket_job.py
+++ b/qiskit_braket_provider/providers/braket_job.py
@@ -35,7 +35,7 @@ def _get_result_from_aws_tasks(
         tasks, AwsQuantumTaskBatch.MAX_CONNECTIONS_DEFAULT
     )
 
-    # For each task the results is get and filled into an ExperimentResult object
+    # For each task we create an ExperimentResult object with the downloaded results.
     for task, result in zip(tasks, results):
         if not result:
             return None


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
- Use AwsQuantumTaskBatch._retrieve_result to download results faster (using multiple parallel workers). 
- Use cached task status value to avoid query the service multiple times.


### Details and comments

