### PR TITLE
Fix some Parameter translation edge cases

### DIFF
--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -492,11 +492,8 @@ def _create_free_parameter(param):
     elif isinstance(param, Parameter):
         return FreeParameter(param.name)
     elif isinstance(param, ParameterExpression):
-        if param.is_real():
-            return float(param)
-        else:
-            renamed_param_name = _rename_param_vector_element(param)
-            return FreeParameterExpression(renamed_param_name)
+        renamed_param_name = _rename_param_vector_element(param)
+        return FreeParameterExpression(renamed_param_name)
     else:
         return param
 

--- a/tests/providers/test_adapter.py
+++ b/tests/providers/test_adapter.py
@@ -4,9 +4,10 @@ from unittest.mock import Mock, patch
 
 import numpy as np
 import pytest
-from braket.circuits import Circuit, FreeParameter, Gate, Instruction, observables
+from braket.circuits import Circuit, Gate, Instruction, observables
 from braket.circuits.angled_gate import AngledGate, TripleAngledGate
 from braket.devices import LocalSimulator
+from braket.parametric import FreeParameter, FreeParameterExpression
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister, transpile
 from qiskit.circuit import Parameter, ParameterVector
 from qiskit.circuit.library import GlobalPhaseGate, PauliEvolutionGate
@@ -497,12 +498,14 @@ class TestAdapter(TestCase):
         v = ParameterVector("v", 2)
         qiskit_circuit.rx(Parameter("a") + 2 * Parameter("b"), 0)
         qiskit_circuit.ry(v[0] - 2 * v[1], 0)
+        qiskit_circuit.rz(2 * Parameter("1.2"), 0)
         braket_circuit = to_braket(qiskit_circuit)
 
         expected_braket_circuit = (
             Circuit()
             .rx(0, FreeParameter("a") + 2 * FreeParameter("b"))
             .ry(0, FreeParameter("v_0") - 2 * FreeParameter("v_1"))
+            .rz(0, FreeParameterExpression("2.4"))
         )
         assert braket_circuit == expected_braket_circuit
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
The transpiler sometimes returns payloads that we don't translate well. This PR fixes a couple of issues I ran into.


### Details and comments
- Parametric gates with FreeParameter are transpiled with parametric global phase, which was throwing an error at translation.
- `Parameter`s can sometimes be composed of only single numerical values, which are not translated to a `FreeParameter`s.