### PR TITLE
feat: support Braket noise model

### DIFF
--- a/qiskit_braket_provider/providers/braket_provider.py
+++ b/qiskit_braket_provider/providers/braket_provider.py
@@ -1,6 +1,9 @@
 """AWS Braket provider."""
 
+from typing import Optional
+
 from braket.aws import AwsDevice
+from braket.circuits.noise_model import NoiseModel as BraketNoiseModel
 from braket.device_schema.dwave import DwaveDeviceCapabilities
 from braket.device_schema.quera import QueraDeviceCapabilities
 from braket.device_schema.xanadu import XanaduDeviceCapabilities
@@ -28,7 +31,9 @@ class AWSBraketProvider(ProviderV1):
          BraketBackend[dm1]]
     """
 
-    def backends(self, name=None, **kwargs):
+    def backends(
+        self, name=None, noise_model: Optional[BraketNoiseModel] = None, **kwargs
+    ):
         if kwargs.get("local"):
             return [BraketLocalBackend(name="default")]
         names = [name] if name else None
@@ -57,6 +62,7 @@ class AWSBraketProvider(ProviderV1):
                     description=f"AWS Device: {device.provider_name} {device.name}.",
                     online_date=device.properties.service.updatedAt,
                     backend_version="2",
+                    noise_model=noise_model,
                 )
             )
         return backends

--- a/tests/providers/mocks.py
+++ b/tests/providers/mocks.py
@@ -15,6 +15,7 @@ from braket.tasks.local_quantum_task import LocalQuantumTask
 RIGETTI_ARN = "arn:aws:braket:::device/qpu/rigetti/Aspen-10"
 RIGETTI_ASPEN_ARN = "arn:aws:braket:::device/qpu/rigetti/Aspen-M-3"
 SV1_ARN = "arn:aws:braket:::device/quantum-simulator/amazon/sv1"
+DM1_ARN = "arn:aws:braket:::device/quantum-simulator/amazon/dm1"
 TN1_ARN = "arn:aws:braket:::device/quantum-simulator/amazon/tn1"
 RIGETTI_REGION = "us-west-1"
 SIMULATOR_REGION = "us-west-1"
@@ -133,6 +134,15 @@ MOCK_GATE_MODEL_SIMULATOR_SV = {
     "providerName": "provider1",
     "deviceStatus": "ONLINE",
     "deviceArn": SV1_ARN,
+    "deviceCapabilities": MOCK_GATE_MODEL_SIMULATOR_CAPABILITIES.json(),
+}
+
+MOCK_GATE_MODEL_SIMULATOR_DM = {
+    "deviceName": "dm1",
+    "deviceType": "SIMULATOR",
+    "providerName": "provider1",
+    "deviceStatus": "ONLINE",
+    "deviceArn": DM1_ARN,
     "deviceCapabilities": MOCK_GATE_MODEL_SIMULATOR_CAPABILITIES.json(),
 }
 

--- a/tests/providers/test_braket_backend.py
+++ b/tests/providers/test_braket_backend.py
@@ -22,6 +22,7 @@ from qiskit_braket_provider import AWSBraketProvider, exception, version
 from qiskit_braket_provider.providers import AWSBraketBackend, BraketLocalBackend
 from qiskit_braket_provider.providers.adapter import aws_device_to_target
 from tests.providers.mocks import (
+    MOCK_GATE_MODEL_SIMULATOR_CAPABILITIES,
     RIGETTI_MOCK_GATE_MODEL_QPU_CAPABILITIES,
     RIGETTI_MOCK_M_3_QPU_CAPABILITIES,
 )
@@ -75,6 +76,16 @@ class TestAWSBraketBackend(TestCase):
         with self.assertRaises(NotImplementedError):
             backend.control_channel([0, 1])
 
+    def test_aws_backend_noise_model(self):
+        """Tests local backend."""
+        mock_noise_model = Mock()
+        mock_set_noise_model = Mock()
+        device = Mock()
+        device.properties = MOCK_GATE_MODEL_SIMULATOR_CAPABILITIES
+        device.set_noise_model = mock_set_noise_model
+        _ = AWSBraketBackend(device, noise_model=mock_noise_model)
+        self.assertEqual(mock_set_noise_model.call_args[0][0], mock_noise_model)
+
     def test_local_backend(self):
         """Tests local backend."""
         backend = BraketLocalBackend(name="default")
@@ -89,6 +100,13 @@ class TestAWSBraketBackend(TestCase):
             backend.measure_channel(0)
         with self.assertRaises(NotImplementedError):
             backend.control_channel([0, 1])
+
+    @patch("braket.devices.LocalSimulator.set_noise_model")
+    def test_local_backend_noise_model(self, mock_set_noise_model):
+        """Tests local backend."""
+        mock_noise_model = Mock()
+        _ = BraketLocalBackend(name="default", noise_model=mock_noise_model)
+        self.assertEqual(mock_set_noise_model.call_args[0][0], mock_noise_model)
 
     def test_local_backend_output(self):
         """Test local backend output"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Support Braket noise model for Braket backend. Solves half of https://github.com/qiskit-community/qiskit-braket-provider/issues/89. Still need to add support to Qiskit noise model which can be a separate PR.


### Details and comments
-  Support noise model in local dm simulator
```
local_dm_simulator = BraketLocalBackend(name='braket_dm', noise_model=noise_model)
```
- Support noise model in DM1 AWS backend
```
qpu_backend = provider.get_backend("dm1", noise_model=noise_model)
```
- This PR depends on https://github.com/amazon-braket/amazon-braket-sdk-python/pull/893. So checks will fail before this PR is merged.


