### PR TITLE
feature: add support for braket measure instruction

### DIFF
--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -6,7 +6,6 @@ from math import inf, pi
 from typing import Optional, Union
 
 import braket.circuits.gates as braket_gates
-import braket.circuits.measure as measure
 import qiskit.circuit.library as qiskit_gates
 from braket.aws import AwsDevice
 from braket.circuits import (
@@ -14,7 +13,7 @@ from braket.circuits import (
     FreeParameter,
     FreeParameterExpression,
     Instruction,
-    observables,
+    measure,
 )
 from braket.device_schema import DeviceActionType, OpenQASMDeviceActionProperties
 from braket.device_schema.ionq import IonqDeviceCapabilities

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -66,7 +66,6 @@ _BRAKET_TO_QISKIT_NAMES = {
     "gpi2": "gpi2",
     "ms": "ms",
     "gphase": _GPHASE_GATE_NAME,
-    "measure": "measure",
 }
 
 _CONTROLLED_GATES_BY_QUBIT_COUNT = {

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -529,7 +529,7 @@ def to_qiskit(circuit: Circuit) -> QuantumCircuit:
         raise TypeError(f"Expected a Circuit, got {type(circuit)} instead.")
 
     num_measurements = sum(
-        instr.operator.name.lower() == "measure" for instr in circuit.instructions
+        isinstance(instr.operator, measure.Measure) for instr in circuit.instructions
     )
     qiskit_circuit = QuantumCircuit(circuit.qubit_count, num_measurements)
     qubit_map = {

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -67,7 +67,7 @@ _BRAKET_TO_QISKIT_NAMES = {
     "gpi2": "gpi2",
     "ms": "ms",
     "gphase": _GPHASE_GATE_NAME,
-    "measure": "measure"
+    "measure": "measure",
 }
 
 _CONTROLLED_GATES_BY_QUBIT_COUNT = {
@@ -130,7 +130,7 @@ _GATE_NAME_TO_BRAKET_GATE: dict[str, Callable] = {
     "zz": lambda angle: [braket_gates.ZZ(2 * pi * angle)],
     # Global phase
     _GPHASE_GATE_NAME: lambda phase: [braket_gates.GPhase(phase)],
-    "measure": lambda: [measure.Measure()]
+    "measure": lambda: [measure.Measure()],
 }
 
 _QISKIT_CONTROLLED_GATE_NAMES_TO_BRAKET_GATES: dict[str, Callable] = {
@@ -185,7 +185,7 @@ _GATE_NAME_TO_QISKIT_GATE: dict[str, Optional[QiskitInstruction]] = {
         Parameter("theta") / (2 * pi),
     ),
     "gphase": qiskit_gates.GlobalPhaseGate(Parameter("theta")),
-    "measure": qiskit_gates.Measure()
+    "measure": qiskit_gates.Measure(),
 }
 
 
@@ -530,8 +530,10 @@ def to_qiskit(circuit: Circuit) -> QuantumCircuit:
     if not isinstance(circuit, Circuit):
         raise TypeError(f"Expected a Circuit, got {type(circuit)} instead.")
 
-    num_measurements = sum(instr.operator.name.lower() == "measure" for instr in circuit.instructions)
-    qiskit_circuit = QuantumCircuit(circuit.qubit_count, num_measurements) 
+    num_measurements = sum(
+        instr.operator.name.lower() == "measure" for instr in circuit.instructions
+    )
+    qiskit_circuit = QuantumCircuit(circuit.qubit_count, num_measurements)
     qubit_map = {
         int(qubit): index for index, qubit in enumerate(sorted(circuit.qubits))
     }

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -128,7 +128,6 @@ _GATE_NAME_TO_BRAKET_GATE: dict[str, Callable] = {
     "zz": lambda angle: [braket_gates.ZZ(2 * pi * angle)],
     # Global phase
     _GPHASE_GATE_NAME: lambda phase: [braket_gates.GPhase(phase)],
-    "measure": lambda: [measure.Measure()],
 }
 
 _QISKIT_CONTROLLED_GATE_NAMES_TO_BRAKET_GATES: dict[str, Callable] = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ qiskit>=0.34.2
 # TODO: update to new minimum version >0.5.0 once
 # MS gate implementation in qiskit-ionq has been corrected
 qiskit-ionq>=0.4.7, <=0.5.0
-amazon-braket-sdk>=1.65.0
+amazon-braket-sdk>=1.76.0
 
 setuptools>=40.1.0
 numpy>=1.3

--- a/tests/providers/test_adapter.py
+++ b/tests/providers/test_adapter.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 
 import numpy as np
 import pytest
-from braket.circuits import Circuit, FreeParameter, Gate, Instruction, observables
+from braket.circuits import Circuit, FreeParameter, Gate, Instruction
 from braket.circuits.angled_gate import AngledGate, TripleAngledGate
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit.circuit import Parameter, ParameterVector

--- a/tests/providers/test_adapter.py
+++ b/tests/providers/test_adapter.py
@@ -253,8 +253,12 @@ class TestAdapter(TestCase):
                 "gpi",
                 "gpi2",
                 "ms",
-                "measure",
             ]
+        }
+
+        braket_to_qiskit_gate_names = {
+            **qiskit_to_braket_gate_names,
+            **{"measure": "measure"},
         }
 
         self.assertEqual(
@@ -263,7 +267,7 @@ class TestAdapter(TestCase):
         )
 
         self.assertEqual(
-            set(qiskit_to_braket_gate_names.values()),
+            set(braket_to_qiskit_gate_names.values()),
             set(_GATE_NAME_TO_QISKIT_GATE.keys()),
         )
 

--- a/tests/providers/test_adapter.py
+++ b/tests/providers/test_adapter.py
@@ -253,7 +253,7 @@ class TestAdapter(TestCase):
                 "gpi",
                 "gpi2",
                 "ms",
-                "measure"
+                "measure",
             ]
         }
 
@@ -320,10 +320,7 @@ class TestAdapter(TestCase):
         braket_circuit = to_braket(qiskit_circuit)
 
         expected_braket_circuit = (
-            Circuit()  # pylint: disable=no-member
-            .h(0)
-            .cnot(0, 1)
-            .measure(0)
+            Circuit().h(0).cnot(0, 1).measure(0)  # pylint: disable=no-member
         )
 
         self.assertEqual(braket_circuit, expected_braket_circuit)
@@ -344,10 +341,7 @@ class TestAdapter(TestCase):
         braket_circuit = to_braket(qiskit_circuit)
 
         expected_braket_circuit = (
-            Circuit()  # pylint: disable=no-member
-            .h(0)
-            .cnot(0, 1)
-            .measure(0)
+            Circuit().h(0).cnot(0, 1).measure(0)  # pylint: disable=no-member
         )
 
         self.assertEqual(braket_circuit, expected_braket_circuit)
@@ -699,4 +693,3 @@ class TestFromBraket(TestCase):
         expected_qiskit_circuit.measure(0, 1)
 
         self.assertEqual(qiskit_circuit, expected_qiskit_circuit)
-


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Add support for Braket's `measure` instruction.

This solves the bug detailed in [Issue #130 ](https://github.com/qiskit-community/qiskit-braket-provider/issues/130) where translating a circuit in qiskit to braket returned all the measurements instead of the requested measured qubit.

### Details and comments

Now, users can measure a subset of qubits on local simulators or any device that supports partial measurement.

Example:
```
sim = BraketLocalBackend()
qc = QuantumCircuit(2, 1)
qc.h(0)
qc.cx(0, 1)
qc.measure(0, 0)
task = transpile(qc, sim)
task = sim.run(task)
result = task.result()
counts = result.get_counts()
print(counts)
```
{'1': 518, '0': 506}

To keep the current functionality of the bug and measure all the qubits, simply change `measure(0, 0)` to `measure_all()`
```
sim = BraketLocalBackend()
qc = QuantumCircuit(2, 1)
qc.h(0)
qc.cx(0, 1)
qc.measure_all()
task = transpile(qc, sim)
task = sim.run(task)
result = task.result()
counts = result.get_counts()
print(counts)
```
{'00': 503, '11': 521}


## List of changes
- Update the amazon-braket-sdk version
- add `measure` to the Braket gates
- update adapter.py to use Braket's `measure`
- add tests