### PR TITLE
Providerv1 deprication patch

### DIFF
--- a/qiskit_braket_provider/providers/braket_provider.py
+++ b/qiskit_braket_provider/providers/braket_provider.py
@@ -7,10 +7,11 @@ from braket.device_schema.dwave import DwaveDeviceCapabilities
 from braket.device_schema.quera import QueraDeviceCapabilities
 from braket.device_schema.xanadu import XanaduDeviceCapabilities
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
+
 from .braket_backend import BraketAwsBackend, BraketLocalBackend
 
 
-class BraketProvider():
+class BraketProvider:
     """BraketProvider class for accessing Amazon Braket backends.
 
     Example:
@@ -27,16 +28,37 @@ class BraketProvider():
          BraketBackend[TN1],
          BraketBackend[dm1]]
     """
-    def get_backend(self, name=None, **kwargs): 
+
+    def get_backend(self, name=None, **kwargs):
+        """Return a single backend matching the specififed filters.
+
+        Args:
+            name (str): name of the selected backend
+            **kwargs: dict with additional options for filitering and storing aws session
+        Returns:
+            BraketAwsBackend: a backend matching the filters.
+        Raises:
+            QiskitBackendNotFoundError: if no backend could be found or
+            more than one backend matches the filters.
+        """
         backends = self.backends(name=name, **kwargs)
         if len(backends) > 1:
-            raise QiskitBackendNotFoundError("More than one backend matches the criteria")
+            raise QiskitBackendNotFoundError(
+                "More than one backend matches the criteria"
+            )
         if not backends:
             raise QiskitBackendNotFoundError("No backend matches the criteria")
         return backends[0]
 
-
     def backends(self, name=None, **kwargs):
+        """Return a list of backends matching the specififed filters.
+
+        Args:
+            name (str): name of the selected backend
+            **kwargs: dict with additional options for filitering and storing aws session
+        Returns:
+            BraketAwsBackend: a list of backends matching the filters.
+        """
         if kwargs.get("local"):
             return [
                 BraketLocalBackend(name="braket_sv"),

--- a/qiskit_braket_provider/providers/braket_provider.py
+++ b/qiskit_braket_provider/providers/braket_provider.py
@@ -6,12 +6,11 @@ from braket.aws import AwsDevice
 from braket.device_schema.dwave import DwaveDeviceCapabilities
 from braket.device_schema.quera import QueraDeviceCapabilities
 from braket.device_schema.xanadu import XanaduDeviceCapabilities
-from qiskit.providers import ProviderV1
-
+from qiskit.providers.exceptions import QiskitBackendNotFoundError
 from .braket_backend import BraketAwsBackend, BraketLocalBackend
 
 
-class BraketProvider(ProviderV1):
+class BraketProvider():
     """BraketProvider class for accessing Amazon Braket backends.
 
     Example:
@@ -28,6 +27,14 @@ class BraketProvider(ProviderV1):
          BraketBackend[TN1],
          BraketBackend[dm1]]
     """
+    def get_backend(self, name=None, **kwargs): 
+        backends = self.backends(name=name, **kwargs)
+        if len(backends) > 1:
+            raise QiskitBackendNotFoundError("More than one backend matches the criteria")
+        if not backends:
+            raise QiskitBackendNotFoundError("No backend matches the criteria")
+        return backends[0]
+
 
     def backends(self, name=None, **kwargs):
         if kwargs.get("local"):

--- a/tests/providers/test_braket_provider.py
+++ b/tests/providers/test_braket_provider.py
@@ -11,6 +11,7 @@ from qiskit import QuantumCircuit
 from qiskit import circuit as qiskit_circuit
 from qiskit.compiler import transpile
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
+
 from qiskit_braket_provider.providers import BraketProvider
 from qiskit_braket_provider.providers.braket_backend import (
     BraketAwsBackend,

--- a/tests/providers/test_braket_provider.py
+++ b/tests/providers/test_braket_provider.py
@@ -10,7 +10,7 @@ from braket.circuits import Circuit
 from qiskit import QuantumCircuit
 from qiskit import circuit as qiskit_circuit
 from qiskit.compiler import transpile
-
+from qiskit.providers.exceptions import QiskitBackendNotFoundError
 from qiskit_braket_provider.providers import BraketProvider
 from qiskit_braket_provider.providers.braket_backend import (
     BraketAwsBackend,
@@ -37,6 +37,30 @@ class TestBraketProvider(TestCase):
         self.mock_session.region = SIMULATOR_REGION
         self.mock_session.boto_session.region_name = SIMULATOR_REGION
         self.mock_session.search_devices.return_value = simulators
+
+        self.empty_mock_session = Mock()
+        self.empty_mock_session.get_device.side_effect = []
+        self.empty_mock_session.region = SIMULATOR_REGION
+        self.empty_mock_session.boto_session.region_name = SIMULATOR_REGION
+        self.empty_mock_session.search_devices.return_value = []
+
+    def test_provider_backend(self):
+        """Test QiskitBackendNotFoundError is raised"""
+        provider = BraketProvider()
+
+        # Matches QiskitBackendNotFoundError where multiple backends are found
+        with self.assertRaises(QiskitBackendNotFoundError) as err1:
+            provider.get_backend(
+                aws_session=self.mock_session, types=[AwsDeviceType.SIMULATOR]
+            )
+        self.assertIsInstance(err1.exception, QiskitBackendNotFoundError)
+
+        # Matches QiskitBackendNotFoundError where no backends are found
+        with self.assertRaises(QiskitBackendNotFoundError) as err2:
+            provider.get_backend(
+                aws_session=self.empty_mock_session, types=[AwsDeviceType.SIMULATOR]
+            )
+        self.assertIsInstance(err2.exception, QiskitBackendNotFoundError)
 
     def test_provider_backends(self):
         """Tests provider."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Qiskit's `ProviderV1` and `Provider` abstract classes are deprecated and will be removed after the release of v2.0. This change requires the removal of the abstract class from the `BraketProvider` and the re-implementation of `get_backend(self, name=None, **kwargs)`.

### Details and comments
The change described in the summary has been implemented, and additionally, comments for the `self.backends()` and `self.get_backend()` methods have been added.
