### PR TITLE
Add native switch to run method

### DIFF
--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -199,13 +199,14 @@ _GATE_NAME_TO_QISKIT_GATE: dict[str, Optional[QiskitInstruction]] = {
 def native_gate_connectivity(
     properties: DeviceCapabilities,
 ) -> Optional[list[list[int]]]:
-    """Returns the gate set and connectivity natively supported by a Braket device from its properties
+    """Returns the connectivity natively supported by a Braket device from its properties
 
     Args:
         properties (DeviceCapabilities): The device properties of the Braket device.
 
     Returns:
-        Optional[list[list[int]]]: A list of connected qubit pairs or None if the device is fully connected
+        Optional[list[list[int]]]: A list of connected qubit pairs or `None` if the device is fully
+            connected.
     """
     device_connectivity = properties.paradigm.connectivity
     connectivity = (
@@ -221,7 +222,7 @@ def native_gate_connectivity(
 
 
 def native_gate_set(properties: DeviceCapabilities) -> set[str]:
-    """Returns the gate set and connectivity natively supported by a Braket device from its properties
+    """Returns the gate set natively supported by a Braket device from its properties
 
     Args:
         properties (DeviceCapabilities): The device properties of the Braket device.

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -17,8 +17,8 @@ from braket.circuits import (
 )
 from braket.device_schema import (
     DeviceActionType,
-    OpenQASMDeviceActionProperties,
     DeviceCapabilities,
+    OpenQASMDeviceActionProperties,
 )
 from braket.device_schema.ionq import IonqDeviceCapabilities
 from braket.device_schema.iqm import IqmDeviceCapabilities

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -196,7 +196,17 @@ _GATE_NAME_TO_QISKIT_GATE: dict[str, Optional[QiskitInstruction]] = {
 }
 
 
-def native_gate_support(properties: DeviceCapabilities) -> dict:
+def native_gate_connectivity(
+    properties: DeviceCapabilities,
+) -> Optional[list[list[int]]]:
+    """Returns the gate set and connectivity natively supported by a Braket device from its properties
+
+    Args:
+        properties (DeviceCapabilities): The device properties of the Braket device.
+
+    Returns:
+        Optional[list[list[int]]]: A list of connected qubit pairs or None if the device is fully connected
+    """
     device_connectivity = properties.paradigm.connectivity
     connectivity = (
         [
@@ -207,15 +217,25 @@ def native_gate_support(properties: DeviceCapabilities) -> dict:
         if not device_connectivity.fullyConnected
         else None
     )
+    return connectivity
 
+
+def native_gate_set(properties: DeviceCapabilities) -> set[str]:
+    """Returns the gate set and connectivity natively supported by a Braket device from its properties
+
+    Args:
+        properties (DeviceCapabilities): The device properties of the Braket device.
+
+
+    Returns:
+        set[str]: The names of qiskit gates natively supported by the Braket device.
+    """
     native_list = properties.paradigm.nativeGateSet
-    gateset = {
+    return {
         _BRAKET_TO_QISKIT_NAMES[op.lower()]
         for op in native_list
         if op.lower() in _BRAKET_TO_QISKIT_NAMES
     }
-
-    return {"native_gates": gateset, "connectivity": connectivity}
 
 
 def gateset_from_properties(properties: OpenQASMDeviceActionProperties) -> set[str]:

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -227,7 +227,6 @@ def native_gate_set(properties: DeviceCapabilities) -> set[str]:
     Args:
         properties (DeviceCapabilities): The device properties of the Braket device.
 
-
     Returns:
         set[str]: The names of qiskit gates natively supported by the Braket device.
     """

--- a/qiskit_braket_provider/providers/braket_backend.py
+++ b/qiskit_braket_provider/providers/braket_backend.py
@@ -23,7 +23,8 @@ from .adapter import (
     aws_device_to_target,
     gateset_from_properties,
     local_simulator_to_target,
-    native_gate_support,
+    native_gate_connectivity,
+    native_gate_set,
     to_braket,
 )
 from .braket_quantum_task import BraketQuantumTask
@@ -334,9 +335,8 @@ class BraketAwsBackend(BraketBackend):
         if verbatim:
             gateset = None
         elif native:
-            gateset, connectivity = native_gate_support(
-                self._device.properties
-            ).values()
+            gateset = native_gate_set(self._device.properties)
+            connectivity = native_gate_connectivity(self._device.properties)
 
         braket_circuits = [
             to_braket(

--- a/tests/providers/test_braket_backend.py
+++ b/tests/providers/test_braket_backend.py
@@ -426,6 +426,7 @@ class TestBraketAwsBackend(TestCase):
 
     @patch("qiskit_braket_provider.providers.braket_backend.to_braket")
     def test_native_transpilation(self, mock_to_braket):
+        """Tests running circuit with native mode"""
         mock_device = Mock()
         mock_device.properties = RIGETTI_MOCK_GATE_MODEL_QPU_CAPABILITIES
         mock_device.properties.paradigm.connectivity.connectivityGraph = {
@@ -456,9 +457,9 @@ class TestBraketAwsBackend(TestCase):
         ]
 
         backend.run(circuit, verbatim=True)
-        assert mock_to_braket.call_args.kwargs["basis_gates"] == None
-        assert mock_to_braket.call_args.kwargs["verbatim"] == True
-        assert mock_to_braket.call_args.kwargs["connectivity"] == None
+        assert mock_to_braket.call_args.kwargs["basis_gates"] is None
+        assert mock_to_braket.call_args.kwargs["verbatim"] is True
+        assert mock_to_braket.call_args.kwargs["connectivity"] is None
 
     @patch("qiskit_braket_provider.providers.braket_provider.AwsDevice")
     def test_queue_depth(self, mocked_device):

--- a/tests/providers/test_braket_backend.py
+++ b/tests/providers/test_braket_backend.py
@@ -424,6 +424,42 @@ class TestBraketAwsBackend(TestCase):
 
         self.assertEqual(sum(result.get_counts().values()), 10)
 
+    @patch("qiskit_braket_provider.providers.braket_backend.to_braket")
+    def test_native_transpilation(self, mock_to_braket):
+        mock_device = Mock()
+        mock_device.properties = RIGETTI_MOCK_GATE_MODEL_QPU_CAPABILITIES
+        mock_device.properties.paradigm.connectivity.connectivityGraph = {
+            "0": ["1"],
+            "1": ["0", "2"],
+            "2": ["1"],
+        }
+        mock_device.properties.paradigm.nativeGateSet = ["rx", "rz", "cnot"]
+
+        mock_batch = Mock()
+        mock_batch.tasks = [Mock(id="abcd1234")]
+        mock_device.run_batch.return_value = mock_batch
+
+        circuit = QuantumCircuit(3)
+        circuit.h(0)
+        circuit.cx(0, 1)
+        circuit.cx(0, 2)
+
+        backend = AWSBraketBackend(device=mock_device)
+
+        backend.run(circuit, native=True)
+        assert mock_to_braket.call_args.kwargs["basis_gates"] == {"rx", "rz", "cx"}
+        assert mock_to_braket.call_args.kwargs["connectivity"] == [
+            [0, 1],
+            [1, 0],
+            [1, 2],
+            [2, 1],
+        ]
+
+        backend.run(circuit, verbatim=True)
+        assert mock_to_braket.call_args.kwargs["basis_gates"] == None
+        assert mock_to_braket.call_args.kwargs["verbatim"] == True
+        assert mock_to_braket.call_args.kwargs["connectivity"] == None
+
     @patch("qiskit_braket_provider.providers.braket_provider.AwsDevice")
     def test_queue_depth(self, mocked_device):
         """Tests queue depth."""


### PR DESCRIPTION
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.


### Summary
This change will add a `native=[bool]` switch to the `run()` method. This switch will ensure that the `to_braket` transpilation step uses:
* the device's native gate set
* the device's native topology

### Details and comments

