### PR TITLE
fix: Preserve classical bit ordering for measurement results

### DIFF
--- a/.github/workflows/citation.yml
+++ b/.github/workflows/citation.yml
@@ -61,7 +61,7 @@ jobs:
           fi
       - name: Upload PDF
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: preview.pdf
           path: preview.pdf

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,7 +41,7 @@ jobs:
           sudo apt-get install -y pandoc
       - name: Build docs
         run: tox -e docs
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: html_docs
           path: docs/_build/html

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -23,7 +23,7 @@ jobs:
           python setup.py sdist
           python setup.py bdist_wheel
         shell: bash
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: ./dist/qiskit*
       - name: Publish to PyPi

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -493,7 +493,7 @@ def to_braket(
     _validate_name_conflicts(circuit.parameters)
 
     # Handle qiskit to braket conversion
-    measured_qubits = set()
+    measured_qubits = {}
     for circuit_instruction in circuit.data:
         operation = circuit_instruction.operation
         gate_name = operation.name
@@ -503,11 +503,12 @@ def to_braket(
         if gate_name == "measure":
             qubit = qubits[0]  # qubit count = 1 for measure
             qubit_index = circuit.find_bit(qubit).index
-            if qubit_index in measured_qubits:
+            if qubit_index in measured_qubits.values():
                 raise ValueError(
                     f"Cannot measure previously measured qubit {qubit_index}"
                 )
-            measured_qubits.add(qubit_index)
+            clbit = circuit.find_bit(circuit_instruction.clbits[0]).index
+            measured_qubits[clbit] = qubit_index
         elif gate_name == "barrier":
             warnings.warn(
                 "The Qiskit circuit contains barrier instructions that are ignored."
@@ -525,7 +526,9 @@ def to_braket(
 
             # Getting the index from the bit mapping
             qubit_indices = [circuit.find_bit(qubit).index for qubit in qubits]
-            if intersection := measured_qubits.intersection(qubit_indices):
+            if intersection := set(measured_qubits.values()).intersection(
+                qubit_indices
+            ):
                 raise ValueError(
                     f"Cannot apply operation {gate_name} to measured qubits {intersection}"
                 )
@@ -562,8 +565,8 @@ def to_braket(
             Circuit(braket_circuit.instructions)
         )
 
-    for qubit in sorted(measured_qubits):
-        braket_circuit.measure(qubit)
+    for clbit in sorted(measured_qubits):
+        braket_circuit.measure(measured_qubits[clbit])
 
     return braket_circuit
 

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -493,7 +493,7 @@ def to_braket(
     _validate_name_conflicts(circuit.parameters)
 
     # Handle qiskit to braket conversion
-    measured_qubits = {}
+    measured_qubits: dict[int, int] = {}
     for circuit_instruction in circuit.data:
         operation = circuit_instruction.operation
         gate_name = operation.name

--- a/qiskit_braket_provider/providers/braket_backend.py
+++ b/qiskit_braket_provider/providers/braket_backend.py
@@ -176,7 +176,7 @@ class BraketLocalBackend(BraketBackend):
 class BraketAwsBackend(BraketBackend):
     """BraketAwsBackend."""
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(  # pylint: disable=too-many-positional-arguments
         self,
         arn: Optional[str] = None,
         provider: Provider = None,
@@ -364,7 +364,7 @@ class AWSBraketBackend(BraketAwsBackend):
         )
         super().__init_subclass__(**kwargs)
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(  # pylint: disable=too-many-positional-arguments
         self,
         device: AwsDevice,
         provider: Provider = None,

--- a/qiskit_braket_provider/providers/braket_backend.py
+++ b/qiskit_braket_provider/providers/braket_backend.py
@@ -169,7 +169,7 @@ class BraketLocalBackend(BraketBackend):
             task_id=task_id,
             tasks=tasks,
             backend=self,
-            shots=shots,
+            shots=shots,  # type: ignore[arg-type]
         )
 
 

--- a/tests/providers/test_adapter.py
+++ b/tests/providers/test_adapter.py
@@ -323,6 +323,30 @@ class TestAdapter(TestCase):
 
         self.assertEqual(braket_circuit, expected_braket_circuit)
 
+    def test_measure_order_preserved(self):
+        """Tests the translation of measure instructions on multiple qubits"""
+
+        qiskit_circuit = QuantumCircuit(3, 3)
+        qiskit_circuit.h(0)
+        qiskit_circuit.cx(0, 1)
+        qiskit_circuit.cx(1, 2)
+        qiskit_circuit.measure(0, 1)  # measure qubit 0 into classical bit 1
+        qiskit_circuit.measure(1, 2)  # measure qubit 1 into classical bit 2
+        qiskit_circuit.measure(2, 0)  # measure qubit 2 into classical bit 0
+        braket_circuit = to_braket(qiskit_circuit)
+
+        expected_braket_circuit = (
+            Circuit()
+            .h(0)
+            .cnot(0, 1)
+            .cnot(1, 2)
+            .measure(2)
+            .measure(0)
+            .measure(1)  # pylint: disable=no-member
+        )
+
+        self.assertEqual(braket_circuit, expected_braket_circuit)
+
     def test_measure_repeated(self):
         """Tests that repeated measurement on a qubit raises a ValueError."""
         qiskit_circuit = QuantumCircuit(2, 2)
@@ -451,8 +475,8 @@ class TestAdapter(TestCase):
             .h(0)
             .cnot(0, 2)
             .x(1)
-            .measure(0)
             .measure(2)
+            .measure(0)
         )
         self.assertEqual(braket_circuit, expected_braket_circuit)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Fixes an issue where the classical bit ordering in a Qiskit circuit was not preserved when converting to a Braket circuit.

### Details and comments

Unit tests added and updated to verify new behavior.