### PR TITLE
fix: added iswap to maps it was missing from

### DIFF
--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -58,6 +58,7 @@ _BRAKET_TO_QISKIT_NAMES = {
     "v": "sx",
     "vi": "sxdg",
     "swap": "swap",
+    "iswap": "iswap",
     "rx": "rx",
     "ry": "ry",
     "rz": "rz",


### PR DESCRIPTION
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.


### Summary
Adding Iswap to `_BRAKET_TO_QISKIT_NAMES` so that I can use `native_gate_set` for Ankaa-3 since `native_gate_set` maps from nativeGateSet in the device capabilities to the qiskit format via `_BRAKET_TO_QISKIT_NAMES`, and `iswap` is in Ankaa-3's `nativeGateSet` (and is actually the only 2q gate). Without this code change, `native_gate_set` was filtering `iswap` out of Ankaa-3's gateset

### Details and comments

