### PR TITLE
Extend `to_braket` to respect gate angle restrictions of native gates

### DIFF
--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -242,6 +242,31 @@ def native_gate_set(properties: DeviceCapabilities) -> set[str]:
     }
 
 
+def native_angle_restrictions(
+    properties: DeviceCapabilities,
+) -> dict[str, dict[int, Union[set[float], tuple[float, float]]]]:
+    """Returns angle restrictions for gates natively supported by a Braket device.
+
+    The returned mapping specifies, for each gate name, constraints on the
+    gate parameters indexed by their position. The constraint can either be a
+    set of allowed angles or a tuple representing an inclusive ``(min, max)``
+    range. Angle units are in radians.
+
+    Args:
+        properties (DeviceCapabilities): The device properties of the Braket device.
+
+    Returns:
+        dict[str, dict[int, Union[set[float], tuple[float, float]]]]: Mapping
+            of gate names to parameter index restrictions.
+    """
+
+    if isinstance(properties, (RigettiDeviceCapabilities, RigettiDeviceCapabilitiesV2)):
+        return {"rx": {0: {pi, -pi, pi / 2, -pi / 2}}}
+    if isinstance(properties, IonqDeviceCapabilities):
+        return {"ms": {2: (0.0, 1.0)}}
+    return {}
+
+
 def gateset_from_properties(properties: OpenQASMDeviceActionProperties) -> set[str]:
     """Returns the gateset supported by a Braket device with the given properties
 
@@ -464,6 +489,9 @@ def to_braket(
     basis_gates: Optional[Iterable[str]] = None,
     verbatim: bool = False,
     connectivity: Optional[list[list[int]]] = None,
+    angle_restrictions: Optional[
+        dict[str, dict[int, Union[set[float], tuple[float, float]]]]
+    ] = None,
 ) -> Circuit:
     """Return a Braket quantum circuit from a Qiskit quantum circuit.
 
@@ -476,6 +504,8 @@ def to_braket(
             words without transpiling it. Default: False.
         connectivity (Optional[list[list[int]]): If provided, will transpile to a circuit
             with this connectivity. Default: `None`.
+        angle_restrictions (Optional[dict]): Mapping of gate names to parameter
+            angle constraints used to validate numeric parameters. Default: ``None``.
 
     Returns:
         Circuit: Braket circuit
@@ -541,6 +571,7 @@ def to_braket(
                     f"Cannot apply operation {gate_name} to measured qubits {intersection}"
                 )
             params = _create_free_parameters(operation)
+            _validate_angle_restrictions(gate_name, params, angle_restrictions)
             if gate_name in _QISKIT_CONTROLLED_GATE_NAMES_TO_BRAKET_GATES:
                 for gate in _QISKIT_CONTROLLED_GATE_NAMES_TO_BRAKET_GATES[gate_name](
                     *params
@@ -592,6 +623,44 @@ def _create_free_parameters(operation):
             params[i] = FreeParameterExpression(renamed_param_name)
 
     return params
+
+
+def _validate_angle_restrictions(
+    gate_name: str,
+    params: Iterable,
+    angle_restrictions: Optional[
+        dict[str, dict[int, Union[set[float], tuple[float, float]]]]
+    ],
+) -> None:
+    if not angle_restrictions or gate_name not in angle_restrictions:
+        return
+    restrictions = angle_restrictions[gate_name]
+    for index, restriction in restrictions.items():
+        if index >= len(params):
+            continue
+        param = params[index]
+        if isinstance(
+            param,
+            (
+                FreeParameter,
+                FreeParameterExpression,
+                ParameterExpression,
+            ),
+        ):
+            continue
+        angle = float(param)
+        if isinstance(restriction, set):
+            if not any(abs(angle - allowed) <= _EPS for allowed in restriction):
+                raise ValueError(
+                    f"Angle {angle} for {gate_name} parameter {index} is not supported"
+                )
+        else:
+            min_angle, max_angle = restriction
+            if angle < min_angle - _EPS or angle > max_angle + _EPS:
+                raise ValueError(
+                    f"Angle {angle} for {gate_name} parameter {index} "
+                    f"not in range [{min_angle}, {max_angle}]"
+                )
 
 
 def _rename_param_vector_element(parameter):

--- a/qiskit_braket_provider/providers/braket_backend.py
+++ b/qiskit_braket_provider/providers/braket_backend.py
@@ -25,6 +25,7 @@ from .adapter import (
     local_simulator_to_target,
     native_gate_connectivity,
     native_gate_set,
+    native_angle_restrictions,
     to_braket,
 )
 from .braket_quantum_task import BraketQuantumTask
@@ -340,10 +341,17 @@ class BraketAwsBackend(BraketBackend):
         connectivity = (
             native_gate_connectivity(self._device.properties) if native else None
         )
+        angle_restrictions = (
+            native_angle_restrictions(self._device.properties) if native else None
+        )
 
         braket_circuits = [
             to_braket(
-                circ, basis_gates=gateset, verbatim=verbatim, connectivity=connectivity
+                circ,
+                basis_gates=gateset,
+                verbatim=verbatim,
+                connectivity=connectivity,
+                angle_restrictions=angle_restrictions,
             )
             for circ in circuits
         ]

--- a/tests/providers/test_adapter.py
+++ b/tests/providers/test_adapter.py
@@ -600,6 +600,24 @@ class TestAdapter(TestCase):
             )
         )
 
+    def test_angle_restrictions_rigetti(self):
+        """Tests that angle restrictions for native gates are enforced."""
+        circuit = QuantumCircuit(1)
+        circuit.rx(np.pi / 4, 0)
+
+        restrictions = {"rx": {0: {np.pi, -np.pi, np.pi / 2, -np.pi / 2}}}
+        with pytest.raises(ValueError):
+            to_braket(circuit, basis_gates={"rx"}, angle_restrictions=restrictions)
+
+    def test_angle_restrictions_ionq(self):
+        """Tests IonQ MS gate angle range enforcement."""
+        circuit = QuantumCircuit(2)
+        circuit.append(ionq_gates.MSGate(0, 0, 3), [0, 1])
+
+        restrictions = {"ms": {2: (0.0, 1.0)}}
+        with pytest.raises(ValueError):
+            to_braket(circuit, basis_gates={"ms"}, angle_restrictions=restrictions)
+
 
 class TestFromBraket(TestCase):
     """Test Braket circuit conversion."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Extend `to_braket` to have angle restrictions for RIgetti, IonQ. Optional parameter


### Details and comments
closes #200 
