### PR TITLE
add deepcopy method to BraketAwsBackend

### DIFF
--- a/qiskit_braket_provider/providers/braket_backend.py
+++ b/qiskit_braket_provider/providers/braket_backend.py
@@ -1,5 +1,6 @@
 """Amazon Braket backends."""
 
+import copy
 import datetime
 import enum
 import logging
@@ -401,6 +402,18 @@ class BraketAwsBackend(BraketBackend[AwsDevice]):
         tasks: list[AwsQuantumTask] = batch_task.tasks
         task_id = _TASK_ID_DIVIDER.join(task.id for task in tasks)
         return BraketQuantumTask(task_id=task_id, tasks=tasks, backend=self, shots=shots)
+
+    def __deepcopy__(self, memo):
+        """Create deepcopy of the BraketBackend.
+
+        Note: the underlying self._device, and thus self._device.aws_session is shared between copies.
+        """
+        result = copy.copy(self)
+        memo[id(self)] = result
+        for key, value in self.__dict__.items():
+            if key != "_device":
+                setattr(result, key, copy.deepcopy(value, memo))  # Pass memo along
+        return result
 
 
 class AWSBraketBackend(BraketAwsBackend):

--- a/tests/providers/test_braket_backend.py
+++ b/tests/providers/test_braket_backend.py
@@ -1,5 +1,6 @@
 """Tests for AWS Braket backends."""
 
+import copy
 import unittest
 from unittest import TestCase
 from unittest.mock import Mock, patch
@@ -585,3 +586,17 @@ class TestBraketAwsBackend(TestCase):
             self.assertEqual(instruction[0].name, expected_instruction_props[index][0].name)
 
             self.assertEqual(instruction[1], expected_instruction_props[index][1])
+
+    def test_backend_deepcopy(self):
+        """Tests deepcopy of device."""
+        device = Mock()
+        device.properties = RIGETTI_MOCK_GATE_MODEL_QPU_CAPABILITIES
+        device.type = "QPU"
+        device._arn = "MOCK"
+        device.topology_graph = topology_graph(
+            RIGETTI_MOCK_GATE_MODEL_QPU_CAPABILITIES.paradigm.connectivity.connectivityGraph
+        )
+        backend = BraketAwsBackend(device=device)
+        deep = copy.deepcopy(backend)
+        self.assertEqual(deep._device, backend._device)
+        self.assertNotEqual(deep, backend)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

Close #234 by adding a deepcopy method to BraketAwsBackend. 

### Details and comments

Issue relates to how the [IBM Runtime Sampler](https://github.com/Qiskit/qiskit-ibm-runtime/blob/main/qiskit_ibm_runtime/base_primitive.py#L49) treats the BraketAwsBackend as a fake backend and tries to [deepcopy it](https://github.com/Qiskit/qiskit-ibm-runtime/blob/be8af4295ec2d261b4322fb30b06d68769eccc91/qiskit_ibm_runtime/fake_provider/local_service.py#L171C1-L171C49). 

When called by a runtime Sampler, BraketAwsBackend will not try to pickle the SSLContext from the device, but provides a shallow reference to backend._device. 
