### PR TITLE
fix: added check for multiples of m*pi/2

### DIFF
--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -774,9 +774,9 @@ def _create_free_parameters(operation):
                 renamed_param_name = _rename_param_vector_element(param)
                 params[i] = FreeParameterExpression(renamed_param_name)
             case param if isinstance(param, float):
-                mult = 12 * param / pi
+                mult = 2 * param / pi
                 if abs(mult - round(mult)) < _EPS:
-                    params[i] = round(mult) / 12 * pi
+                    params[i] = pi * round(mult) / 2
     return params
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Close #233. Added a simple check for float parameter inputs to check if param is close to a rational $\frac{m}{2}\pi$, and replace it with a standard float.

### Details and comments

Found at least two cases where there is a precision output from the qiskit transpiler that should be validated okay on the service but leads to an error (on Rigetti, pi/2 multiple). Current check in to_braket should be very fast, and successfully catches test cases. 

Note, does not fix general issue of angle validation in the transpiler, which may be better addressed in another issue. 