### PR TITLE
fix: lowered opt level to avoid relabelling

### DIFF
--- a/tests/providers/test_braket_backend.py
+++ b/tests/providers/test_braket_backend.py
@@ -396,7 +396,7 @@ class TestBraketAwsBackend(TestCase):
         circuit = QuantumCircuit(1)
         circuit.h(0)
 
-        backend.run(circuit, shots=0, pass_manager=generate_preset_pass_manager(2, backend))
+        backend.run(circuit, shots=0, pass_manager=generate_preset_pass_manager(1, backend))
         native_circuit = Circuit().add_verbatim_box(
             Circuit().rz(1, np.pi / 2).rx(1, np.pi / 2).rz(1, np.pi / 2)
         )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ X] I have added the tests to cover my changes.
- [X ] I have updated the documentation accordingly.
- [X ] I have read the CONTRIBUTING document.
-->

### Summary

Failing [test_braket_backend::test_run_with_pass_manager](https://github.com/qiskit-community/qiskit-braket-provider/actions/runs/21157949424/job/60846513491). 

### Details and comments

As all 1Q error rates are equal, relabeling should not occur - might occur with some rng with opt level 2 
