### PR TITLE
fix: lint errors

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ Sphinx documentation builder
 
 # General options:
 import os
-from typing import Any, Optional
+from typing import Any
 
 project = "Qiskit-Braket provider"
 copyright = "2022"  # pylint: disable=redefined-builtin
@@ -31,9 +31,9 @@ version_path = os.path.join(
     "qiskit_braket_provider",
     "version.py",
 )
-version_dict: Optional[dict[str, Any]] = {}
+version_dict: dict[str, Any] | None = {}
 with open(version_path) as fp:
-    exec(fp.read(), version_dict)
+    exec(fp.read(), version_dict)  # noqa: S102
 version = version_dict["__version__"]
 release = version_dict["__version__"]
 

--- a/docs/tutorials/3_tutorial_minimum_eigen_optimizer.ipynb
+++ b/docs/tutorials/3_tutorial_minimum_eigen_optimizer.ipynb
@@ -18,19 +18,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-12-05T21:44:28.659795Z",
      "start_time": "2025-12-05T21:44:25.441847Z"
     }
    },
+   "outputs": [],
    "source": [
     "from qiskit_braket_provider import BraketLocalBackend, BraketSampler\n",
     "\n",
     "sampler = BraketSampler(BraketLocalBackend())"
-   ],
-   "outputs": [],
-   "execution_count": 1
+   ]
   },
   {
    "attachments": {},
@@ -84,14 +84,24 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 2,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-12-05T21:44:30.795925Z",
      "start_time": "2025-12-05T21:44:28.666452Z"
     }
    },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/caw/anaconda3/lib/python3.10/site-packages/pandas/core/arrays/masked.py:61: UserWarning: Pandas requires version '1.3.6' or newer of 'bottleneck' (version '1.3.5' currently installed).\n",
+      "  from pandas.core import (\n"
+     ]
+    }
+   ],
    "source": [
-    "from typing import List, Tuple\n",
     "\n",
     "import numpy as np\n",
     "from qiskit.visualization import plot_histogram\n",
@@ -105,36 +115,17 @@
     "from qiskit_optimization.minimum_eigensolvers import QAOA, NumPyMinimumEigensolver\n",
     "from qiskit_optimization.optimizers import COBYLA\n",
     "from qiskit_optimization.utils import algorithm_globals"
-   ],
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/caw/anaconda3/lib/python3.10/site-packages/pandas/core/arrays/masked.py:61: UserWarning: Pandas requires version '1.3.6' or newer of 'bottleneck' (version '1.3.5' currently installed).\n",
-      "  from pandas.core import (\n"
-     ]
-    }
-   ],
-   "execution_count": 2
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 3,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-12-05T21:44:31.795010Z",
      "start_time": "2025-12-05T21:44:31.790254Z"
     }
    },
-   "source": [
-    "# create a QUBO\n",
-    "qubo = QuadraticProgram()\n",
-    "qubo.binary_var(\"x\")\n",
-    "qubo.binary_var(\"y\")\n",
-    "qubo.binary_var(\"z\")\n",
-    "qubo.minimize(linear=[1, -2, 3], quadratic={(\"x\", \"y\"): 1, (\"x\", \"z\"): -1, (\"y\", \"z\"): 2})\n",
-    "print(qubo.prettyprint())"
-   ],
    "outputs": [
     {
      "name": "stdout",
@@ -154,7 +145,15 @@
      ]
     }
    ],
-   "execution_count": 3
+   "source": [
+    "# create a QUBO\n",
+    "qubo = QuadraticProgram()\n",
+    "qubo.binary_var(\"x\")\n",
+    "qubo.binary_var(\"y\")\n",
+    "qubo.binary_var(\"z\")\n",
+    "qubo.minimize(linear=[1, -2, 3], quadratic={(\"x\", \"y\"): 1, (\"x\", \"z\"): -1, (\"y\", \"z\"): 2})\n",
+    "print(qubo.prettyprint())"
+   ]
   },
   {
    "attachments": {},
@@ -166,18 +165,13 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 4,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-12-05T21:44:31.825178Z",
      "start_time": "2025-12-05T21:44:31.820508Z"
     }
    },
-   "source": [
-    "op, offset = qubo.to_ising()\n",
-    "print(\"offset: {}\".format(offset))\n",
-    "print(\"operator:\")\n",
-    "print(op)"
-   ],
    "outputs": [
     {
      "name": "stdout",
@@ -190,7 +184,12 @@
      ]
     }
    ],
-   "execution_count": 4
+   "source": [
+    "op, offset = qubo.to_ising()\n",
+    "print(f\"offset: {offset}\")\n",
+    "print(\"operator:\")\n",
+    "print(op)"
+   ]
   },
   {
    "attachments": {},
@@ -202,17 +201,13 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 5,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-12-05T21:44:31.842305Z",
      "start_time": "2025-12-05T21:44:31.838540Z"
     }
    },
-   "source": [
-    "qp = QuadraticProgram()\n",
-    "qp.from_ising(op, offset, linear=True)\n",
-    "print(qp.prettyprint())"
-   ],
    "outputs": [
     {
      "name": "stdout",
@@ -232,7 +227,11 @@
      ]
     }
    ],
-   "execution_count": 5
+   "source": [
+    "qp = QuadraticProgram()\n",
+    "qp.from_ising(op, offset, linear=True)\n",
+    "print(qp.prettyprint())"
+   ]
   },
   {
    "attachments": {},
@@ -259,17 +258,13 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 6,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-12-05T21:44:32.004275Z",
      "start_time": "2025-12-05T21:44:31.859563Z"
     }
    },
-   "source": [
-    "algorithm_globals.random_seed = 10598\n",
-    "qaoa_mes = QAOA(sampler=sampler, optimizer=COBYLA(), initial_point=[0.0, 0.0])\n",
-    "exact_mes = NumPyMinimumEigensolver()"
-   ],
    "outputs": [
     {
      "name": "stderr",
@@ -280,7 +275,11 @@
      ]
     }
    ],
-   "execution_count": 6
+   "source": [
+    "algorithm_globals.random_seed = 10598\n",
+    "qaoa_mes = QAOA(sampler=sampler, optimizer=COBYLA(), initial_point=[0.0, 0.0])\n",
+    "exact_mes = NumPyMinimumEigensolver()"
+   ]
   },
   {
    "attachments": {},
@@ -292,18 +291,18 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 7,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-12-05T21:44:32.027835Z",
      "start_time": "2025-12-05T21:44:32.025473Z"
     }
    },
+   "outputs": [],
    "source": [
     "qaoa = MinimumEigenOptimizer(qaoa_mes)  # using QAOA\n",
     "exact = MinimumEigenOptimizer(exact_mes)  # using the exact classical numpy minimum eigen solver"
-   ],
-   "outputs": [],
-   "execution_count": 7
+   ]
   },
   {
    "attachments": {},
@@ -315,16 +314,13 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 8,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-12-05T21:44:32.056683Z",
      "start_time": "2025-12-05T21:44:32.048751Z"
     }
    },
-   "source": [
-    "exact_result = exact.solve(qubo)\n",
-    "print(exact_result.prettyprint())"
-   ],
    "outputs": [
     {
      "name": "stdout",
@@ -336,7 +332,10 @@
      ]
     }
    ],
-   "execution_count": 8
+   "source": [
+    "exact_result = exact.solve(qubo)\n",
+    "print(exact_result.prettyprint())"
+   ]
   },
   {
    "attachments": {},
@@ -348,15 +347,13 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 9,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-12-05T21:44:32.077558Z",
      "start_time": "2025-12-05T21:44:32.074181Z"
     }
    },
-   "source": [
-    "qaoa"
-   ],
    "outputs": [
     {
      "data": {
@@ -369,20 +366,19 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 9
+   "source": [
+    "qaoa"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 10,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-12-05T21:44:33.369669Z",
      "start_time": "2025-12-05T21:44:32.095972Z"
     }
    },
-   "source": [
-    "qaoa_result = qaoa.solve(qubo)\n",
-    "print(qaoa_result.prettyprint())"
-   ],
    "outputs": [
     {
      "name": "stderr",
@@ -402,7 +398,10 @@
      ]
     }
    ],
-   "execution_count": 10
+   "source": [
+    "qaoa_result = qaoa.solve(qubo)\n",
+    "print(qaoa_result.prettyprint())"
+   ]
   },
   {
    "attachments": {},
@@ -417,17 +416,13 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 11,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-12-05T21:44:33.401797Z",
      "start_time": "2025-12-05T21:44:33.399088Z"
     }
    },
-   "source": [
-    "print(\"variable order:\", [var.name for var in qaoa_result.variables])\n",
-    "for s in qaoa_result.samples:\n",
-    "    print(s)"
-   ],
    "outputs": [
     {
      "name": "stdout",
@@ -445,7 +440,11 @@
      ]
     }
    ],
-   "execution_count": 11
+   "source": [
+    "print(\"variable order:\", [var.name for var in qaoa_result.variables])\n",
+    "for s in qaoa_result.samples:\n",
+    "    print(s)"
+   ]
   },
   {
    "attachments": {},
@@ -457,40 +456,32 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 12,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-12-05T21:44:33.417353Z",
      "start_time": "2025-12-05T21:44:33.414827Z"
     }
    },
+   "outputs": [],
    "source": [
     "def get_filtered_samples(\n",
-    "    samples: List[SolutionSample],\n",
+    "    samples: list[SolutionSample],\n",
     "    threshold: float = 0,\n",
-    "    allowed_status: Tuple[OptimizationResultStatus] = (OptimizationResultStatus.SUCCESS,),\n",
+    "    allowed_status: tuple[OptimizationResultStatus] = (OptimizationResultStatus.SUCCESS,),\n",
     "):\n",
     "    return [s for s in samples if s.status in allowed_status and s.probability > threshold]"
-   ],
-   "outputs": [],
-   "execution_count": 12
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 13,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-12-05T21:44:33.432979Z",
      "start_time": "2025-12-05T21:44:33.430054Z"
     }
    },
-   "source": [
-    "filtered_samples = get_filtered_samples(\n",
-    "    qaoa_result.samples,\n",
-    "    threshold=0.005,\n",
-    "    allowed_status=(OptimizationResultStatus.SUCCESS,),\n",
-    ")\n",
-    "for s in filtered_samples:\n",
-    "    print(s)"
-   ],
    "outputs": [
     {
      "name": "stdout",
@@ -506,7 +497,15 @@
      ]
     }
    ],
-   "execution_count": 13
+   "source": [
+    "filtered_samples = get_filtered_samples(\n",
+    "    qaoa_result.samples,\n",
+    "    threshold=0.005,\n",
+    "    allowed_status=(OptimizationResultStatus.SUCCESS,),\n",
+    ")\n",
+    "for s in filtered_samples:\n",
+    "    print(s)"
+   ]
   },
   {
    "attachments": {},
@@ -520,30 +519,28 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 14,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-12-05T21:44:33.451921Z",
      "start_time": "2025-12-05T21:44:33.449709Z"
     }
    },
+   "outputs": [],
    "source": [
     "fvals = [s.fval for s in qaoa_result.samples]\n",
     "probabilities = [s.probability for s in qaoa_result.samples]"
-   ],
-   "outputs": [],
-   "execution_count": 14
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 15,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-12-05T21:44:33.479166Z",
      "start_time": "2025-12-05T21:44:33.476442Z"
     }
    },
-   "source": [
-    "np.mean(fvals)"
-   ],
    "outputs": [
     {
      "data": {
@@ -556,19 +553,19 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 15
+   "source": [
+    "np.mean(fvals)"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 16,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-12-05T21:44:33.495191Z",
      "start_time": "2025-12-05T21:44:33.492542Z"
     }
    },
-   "source": [
-    "np.std(fvals)"
-   ],
    "outputs": [
     {
      "data": {
@@ -581,7 +578,9 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 16
+   "source": [
+    "np.std(fvals)"
+   ]
   },
   {
    "attachments": {},
@@ -593,19 +592,13 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 17,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-12-05T21:44:33.510012Z",
      "start_time": "2025-12-05T21:44:33.507222Z"
     }
    },
-   "source": [
-    "samples_for_plot = {\n",
-    "    \" \".join(f\"{qaoa_result.variables[i].name}={int(v)}\" for i, v in enumerate(s.x)): s.probability\n",
-    "    for s in filtered_samples\n",
-    "}\n",
-    "samples_for_plot"
-   ],
    "outputs": [
     {
      "data": {
@@ -624,33 +617,39 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 17
+   "source": [
+    "samples_for_plot = {\n",
+    "    \" \".join(f\"{qaoa_result.variables[i].name}={int(v)}\" for i, v in enumerate(s.x)): s.probability\n",
+    "    for s in filtered_samples\n",
+    "}\n",
+    "samples_for_plot"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 18,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-12-05T21:44:34.189054Z",
      "start_time": "2025-12-05T21:44:33.530569Z"
     }
    },
-   "source": [
-    "plot_histogram(samples_for_plot)"
-   ],
    "outputs": [
     {
      "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAnYAAAHWCAYAAAD6oMSKAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy88F64QAAAACXBIWXMAAA9hAAAPYQGoP6dpAABKpElEQVR4nO3dB5hTZfb48UPvHelt6CgoTToo0gR0EUVQEEQF5M+6gOy6UkS6KCiySBFUmoWiyKJLB+lVWEAWEOkdKdI7Q/7PefeXbDKNeWcyk+Tm+3mePDN5c3Nz78nNzMlbU7hcLpcAAAAg5KUM9AEAAADAP0jsAAAAHILEDgAAwCFI7AAAAByCxA4AAMAhSOwAAAAcgsQOAADAIUjsAAAAHCJ1oA8gVNy7d09OnjwpWbJkkRQpUgT6cAAAQJhwuVxy5coVKVCggKRMGXedHIldPGlSV7hw4UAfBgAACFPHjh2TQoUKxbkNiV08aU2dO6hZs2YN9OEAAIAwcfnyZVO55M5F4kJiF0/u5ldN6kjsAABAcotPVzAGTwBhaPz48RIRESHp06eXKlWqyJo1a+L1vHXr1knq1KmlYsWKPuVTp041f3Ci3m7evOnZRvuH9OzZU4oWLSoZMmSQWrVqyc8//+z3cwOAcEZiB4SZWbNmmQSrX79+sm3bNqlbt640bdpUjh49GufzLl26JB06dJAGDRrE+LjWZJ86dcrnpomjW6dOnWTp0qXy5Zdfys6dO6Vx48bSsGFDOXHihN/PEQDCVQqXDrVAvNq3s2XLZv650RSLUFa9enWpXLmyTJgwwVNWrlw5eeaZZ2T48OGxPu+FF16QUqVKSapUqeSf//ynbN++3afGTpPFixcvxvjcGzdumL4h8+bNk+bNm3vKtebvqaeekqFDh/rt/AAgnHMQauyAMHL79m3ZunWrqS3zpvfXr18f6/OmTJkiBw4ckAEDBsS6zdWrV00zq47Y0mRNawPd7t69K5GRkT41eEqbZNeuXZuocwIA/A+JHRBGzp07ZxKsvHnz+pTr/dOnT8f4nH379knv3r3l66+/Nv3rYlK2bFlTa/fDDz/IjBkzTAJXu3Zt81yltXU1a9aUIUOGmKmD9Bi++uor2bRpk2myBQD4B4kdEIaijqzSHhkxjbbSBKxt27YyaNAgKV26dKz7q1Gjhrz00kvyyCOPmD57s2fPNtt/8sknnm20b52+TsGCBSVdunQyZswYs29t2gUA+AfTnQBhJHfu3CaRilo7d+bMmWi1eO6RrFu2bDHNqm+88YZnFRZN0LT2bsmSJfLEE09Ee57OjP7oo496auxUiRIlZNWqVXLt2jXTXyR//vzSpk0bMzoXAOAf1NgBYSRt2rRmehMdnepN7+v0I1FpJ10dwaoDJdy3rl27SpkyZczvOhAjJpr46eOavEWVKVMmU37hwgVZvHixtGjRwo9nCADhjRo7IMz06tVL2rdvL1WrVjX93iZNmmSmOtGETfXp08dMQTJ9+nRT81a+fHmf5+fJk8f0ofMu16ZabY7VUbNaG6fNrJrYjRs3zrONJnGa8GlSuH//fnnrrbfM76+88koynj0AOBuJHRBmtPnz/PnzMnjwYDNwQRO0BQsWmBGtSsvuN6ddVDrNSZcuXUwTrw7Jr1SpkqxevVqqVavm2UaH6WvSePz4ccmZM6c899xzMmzYMEmTJo3fzxEAwhXz2MUT89gBAIBAYB47AACAMERiBwAA4BAkdgAAAA5BYgcAAOAQJHYAAAAOQWIHAADgECR2AAAADkFiBwAA4BAkdgAAAA5BYgcAAOAQJHYAAAAOQWIHAADgECR2AAAADkFiBwAA4BAkdgAAAA5BYgcAAOAQJHYAAAAOQWIHAADgEKkDfQAAkk+x3vMlWB1+v3mgDwEAQl5Q1tiNHz9eIiIiJH369FKlShVZs2ZNvJ63bt06SZ06tVSsWNGnfOrUqZIiRYpot5s3bybRGQAAACS/oEvsZs2aJT179pR+/frJtm3bpG7dutK0aVM5evRonM+7dOmSdOjQQRo0aBDj41mzZpVTp0753DRxBAAAcIqgS+xGjRolr732mnTq1EnKlSsno0ePlsKFC8uECRPifN7rr78ubdu2lZo1a8b4uNbQ5cuXz+cGAADgJEGV2N2+fVu2bt0qjRs39inX++vXr4/1eVOmTJEDBw7IgAEDYt3m6tWrUrRoUSlUqJA89dRTpjYQAADASYJq8MS5c+ckMjJS8ubN61Ou90+fPh3jc/bt2ye9e/c2/fC0f11MypYta/rZVahQQS5fviz/+Mc/pHbt2rJjxw4pVapUjM+5deuWubnp89SdO3fMTaVMmVJSpUpljvnevXuebd3ld+/eFZfL5SnXMn0stnL3ft3c56Pbx6c8TZo05jj0eLxrKnX72MpjO3bOyZnnFMz0XHifOCfOiXPinCTaOUU91pBJ7LwD4E1PKmqZ0kBo8+ugQYOkdOnSse6vRo0a5uamSV3lypXlk08+kTFjxsT4nOHDh5v9RrVkyRLJmDGj+b1IkSJSqVIl+eWXX3z6AJYpU8Ykk5s3b5azZ896ynVQh9Yarl69Wq5cueIp1+bjPHnymH17Xzj169eXDBkyyIIFC3yOoVmzZnLjxg1ZsWKFp0wvmObNm5vkeMOGDZ7yLFmyyBNPPCHHjh2T7du3e8ofeOABqVWrlkmM9+7d6ynnnJx9TsFMz4X3iXPinDgnzkmindP169clvlK4vNPYIGiK1aTp22+/lZYtW3rKe/ToYQK0atUqn+0vXrwoOXLkMFmtm2a8ekpapm+aBjgmnTt3luPHj8vChQvjXWOnff30TdSBGOH+7YFzCs1zCubpTg4Me5L3iXPinDgnzkmin5PmILlz5zYDRd05SEjU2KVNm9ZMb7J06VKfxE7vt2jRItr2enI7d+6MNlXKTz/9JN99952ZMiUmGiRNFLVpNjbp0qUzt6j0jdSbNw2+d3LpFlvTcGzlUfebkHK9GGJqcoutPLZj55yceU7BzH0evE+ck20558Q5Of2c0sRyTDEJur/+vXr1kvbt20vVqlVNdemkSZNM9WTXrl3N43369JETJ07I9OnTTdDKly/v83ytXtVpTLzLtUlVm2K1P51mvdr8qonduHHjkv38AAAAkkrQJXZt2rSR8+fPy+DBg81cc5qgaXu3u3+Qlt1vTruotMm2S5cuZgBGtmzZTHu2trlXq1Ytic4CAAAg+QVVH7tgpjV9mhTGp30bCFbB3MeOJcUAIPE5SHDPfwAAAIB4I7EDAABwCBI7AAAAhyCxAwAAcAgSOwAAAIcgsQMAAHAIEjsAAACHILEDAABwCBI7AAAAhyCxAwAAcAgSOwAAAIcgsQMAAHAIEjsAAACHILEDAABwCBI7AAAAhyCxAwAAcAgSOwAAAIcgsQMAAHAIEjsAAACHILEDAABwCBI7AAAAhyCxAwAAcAgSOwAAAIcgsQMAAHAIEjsAAACHILEDAABwCBI7AAAAhyCxAwAAcAgSOwAAAIcgsQMAAHAIEjsAAACHILEDAABwCBI7AAAAhyCxAwAAcAgSOwAAAIcgsQMAAHAIEjsAAACHILEDAABwCBI7AAAAhyCxAwAAcAgSOwAAAIcgsQMAAHAIEjsAAACHILEDAABwCBI7AAAAhyCxAwAAcAgSOwAAAIcgsQMAAHAIEjsAAACHILEDAAAI98SuUqVKMmHCBLl8+bJ/jwgAAADJm9jt2bNH3njjDcmfP7907NhR1q5dm9BdAQAAIJCJ3enTp+Xjjz+WkiVLyvTp0+Wxxx6TcuXKyahRo+TcuXP+ODYAAAAkR2KXPXt26d69u+zYsUM2b94snTt3llOnTsnf/vY3KVSokLRp00aWLFmS0N0DAAAgEIMnqlatKp9++qlJ7CZPnizVqlWTb7/9Vpo2bSoREREybNgw8xgAAABCZFRshgwZ5E9/+pO0bNlSChQoIC6XS44cOSL9+/eXYsWKmT55169f9+dLAgAAwN+J3bJly+SFF16QggULmubYe/fuSd++fWXv3r0yc+ZMzyhaTe4AAADgf6kT8+STJ0+aptcpU6bI4cOHTVmjRo2kS5cu0qJFC0mVKpUpK1WqlLRu3VqefvppmTdvnn+OHAAAAP5J7DRJW7RokURGRkrevHmld+/eZgCFNrnGplatWrJgwYKEviQAAACSIrGbP3++T+1c6tSp45UMat87AAAABFFid+DAATPi1Ub58uXNDQAAAEE0eGLIkCHyww8/xLmNNru++uqrCX0JAAAAJEdiN3XqVNm+fXuc2+zcuVOmTZuW0JcAAABAoOaxi+rmzZvx6nsHAACAxEtU1pUiRYoYy3Vi4uPHj5umWAZLAAAABGGNXcqUKc3cdO756QYOHOi5733TWjqd9uTnn382kxYDAAAgyGrs6tWr56mlW716tRQpUiTGees0ucuZM6c88cQTZm47AAAABFlit3LlSp/au1deeUXefffdpDguAAAAJFcfO10LFgAAAGEyKhYAAABBWGOnEw1r/7r33nvPrA0b34mH9TlffPFFYo4RAAAA8ZDCpXOTxIP2qdMkbc+ePVK6dGlzP14vkCKFREZGSqi7fPmyZMuWTS5duiRZs2YN9OEACVKs93wJVoffbx7oQwCAkM9B4l1jd+jQIfOzYMGCPvcBAAAQHOKd2BUtWjTO+wAAAAgsBk8AAACEW43d0aNHE/wiOpExAAAAgiSx0xUmYlsbNi76nLt371o/DwAAAEmU2HXo0CFBiR0AAACCLLGbOnVq0h4JAAAAEoXBEwAAAA5BYgcAAOAQLCkGAADgECwpFk8sKQYnYEkxAAg9LCkGAAAQhlhSDAAAwCEYPAEAABBuNXaxWbdunUybNk22b99u2n61DbhSpUrSvn17qVOnjn+OEgAAAEmX2OmYi27dusmkSZPM70oHVNy7d0+2bNkin3/+uXTp0kXGjx/PihUAAADB3BT70UcfycSJE6V8+fLy7bffyunTp82asPpz9uzZ8tBDD5mkb9SoUf49YgAAACRuupOodMoTncZk586dkjFjxmiPX716VR5++GFJnTq1/PbbbxLqmO4ETsB0JwDg7BwkwTV2x44dk2effTbGpE5lzpzZPK7bAQAAIOklOLErVKiQ3Lx5M85tbt26ZbYDAABAECd2uqSY9qX7/fffY3z81KlTMmvWLOnUqZP1vnXARUREhKRPn16qVKkia9asiXXbtWvXSu3atSVXrlySIUMGKVu2rHz88cfRtpszZ448+OCDki5dOvNz7ty51scFAADgiFGxR48e9bn/wgsvyIYNG8zUJj169DBTm+TJk0fOnDljErExY8ZIzZo1pXXr1lYHpMlgz549TXKnCZsO0GjatKns3r1bihQpEm37TJkyyRtvvGH68+nvmui9/vrr5ncdlav0ONu0aSNDhgyRli1bmqROj0u3rV69utXxAQAAOGat2Kj06bGVu5+no2XjSxOtypUry4QJEzxl5cqVk2eeeUaGDx8er31o3z5N7L788ktzX5M67Xi4cOFCzzZPPvmk5MiRQ2bMmBGvfTJ4Ak7A4AkACD1JslZshw4dknw+utu3b8vWrVuld+/ePuWNGzeW9evXx2sf27ZtM9sOHTrUU6Y1dm+++abPdk2aNJHRo0f76cgBAAACL96J3dSpU5P2SETk3LlzZgqVvHnz+pTrfZ0fLy46SOPs2bOmdnDgwIE+ffv0ubb71IEfevPOltWdO3fMzV0bmSpVKnPMOjGzm7tcj8W7QlTL3DWYMZW79+umU8WoqDWesZWnSZPGHIcej5sm47p9bOWxHTvn5MxzCmZ6LrxPnBPnxDlxThLtnKIea5IuKZYUotYMxtbc60379enceRs3bjQ1fiVLlpQXX3wxwfvUZt9BgwZFK1+yZIlnihft86d9DH/55RefPohlypQxgzg2b95skk23ihUrStGiRWX16tVy5coVT7n2RdT+ibpv7wunfv36ZkDIggULfI6hWbNmcuPGDVmxYoWnTC+Y5s2bm+RYayjdsmTJIk888YSZdkaXfXN74IEHpFatWrJv3z7Zu3evp5xzcvY5BTM9F94nzolz4pw4J4l2TtevX5ckn6A4qZpiNWnSlSx0kIObDs7QAK1atSpe+9FmWO1f5w6eBk6bYr2bY3XkrDbFHjlyJN41doULFzZvort9O5y/PXBOoXlOwdzH7sCwJ3mfOCfOiXPinCT6OWkOkjt3bv/2sYuJZsBjx46VZcuWycmTJ30SIe+TOXDgQLz2lzZtWjO9ydKlS30SO73fokWLeB+XBsH7WDQ71314J3aaqWv2HBudFkVvUekbqTdvGny9ReW+GOJbHnW/CSnXiyGmJrfYymM7ds7JmecUzNznwfvEOdmWc06ck9PPKU0sxxSTBP/116pBTYw0adPs0T1iQ2vdtMpSFShQwOpgVK9evaR9+/ZStWpVk5DperNaPdm1a1fzeJ8+feTEiRMyffp0c3/cuHGmRk6rLJVOYfLhhx/KX/7yF58av3r16skHH3xgEsR58+aZZFS3BQAAcIoEJ3Y6QEGTOk2w2rVrZzJNrRF799135eeffzaJlWaaWjNmQ6cmOX/+vAwePNhMcly+fHnT3u3uH6Rl3u3QWnWpyd6hQ4fM65UoUULef/99M5edmyagM2fOlHfeeUf69+9vttH58pjDDgAAOEmC+9jpyhA6QEGbOJVWOWqyp4mdunDhglSoUEHatm0rI0aMkFDHPHZwgmDuY8c8dgCQ+BwkwfMfaM2ZjuRw0xo7dxOs0sl/dcUIHQgBAACApJfgxE4zR+8RJZrIHT9+3GcbzSpjW0sWAAAAQZLYFS9eXA4fPuy5r7V32iz7xx9/mPtae/fjjz/GuL4rAAAAgiix02W+li9f7pk0TwcrnDlzRh555BF5/vnnzaAHHVzRsWNHfx4vAAAA/J3Y6fQjn332mSexe/bZZ2XkyJFm9Yc5c+aY5bp06pK33noroS8BAAAAC35feUJnT9bVGXS5jvstAxZKGBULJ2BULAA4Owfx+/T0Ojo2b968/t4tAAAA7iPRid21a9fMSg66lqtmkppR6sK7usJDpkyZErt7AAAAJEdiN2PGDHnjjTfk4sWLPgvsahNs9uzZzXJfL7zwQmJeAgAAAEmd2OlUJi+99JKkT59eunXrJnXr1jVNsDpv3erVq2XKlCnm8SxZskjz5vSdAQAACNrBE7rO6t69e2Xz5s1SunTpaI//+uuvZpty5crJxo0bJdQxeAJOwOAJAAg9ybKk2M6dO00za0xJnSpbtqx5/JdffknoSwAAAMBCghM7zRi1H11c9HHNMAEAABDEid3TTz8t//rXv8y8dTG5e/euzJ8/X/70pz8l5vgAAACQ1ImdrjKhAyeaNm0qmzZt8nlM+9RpeYYMGeSDDz5I6EsAAAAgKUbFFi9ePFrZ7du3Zdu2bWbN2DRp0kiuXLnk/PnzcufOHfN4/vz5pUqVKmbNWAAAAARJYnfv3r1oS4RpMlekSBGfMk3moj4PAAAAQZTYHT58OGmPBAAAAIHpYwcAAACHrRXrHgH722+/eSbOK1OmjKRO7ZddAwAAIDlq7C5cuCBdunQx89VVqFBB6tSpIw8//LC5r+U6kAIAAADJI3VikrqaNWuamjodDatrxebLl8+sFbtlyxb5/PPPZdWqVbJhwwbJmTOnf48aAAAA/quxGzJkiEnq+vTpI0eOHJGFCxfKlClTZMGCBeZ+v379ZN++fTJ06NCEvgQAAAAspHC5XC5JAJ3XLiIiwsxhF5uGDRvKwYMHzS2cFuAFglWx3vMlWB1+v3mgDwEAQj4HSXCN3cmTJ6VGjRpxblO9enWzHeyNHz/eJM66uodO8rxmzZpYt/3++++lUaNG8sADD5g3XJvIFy9e7LPNZ599ZprLc+TIYW6adG/evDnavk6cOCEvvfSSaV7PmDGjVKxYUbZu3Zok5wgAAPwrwYmdZo7a5BoXfVy3g51Zs2ZJz549TXO2ruyhCZku0Xb06NEYt1+9erVJ7LQZXJOw+vXrm7V89bluK1eulBdffFFWrFhh+j3qxNKNGzc2iZx3v8natWubiae1aX337t3y0UcfmcEwAADAwU2xbdq0kX/+858yf/58U/sTlTbRNmvWTJ555hmTqIS65GyK1ZrOypUry4QJEzxl5cqVM7EcPnx4vPbx0EMPmffo3XffjfHxyMhIU3M3duxY6dChgynr3bu3rFu3Ls7aQYQ2mmIBIPQkS1PsgAEDTM1OkyZNTO3Qhx9+KF9++aX5+dRTT5naoLRp08aaWCBmuv6u1rpp/Lzp/fXr18drH7qM25UrV+IcjXz9+nWzpq/3Nj/88INUrVpVnn/+ecmTJ49UqlTJNOECAACHT3fy4IMPypIlS6Rjx46m1k5vupasuwKwRIkSMnXqVFNzhPg7d+6cqU3LmzevT7neP336dLz2oc2n165dk9atW8e6jdbOFSxY0Ke2VQe5aC1hr169pG/fvqYPXvfu3SVdunSeWj0AABC8ErU8RK1atWTv3r2m+U77c2lVoVYRak2P9tXSRA8JEzV2mjDHJ54zZsyQgQMHyrx580ytW0xGjBhhttN+dzo4w7umT2vs3nvvPXNf38ddu3aZZI/EDgAAByd2r776qlllQjv564oTekPi5c6dW1KlShWtdu7MmTPRavGi0r6Mr732mnz77bcx9ntU2lSuiduyZcvM++ctf/78pibWm/btmzNnToLPBwAAJJ8E97H75ptvzCoT8C/tl6jTmyxdutSnXO9rDWlstAZOm8X1fWnePOZO6CNHjjQTSy9atMjUzEWltaxaA+tNJ6EuWrRogs8HAACEQI1dyZIl5dSpU/49Ghjax619+/Ym+dI56SZNmmSmOunatat5XFf70GlKpk+f7knqtKn0H//4h5lb0F3blyFDBs90M9r82r9/f5P4FStWzLNN5syZzU29+eabJnnUGj3tn6d97PS19QYAABxcY6dNfjpgwnseNPiHTlMyevRoGTx4sJkgWOep0znq3DVnmlB7z2k3ceJEuXv3rvz5z382zanuW48ePXwmPNYRt61atfLZRptm3R599FGZO3euSRTLly9vavf0ONq1a5fMEQAAAMk6j93hw4fljTfekJ07d8rf//53kxRoH7CYOvjrZLihjiXF4ATMYwcAzs5BEtwUq2vFuqc30SkxYqPbaG0SAAAAklaCEzvt08V0JgAAAA5I7HTyYQAAADhg8AQAAAActPKEm65hun37dtOpTzv36UjOuOZcAwAAQJAldjoNR+fOnWX//v3Rlr0qVaqUWUC+bt26/jlSAAAAJE1it2HDBmncuLHcuXNHmjVrZhI4ne5EV6PQhG/hwoXm8RUrVphJcwEAABCkiV3fvn1N7ZwuJB+1Vk7ntVu1apU0adLEbPfTTz/541gBAACQFIMnfv75Z7NCQmxNrY899ph5XJelAgAAQBDX2KVPn14KFiwY5zb6uG6H0F8ZgFUBAABwcI1dgwYN7tvEqo83bNgwoS8BAACA5EjsPvroIzl58qS88sorcuLECZ/H9H7Hjh3l9OnTPovMAwAAIEiXFMuZM6dMnz5dvv76aylatKjkyZNHzpw5I0eOHJHIyEh5+OGHzXbedMDF8uXL/XHsAAAA8Edip6Nh3e7evSsHDhwwN287duyI9jzWlwUAAAiyxO7evXv+PRIAAAAkCmvFAgAAOITfErujR4+aFScAAAAQ4ondlClTpH79+v7aHQAAACzRFAsAAOAQJHYAAAAOQWIHAADgEH5L7LJlyyZFihTx1+4AAAAQqMSuZ8+ecujQIX/tDgAAAJZoigUAAAi3lSfcc9RVq1ZN0qdPbzVnXb169RJ2dAAAAPB/Yvf444+bdV737NkjpUuX9tyPj8jIyPgfEQAAAJI2sXv33XdNIpc7d26f+wAAAAixxG7gwIFx3gcAAEBgMXgCAAAg3BO7q1evytGjR+Xu3bs+5bNmzZJ27dpJp06dZPv27f44RgAAAPizKTaqt99+W6ZNmya///67pE79391MmDBB3njjDXG5XJ4kb8uWLVKmTJmEvgwAAACSusZuzZo10rBhQ8mUKZOnbPjw4VKwYEEzFcrs2bPNaNiRI0cm9CUAAACQHDV2J06cMImd286dO+X48eMyYsQIqVOnjin77rvvZNWqVQl9CQAAACRHjd2NGzckbdq0nvtr16410580btzYU1a8eHGTAAIAACCIE7tChQrJL7/84rk/f/58yZEjh1SoUMFTdv78ecmcOXPijxIAAABJ1xTbtGlTGTdunLz11ltmibFFixZJ+/btfSYt/vXXX6VIkSIJfQkAAAAkR2LXp08f+fHHH+Wjjz4y9/PlyyeDBg3yPK5Toaxbt066d++e0JcAAABAciR2msjt2rVLli9fbu7Xq1dPsmbN6nn8ypUrJulr0qRJQl8CAAAAyZHYqQwZMshTTz0V42MPPfSQuQEAACB5sKQYAACAQySqxk4nINaJiJctWyYnT56UW7duRdtGB1O4m2sBAAAQhIndtWvXzJx1GzduNEuIaQLnXkpMue97j5IFAABAEDbFDh06VDZs2GBGwp47d84kcQMHDpRTp06ZNWIjIiKkVatWMdbiAQAAIIgSu++//15q1Kgh77zzjuTMmdNTnjdvXnn++edl5cqVpgmWtWIBAACCPLHTeeo0sfPsKGVKn9o5XZmiefPmMm3atMQfJQAAAJIuscuUKZNJ5tyyZctmmmGjznWnCSAAAACCOLErWrSoT9JWvnx5+emnnzy1dtrnTpti8+fP758jBQAAQNIkdg0aNJAVK1bI3bt3zf2XX37ZJHo1a9Y068fWqVNHtm/fLs8991xCXwIAAADJMd1J586dJVeuXHL27FlTK/fqq6/Ktm3bZPz48SahU5rU6UhZAAAABHFiV6pUKXn77bd9yj755BN599135eDBg6apVvvYAQAAIARWnojJAw88YG4AAABIXqwVCwAAEO41dsWLF4/Xdrqk2IEDBxL6MgAAAEjqxO7evXsxrgN76dIluXjxovldB1WkTZs2oS8BAACA5EjsDh8+HOdjvXr1kt9//12WLl2a0JcAAABAoPvYFStWTGbNmiUXLlyQfv36JcVLAAAAILkGT6RJk0YaNWoks2fPTqqXAAAAQHKNir1+/br88ccf1s/TSY4jIiIkffr0UqVKFVmzZk2s2+r6tG3btpUyZcqYtWt79uwZbZupU6ea/oBRbzdv3rQ+NgAAgLBL7FavXi0zZswwCZcNbcLV5EybcHUli7p160rTpk191qX1pmvT6rx5uv0jjzwS636zZs1qkkDvmyaOAAAAEu6DJ5544okYy3Xt2BMnTpgBFC6XS9555x2r/Y4aNUpee+016dSpk7k/evRoWbx4sUyYMEGGDx8eY3++f/zjH+b3yZMnx7pfraFjJQwAAOBkCU7sVq5cGWsClSNHDtO/7s0335QmTZrEe5+3b9+WrVu3Su/evX3KGzduLOvXr5fEuHr1qlnmLDIyUipWrChDhgyRSpUqJWqfAAAAjpnHzt/OnTtnEq+8efP6lOv906dPJ3i/ZcuWNf3sKlSoIJcvXzY1fLVr15YdO3aYNW9ja+LVm5s+T925c8fclPbpS5UqlTlm73i4y7X2Umst3bRMH4ut3L3fYKTn6I9zSp36v5ecbh+fch2Eo7HV1/f+8qDbx1Ye2/uRVO9TKJ1TMHNfY7xPnBPnxDlxTil9zskmP0j0WrFnzpwxTa96QAULFvRLc2fUiY/1pGKaDDm+atSoYW5umtRVrlxZPvnkExkzZkyMz9Fm30GDBkUrX7JkiWTMmNH8XqRIEVPr98svv/j0AdR+hZpMbt68Wc6ePesp15pCrTXU/odXrlzxlNesWVPy5Mlj9h2s9u3bl+Bz8v4w1K9fXzJkyCALFizw2X+zZs3kxo0bsmLFCk+ZfgiaN29uEv4NGzZ4yrNkyWK6Ahw7dky2b9/uKde+lrVq1TLHunfvXk95UrxPoXpOwUzPhfeJc+KcOCfOSaKdkw5Gja8ULu80Np60JksTos8++yzacmHaDNu+fXvp0aOH6f9mQ5tiNWn69ttvpWXLlp5y3ZcGaNWqVXE+//HHHzdvpPbLu5/OnTvL8ePHZeHChfGusStcuLB5E3UgRlJ9eyjVPziTuwPDnnT8N6JwOKdivedLsHJfY7xPnBPnxDlxTil9zklzkNy5c5vVvdw5iN9q7DQL1Sx1165d5sUKFChgEh79XROlkydPmqbOL7/8UmbOnCkNGzY0z9PytWvXSuvWrWPdty4/ptOb6GoV3omd3m/RooX4ix6rJoraNBubdOnSmVtU+kbqzZsGX29RuS+G+JZH3W8wcZ+fv87Jplwv8JiaEWMrj+39SOr3KRTOKZi5z4P3iXOyLeecwu+cJk6cKCNHjjQzXDz00EOmQkdn0YiJ1nj99a9/NX34tcase/fuZnvvY9SKqunTp8t//vMfc19zkffee0+qVavm2UZr5vQ1dT/6unPnzpVnnnkmWd4nm/zAqtONZrdaJakn/uKLL8qePXtMMqcnu3HjRvO7lrVr187MX6fJ2KFDh2T//v1Sp04d+fXXX+/7GroU2eeff25GuOq+dACGVk927drVPN6nTx/p0KGDz3M0SdObDpDQN1B/3717t+dxbVLVkbUHDx40j+moW/3p3icAAAgNSTEt2sqVK01eo82tmtNoE6kO3NSuZm7Xrl0zzx87dqwEM6uv9Zoha03dgAEDzC0m2i6stXWlS5c22+jkwTr1iSZ6mgHfT5s2beT8+fMyePBgkxGXL1/etHe7+wdpWdQ3z3t0q2bS33zzjdnevZ7txYsXpUuXLmYARrZs2cz22ubunYkDAIDglxTTon399dc+97UG77vvvpPly5d7KpM0edRbsLNK7HR5sJIlS8q777573211/rqvvvpKNm3aZPrdLVq0yHRMjI9u3bqZW0x0dGtU9+sm+PHHH5sbAAAIXUk5LZo3HaygrZQ5c+aUUGPVFKvNmxq8+IxQ1W3c22pyF9+kDgAAIDmnRYtKE0ed6cM9TiCUWNXYaR82bcqMLx25oR3/tJYPAADAH/w9LZq3ESNGmCVRtd9dKC49apXY6bwvOhAivnQqFH0OAABAYumUHzp6NGrtnM6pG7UWLyE+/PBDMxp22bJl8vDDD0sosmqK1Un9dN63+FR36jbz5883o2EBAAASy3taNG96XycATgydykSXG9UxAVWrVpVQZZXY6fQg2hyrc8xpO3dsdFSrbqOdD19//XV/HCcAAECSTIs2YsQIM+hT96mjaLVySm+6vZv+7t6P0unc9PfYplkJiaZYHQChKzboMOBy5cqZpE2XztAJit2TF+vQYH1cEz+dYkRXgwAAAPCHpJgWbfz48WbEbatWrXyep9O2DRw40Py+ZcsWn4GgmmCql19+OcYZOwLFekkxHY2io0V0+pCYnqplOtuynrDOJxPTTMqhSJfz0IEj8VnOIzGCdcmnw+83D/QhwMHXl+IaA4DE5yDW6w5poqbt0FpbN2XKFDNDs7vPXb58+Uwbd8eOHRkJCwAAEMx97Lxp4jZs2DD56aefTDu13vT3oUOHktQBQJjTpq2IiAgzXYR2dl+zZk2s22rTma5SpCsXaYuPLhcVkzlz5siDDz5o1vHWn7pWpzdtMtMpL7xvWuEAhJMEJ3YAACTXWp7aOqR9q9q3by87duwwP1u3bm0mwPemC8Jroui+7dy5M0nOEQhWJHYAgCRby1MH2ulanjrITtfyjIl7LU8dyRjbJPi6j0aNGpkRj2XLljU/GzRoYMq96aT4WkvnvmnCCIQTEjsAgN/X8tQlJf25lqfW2EXdZ5MmTaLtc9++fVKgQAHTDPzCCy/IwYMHE/yaQCgisQMABP1anvrc++2zevXqMn36dFm8eLGZdksf0wF9OjUGEC6sR8UCABCItTzvt0/tx+dWoUIFs1pSiRIlZNq0aZ45xxDagnXKpsNBNF0TNXYAgKBfy1P7y9nuM1OmTCbB0+ZZIFyQ2AEAgn4tT619i7rPJUuWxLlPHW2rS07lz58/wa8LhBqaYgEAfqXNnjodiS6krgnZpEmToq3leeLECdMfzs29/qb3Wp6aJOp8dapHjx5Sr149+eCDD6RFixYyb948WbZsmaxdu9azj7/97W/y9NNPS5EiRUxtns6rqjP265JPQLggsQMABP1anlozN3PmTLNQe//+/U3fOZ0vTwdMuB0/flxefPFFM4BDpzmpUaOGbNy40fO6QDggsQMA+F23bt3MLSYxLZgen2XLdYH2qIu0e9PEDwh39LEDAABwCBI7AAAAhyCxAwAAcAgSOwAAAIcgsQMAAHAIEjsAAACHYLoTAIDfsJYnEFjU2AEAADgEiR0AAIBDkNgBAAA4BIkdAACAQ5DYAQAAOASJHQAAgEOQ2AEAADgEiR0AAIBDkNgBAAA4BIkdAACAQ5DYAQAAOASJHQAAgEOQ2AEAADgEiR0AAIBDkNgBAAA4BIkdAACAQ5DYAQAAOASJHQAAgEOQ2AEAADgEiR0AAIBDkNgBAAA4BIkdAACAQ5DYAQAAOASJHQAAgEOQ2AEAADgEiR0AAIBDkNgBAAA4BIkdAACAQ5DYAQAAOASJHQAAgEOQ2AEAADgEiR0AAIBDkNgBQDyMHz9eIiIiJH369FKlShVZs2ZNnNuvWrXKbKfbFy9eXD799FOfx7///nupWrWqZM+eXTJlyiQVK1aUL7/80mebgQMHSooUKXxu+fLlS5LzA+AMJHYAcB+zZs2Snj17Sr9+/WTbtm1St25dadq0qRw9ejTG7Q8dOiTNmjUz2+n2ffv2le7du8ucOXM82+TMmdPsb8OGDfLLL7/IK6+8Ym6LFy/22ddDDz0kp06d8tx27tyZ5OcLIHSlDvQBAECwGzVqlLz22mvSqVMnc3/06NEmAZswYYIMHz482vZaO1ekSBGznSpXrpxs2bJFPvzwQ3nuuedM2eOPP+7znB49esi0adNk7dq10qRJE0956tSpqaUDEG/U2AFAHG7fvi1bt26Vxo0b+5Tr/fXr18f4HK2Fi7q9Jmua3N25cyfa9i6XS5YvXy579+6VevXq+Ty2b98+KVCggGkGfuGFF+TgwYN+OS8AzkSNHQDE4dy5cxIZGSl58+b1Kdf7p0+fjvE5Wh7T9nfv3jX7y58/vym7dOmSFCxYUG7duiWpUqUy/fgaNWrkeU716tVl+vTpUrp0afn9999l6NChUqtWLdm1a5fkypUrSc4XQGijxg4A4kEHLkStZYtadr/to5ZnyZJFtm/fLj///LMMGzZMevXqJStXrvQ8rv34tOm2QoUK0rBhQ5k/f74p1yZbOIu/B+d89tlnpo9njhw5zE2vn82bN/tsc+XKFdN3tGjRopIhQwbzpUGvRYQ2EjsAiEPu3LlNbVrU2rkzZ85Eq5Vz0z5xMW2v/eW8a9pSpkwpJUuWNCNi//rXv0qrVq1i7LPnpqNnNcnT5lk4R1IMztEvCC+++KKsWLHCdA3QPp/aPeDEiROebbTP6NKlS81obB2Uo49rAui9DUIPiR0AxCFt2rSmZkT/AXrT+1rDEZOaNWtG237JkiVmepM0adLE+lpaq6fNsrHRx/bs2eNpyoXzBufoQBsddFO4cGEzOCcm3oNzdHt93quvvmoG57h9/fXX0q1bN/OloWzZsqYG7969e6Yvp7px44ZJBEeMGGH6deoXDJ1eR2sNY3tdhAYSOzhCIJoxvGktizax6bduOI82kX7++ecyefJkk1i9+eabpjala9eu5vE+ffpIhw4dPNtr+ZEjR8zzdHt93hdffCF/+9vffK4ZTf50MMSvv/5q/rlrf7qXXnrJs41ur9eq1tBs2rTJ1OhdvnxZXn755WSOAEJ5cI66fv26eUyn2VHa31P7jurfQG/aJKsjsxG6GDwBxzRjaHJXu3ZtmThxomnG2L17t/lWG1szRufOneWrr76SdevWmW+2DzzwgGcqCnczhtbI6B8+/Varf0i107p2dvemfVImTZokDz/8cLKdM5JXmzZt5Pz58zJ48GAzl1z58uVlwYIFpm+S0jLvZjP9kqGPawI4btw4M6p1zJgxnutLXbt2zVx3x48fN/9MtVZFr0d9LTd9TK9DHXCh12eNGjVk48aNntdF6EvKwTneevfubf526ZdUd/9OrVkeMmSIqfXT58+YMcN8gShVqpRfzxHJi8QOIS8p5hjTZoyoNXjfffedacbwrpm5evWqtGvXzjyuIxbhXJqE6S0mU6dOjVb22GOPyb///e9Y96fXy/2umZkzZybgSBGKkmJwjpt+MdWkTb+wetfQad86bcLVhE/7kVauXFnatm0b53WL4EdTLEJaoJox3P785z9L8+bNPd+CASBYBuco/cL63nvvmT6eUVsVSpQoYZr69QvqsWPHTHcT/TunNc4IXSR2CGlJ0YwRk6jNGO7aFP1mG9coRgAI1OCckSNHmqbWRYsWmcfiGm2tzbcXLlwwrR0tWrRI9HkhcGiKhSMkdzOGfrvVJaD0j2nUzscAYEMH2bRv394kX5q0aZ/dqINzdAoSHVyjtHzs2LHmedpXWFshdHCO/p3y/rvVv39/+eabb6RYsWKeL7qZM2c2N6VJnP7tK1OmjOzfv1/eeust87uuWYzQRWKHkJZczRjLli3zacbQ5l99jn7TdtOaw9WrV5s/uO6VBBD6ivX+76TAwebw+80DfQgI4sE5OphMu6roSGpvAwYMMNOauFc+0aRRB+loNxN9vk6UHdeUPAh+JHZwTDNGy5YtPeV6P7bmBP1G/OOPP8arGUM7t+u32qjNGA0aNDATenrTb7k6svHtt98mqQMQ0ME5hw8fvu9rtm7d2tzgLCR2CHmBaMbQqQL0W3XUfipa4xe1HACA5EJih5AXqGYMAACCDYkdHCEQzRhReS/eDgBAIJDYAQAQIAzOgb8xjx0AAIBDkNgBAAA4BE2xCGk0YwAA8D/U2AEAADgEiR0AAIBDkNgBAAA4BIkdAACAQ5DYAQAAOASJHQAAgEOQ2AEAADgEiR0AAIBDkNgBAAA4BIkdAACAQ5DYAQAAOERQJnbjx4+XiIgISZ8+vVSpUkXWrFkT5/arVq0y2+n2xYsXl08//TTaNnPmzJEHH3xQ0qVLZ37OnTs3Cc8AAAAg+QVdYjdr1izp2bOn9OvXT7Zt2yZ169aVpk2bytGjR2Pc/tChQ9KsWTOznW7ft29f6d69u0nk3DZs2CBt2rSR9u3by44dO8zP1q1by6ZNm5LxzAAAAMIssRs1apS89tpr0qlTJylXrpyMHj1aChcuLBMmTIhxe62dK1KkiNlOt9fnvfrqq/Lhhx96ttHHGjVqJH369JGyZcuanw0aNDDlAAAAThFUid3t27dl69at0rhxY59yvb9+/foYn6O1cVG3b9KkiWzZskXu3LkT5zax7RMAACAUpZYgcu7cOYmMjJS8efP6lOv906dPx/gcLY9p+7t375r95c+fP9ZtYtununXrlrm5Xbp0yfz8448/PAljypQpJVWqVOaY792759nWXa7H4HK5POVapo/FVq77vXfrugSjCxcuJPicvKVO/d9LTrePT3maNGlMbDXGbilSpDDba3mwxuv8+fMJPqeYymO7xmyvvWCNl/c15s/Pkz+uvVC8xgJ57QVzvPz9efLHtRfM8UrOv+XxvfaCPV4pkuhv+ZUrV0y59/UWEomddwC86YlELbvf9lHLbfc5fPhwGTRoULRyHdQRjnLSam0lN/GyxjVmh2vMDvGyQ7yCM16a4GXLli10ErvcuXObDDVqTdqZM2ei1bi55cuXL8btNTPOlStXnNvEtk+l/fB69erlua+ZtNbW6T7jSgiDxeXLl03fxGPHjknWrFkDfThBj3jZIV72iJkd4mWHeDk7Xq7/q7UrUKDAfbcNqsQubdq0ZtqSpUuXSsuWLT3ler9FixYxPqdmzZry448/+pQtWbJEqlataqp+3dvoPt58802fbWrVqhXrsei0KHrzlj17dgk1esGGwkUbLIiXHeJlj5jZIV52iJdz43W/mrqgTOyU1pLpdCSamGlCNmnSJDPVSdeuXT01aSdOnJDp06eb+1o+duxY87zOnTubgRJffPGFzJgxw7PPHj16SL169eSDDz4wCeK8efNk2bJlsnbt2oCdJwAAgL8FXWKn881pJ8TBgwfLqVOnpHz58rJgwQIpWrSoeVzLvOe00z5v+rjWxo0bN85UU44ZM0aee+45zzZaMzdz5kx55513pH///lKiRAkzX1716tUDco4AAABhkdipbt26mVtMpk6dGq3ssccek3//+99x7rNVq1bmFi60GXnAgAHRmpMRM+Jlh3jZI2Z2iJcd4mUnnYPjlcIVn7GzAAAACHpBNUExAAAAEo7EDgAAwCFI7AAAAByCxM7h6EKJpMT1haTGNYak5HLg9cXgCQAAAIcIyulOkHi6cLCurrFp0yYpUqSIWa5N5+8rVaqUI4d3J4Z73WBdNk5/12XtEDeur/jj+koYrrH44xqzd9fB1xc1dg714osvyrp16yRnzpxy/PhxyZgxo7lg69evLx07dpRChQoF+hCDyrlz58wH2y0yMtL85A9kzLi+7HB92eMas8M1ZudFJ19fmtjBWb766itX8eLFXStXrvSUrVq1ytWlSxdX7ty5XaVKlfI8du/ePVe4mz17titFihSuBg0auKZMmeK6deuWz+N37951Xbt2zbVhw4Zoj4Ujri87XF/2uMbscI3Z+crh1xc1dg79JqLf3D755BPzrc37G9u1a9fMt5EzZ87IihUrJGVKxs/oiiTHjh2TkiVLyqpVq+TGjRvSoEEDee2116RJkyZmm4ULF0rbtm3lwoULEu64vuxwfdnjGrPDNWbnRYdfX6F3xLivhx9+WNauXWvW3NULVvtd3L59W27duiWZMmUy6+rqmruLFi2ScHfz5k25fv26PP/88/Lxxx/L3LlzzTIzly9flnbt2pm+FxqvESNGmKXr3H0zwhnXV/xxfSUM11j8cY3Ze9jp11egqwzhf7t27XLlz5/f9cwzz7h2794d7fE7d+64cubM6dq8eXPIVjX7y8WLF10fffSRa/r06T7xOXHihGv58uWud99911W5cmXTzPHzzz+bxyMjI13hjOsr/ri+EoZrLP64xuztcvj1RVOsQ0dHbdiwQf7617/KoUOHpGLFivL000+bm96fPHmyrF+/Xn777bdAH27QuHPnjqRJk8Z8c/OuetdvtsOGDZNPP/3UfIMLd1xfCcP1FX9cYwnDNRY/rjC4vkjsHOzAgQOyePFiWbNmjWzdulX2798v2bNnN9Xx3bp1k0aNGkXrXxCuH/K4yvXDrqOlRo0aZf5Ipk7NLEGK6+v+uL4Sh2vs/rjGEu6AQ68vErsw+JCfPn3aDIXXb3PacbZKlSrmd8T+R9FN+1xMnTpVWrZsKXny5Lnv9k7H9WWH68se15gdrjE7rjC4vkjsHMb97eLtt9+W5557TqpVqxZtm6hV9eHMHa/evXubkWVVq1YN9CEFNa4vO1xf9rjG7HCN2YkMg+srdI8cMdILVkdDjRw50vONo2fPnnLy5EnPNqF8wSZVvHTEmLu6vVevXp6+KHzv8cX1ZYfryx7XmB2uMTupwuH6CvDgDfiRTkKpdITUo48+an5fu3atGQ11/vz5AB9d8CFedoiXHeJlj5jZIV527oZJvEI8LYU397eMKVOmSOvWrc3vEydOlA4dOphlU+CLeNkhXnaIlz1iZod42UkZLvEKdGYJ/3DPs7Nv3z5XlixZzBxGSufiWbZsWYCPLvgQLzvEyw7xskfM7BAvO/fCKF7U2DmEe8HnCRMmSI0aNaRAgQLy3XffmaHbderUCfThBR3iZYd42SFe9oiZHeJlJzKM4kVi5xDueYlmz54tL7/8sqeKWUf9pEuXLsBHF3yIlx3iZYd42SNmdoiXndThFK9AVxnCf1XM69atM9XKN27ccF2+fNmVNWtW144dOwJ9eEGHeNkhXnaIlz1iZod42bkXZvGixs4B3JMt6iSLffr0kfTp08u0adOkWLFiZrFj+CJedoiXHeJlj5jZIV52UoRZvFhXxCGuX78uzz77rNy+fdvcv3nzpvTr1y/QhxW0iJcd4mWHeNkjZnaIl53rYRQvVp4IYe41/+bNm2duH3zwgTzwwAOex0NxjbukRLzsEC87xMseMbNDvOzcDdd4BbotGAkXGRlpfpYvX95MsDhkyJBY+xaAeNkiXnaIlz1iZod42YkM03iR2IUo98V46NAhV9q0aV1ffPGFK1OmTK4NGzb4PD5jxgzXmTNnXOGOeNkhXnaIlz1iZod42bkXxvEisQtRd+7cMT/ffPNN15NPPml+79ixo6tp06auW7dumft79+4131KuXr3qCnfEyw7xskO87BEzO8TLzp0wjheJXYjLkSOH65tvvjG/796921W8eHHXrFmzzP2///3vrjp16viskRfuiJcd4mWHeNkjZnaIl50cYRgvErsQduTIEfPt4/bt256yt956y1WmTBnXzZs3XREREa6ZM2c67qJNKOJlh3jZIV72iJkd4mXnSJjGi1GxIe78+fOSK1cuz/0//vjDLI+SP39+2bhxo1y7di2gxxdsiJcd4mWHeNkjZnaIl53z4RivQGeW8P8IIO0Mqv0GXn/9dZ++BvBFvOwQLzvEyx4xs0O87ESGSbyosXOYe/fumbl7vv76a6lXr56UKFHClKVMySIjMSFedoiXHeJlj5jZIV527oVBvEjsAAAAHMI5KWoY0m8ZMeXl/zcoJiDHFMyIl38QLzvEK3Z8Ju0QL/9wOTxeJHYhRte327lzp5w7d85UHbsXN9alUfRDr7TMXR7uiJf//+ARr/8hXvb4TNohXnZcfCZJ7ELJN998IzVq1JCXXnpJihUrJuXLl5dhw4aZUT+63p2T+gj4A/Gyo/1OvP/gxfYH0v3PJNwRL3t8Ju0QLzt8Jv+LPnYhYtWqVfLyyy/LM888I7Vr15Y0adLIypUrZe7cuXLq1Cnp2rWrDBw4UHLmzBnoQw0KxMvOf/7zHxk1apQ0bNhQqlWrJiVLlvR53P0Hkn8k/0W87PGZtEO87PCZ9BLoYbmIn+eff971yiuveO6717k7deqUa+zYsa5HHnnE9f777wfwCIML8bLTrl07V6pUqVzVq1d3NW/e3NW3b1/XDz/84Dp58qRnm02bNrmqVavmuKkBEoJ42eMzaYd42eEz+T+pvZM8BC/9tpYpUybPfXdVc758+eTPf/6znD17Vj7//HNp1aqVGb4d7oiXnX379sl7770nERERsmjRIlm2bJm5FS1aVKpUqWJqDDReqVOnNjft36NNQeGKeNnjM2mHeNnhM+nFK8lDEPvqq6/MhIrTpk1zXbp0KdrjFy9edBUrVsy1fv16n2934Yp4xd+JEydc7du3d40bN85TdvToUdeECRNczz77rKty5cquWrVqmXjOmzfPccvv2CJeCcNn0g7xij8+k77oYxdCevfubb6J1K9fXx5//HEpV66clC5d2jw2bdo06d69u1y6dCnQhxk0iFf8nTlzxnQo1tqAqN9kd+3aJUOGDDGxvHjxYkCPM1gQr4ThM2mHeMUfn8n/oSk2hPTq1UsyZ84ss2fPlh9++MHzAT9w4IBkzJhR3nrrLc/IIK1qDnfEK/7y5Mljfur3PP2DqD/1j6T+/tBDD8mVK1ekadOmZhviRbwSis+kHeIVf3wm/4cauxCk30b+9a9/yfLly82FmzVrVnnqqafMSCC9WPUtdfIcPbaIV8K443L16lVp0aKFDB482PRTcdryO/5CvOKPz6Qd4pUwrjD9TJLYhQB3tbJ+sCtWrCiFChXyPOb0bx4JQbwSFq+FCxdKpUqVTFMGYke87PGZtEO87PCZ9OXclNVB3H0FdN6iEydOmN/nzZsn165d83xbw/8Qr4TFq3PnznLkyBHz+/z58+XGjRthMZmnLeJlj8+kHeJlh8+kLxK7EPgm4p6BXIe/V69eXfbv3y9/+ctfzIdcUQX/P8TLP/H6f//v/5k+KcrJTRa2iJc9PpN2iJcdPpPRhdfZhrCJEydK69atze/jx4+XBx980NNZFNERLzvEyw7xskfM7BAvO8TLS5TpTxBE3PMS/fHHH67MmTO7/vOf/5j7hQsXds2cOTPARxd8iJcd4mWHeNkjZnaIlx3iFTNq7EKgillnyy5TpowZsr1mzRq5deuWPPnkk4E+vKBDvOwQLzvEyx4xs0O87BCvmJHYhUCH0KlTp0q7du08VczNmjWTbNmyBfjogg/xskO87BAve8TMDvGyQ7xiEUtNHgIsMjLS/Ny9e7crR44crtOnT5v7+vtPP/0U4KMLPsTLDvGyQ7zsETM7xMsO8YodNXZByj2KZ8aMGaaKOW/evGbUj/7UCRbhi3jZIV52iJc9YmaHeNkhXrFjguIQcO7cOcmdO7dZDqV48eIybty4QB9SUCNedoiXHeJlj5jZIV52iJcvErsg417qZPPmzXLs2DF57rnnfB7XeXmyZMkSsOMLNsTLDvGyQ7zsETM7xMsO8bo/mmKDtHpZR/b07dtX1q9f7/N4uF+wUREvO8TLDvGyR8zsEC87xOv+SOyClE60WKNGDXniiSfkvffeM4sYa+VquC2NEl/Eyw7xskO87BEzO8TLDvGKQxwDKxAEPvvsM9ejjz7qGjVqVKAPJSQQLzvEyw7xskfM7BAvO8QrOhK7IHft2jXXpEmTXFmzZnW1atXKdeTIEVN+9+7dQB9aUCJedoiXHeJlj5jZIV52iFd0DJ4IEvo26MLOd+/elYsXL8qRI0ekRIkScvnyZfPYtm3bpE+fPlKrVi0ZPXp02PcjIF52iJcd4mWPmNkhXnaIl4UYkj0EcM27QYMGubJnz+6qUqWKK3369K4yZcq4KlSo4EqVKpUrZ86cZvLFRx55xLVp0yZXOCNedoiXHeJlj5jZIV52iFf8UWMXZA4cOCBbtmwxc/IULVpUDh06JPny5ZMcOXLI+fPnzbeV999/X65fv24mYwzrZVOIlzXiZYd42SNmdoiXHeIVDxZJIILEvn37XHny5HHNnDkz0IcSEoiXHeJlh3jZI2Z2iJedfWEeL6Y7CULew7W9K1TdvxcpUkTSpk0r1apVC8jxBRviZYd42SFe9oiZHeJlh3jFjcQuiCdgVNpZNOrvt27dkk8++UQiIiICcnzBhnjZIV52iJc9YmaHeNkhXnGjj10Qjfbx/ibifeHCF/GyQ7zsEC8AoYy/VkFA/4lcuHDB8w/E/U8kthm0wz0XJ152iJcd4pX0iJkd4mXHFebxosYugG7evClLliyRsWPHSpo0acw/jvLly0ubNm2katWqgT68oEO87BAvO8QLgBOQ2AXQgAEDZO7cuWaSxcKFC0tkZKTs2LFDTp06JY8++qj06tUrbDt/xoR42SFedoiXvRUrVsjt27elUqVKkitXLkmVKlW0bTRBpin7v4iXHeKVMCR2AaTz8IwZM0batm1r7l+5ckUOHjwo69evl5kzZ5pag2nTpknBggUDfahBgXjZIV52iJc9nTvs0qVLUr16dXn22WelQYMGJjHWWf/d/2y//vpruXHjhnTq1EnCHfGyQ7wSKMDTrYStvXv3ukqVKuXauXNnjI8fOHDAVbRoUdc777yT7McWjIiXHeJlh3jZ27hxo6tkyZKur776yvXqq6+6smTJ4sqQIYOrWbNmrsmTJ5uYnjlzxhUREeH69NNPzXMiIyNd4Yp42SFeCUdiFyAXL1501apVy9W0aVPXuXPnPMuleBs7dqzr0UcfDevFjN2Ilx3iZYd42fv+++9dTz/9tGv//v2esh9//NHVpEkTs7yTThCrv6dMmdJ148YNV7gjXnaIV8LRMB0gusxJ//795dixY9KzZ0/ZsGGDWQJF+/W47d2711RFa78C7/JwRLzsEC87xMue9jd8/fXXTRO221NPPSWLFi0ysRs6dKgsW7ZMWrVqJenTpw/7mBEvO8Qr4ehjF0Aa+jlz5sjAgQNlz549UrlyZWncuLH5J6Oj806ePCkff/yxNGnSxFy0MXUcDSfEyw7xskO8Ek/jonFMnTq1uZ89e3bTL7FFixbELAbEyw7xih8SuyCxbt060wlU/4HkzZtX8ufPL127dpWGDRsG+tCCEvGyQ7zsEK/E00EnOhDl8OHDgT6UkEC87BCv2JHYBdj27dvNXFnubyDq/PnzZmg3oiNedoiXHeJlb9euXVKuXLloU05oc9nZs2elaNGiTEnhhXjZIV72iEQAuPsCrFmzxjT76AWpc/X8+uuvppqZfyK+iJcd4mWHeCUuZv369TO/37lzRw4cOODZJmPGjOafrgr3f7rEyw7xShyiEUAfffSRuTj1opw8ebJMnDjRZ0Fj+CJedoiXHeKV+Jjpqh2IHfGyQ7wShsQuANwdPFevXm367bgv4CJFigT4yIIT8bJDvOwQL//E7MMPPyRmsSBedohX4pDYBaiK+csvvzRNPPXq1ZPffvvN9OPRNSnhi3jZIV52iJc9YmaHeNkhXolHYhcgkyZNkueff978Pm7cOKlVq5YUKFAg0IcVtIiXHeJlh3jZI2Z2iJcd4pUIiZjcGJbcs9mfPXvWlTlzZteePXvM/QIFCri+/fbbAB9d8CFedoiXHeJlj5jZIV52iJd/UGMXgCpm/SaiUyqULVtWVqxYYcp1IlT4Il52iJcd4mWPmNkhXnaIl3+Q2CUj99xY33zzjTz77LPm9wkTJsif/vQnyZo1a4CPLvgQLzvEyw7xskfM7BAvO8TLT/xU8weLquaVK1e6rl27Zu5nypTJtXz58kAfVtAiXnaIlx3iZY+Y2SFedohX4rHyRDLQEOt8WJcvX/b51nHt2jVZu3atNGrUiAkWvRAvO8TLDvGyR8zsEC87xMu/iFQycE9y2qpVK8+6dnohZ8qUySwoDl/Eyw7xskO87BEzO8TLDvHyLxK7ZHLhwgX5/fff5bPPPvO5kPXi1W8iVJz6Il52iJcd4mWPmNkhXnaIlx/5oTkX8aTDtXUIt/ew7XPnzrkmT57s+vzzzwN6bMGIeNkhXnaIlz1iZod42SFe/vHfIShIFlrNrIsajx8/Xo4ePSrff/+9HDlyxCxu/Pe//91sc+/ePfoS/B/iZYd42SFe9oiZHeJlh3j5B4MnkpDOvaNr3h06dEi+++472b17tyxevFhOnz5tHh8+fLiZp+fJJ5+UdOnS+XQiDUfEyw7xskO87BEzO8TLDvFKGtTYJcNCxi+99JJcv35dSpUqJVOnTjUX7ciRI6VChQrSrFkzz6SMKpwvWOJlh3jZIV72iJkd4mWHeCURPzXpIg47duxwXb9+3aesU6dOrmLFirkOHjwYsOMKVsTLDvGyQ7zsETM7xMsO8fIvmmKTmbsaWb+BNGzYUMqUKSOffvppoA8raBEvO8TLDvGyR8zsEC87xCvx6IGYzPSC1c6fWgXdpUsXzxBuLUN0xMsO8bJDvOwRMzvEyw7xSjxq7ALs9u3bkjZtWjqExhPxskO87BAve8TMDvGyQ7zskdgBAAA4BE2xAAAADkFiBwAA4BAkdgAAAA5BYgcAAOAQJHYAAAAOQWIHAADgECR2AAAADkFiBwAA4BAkdgAAAOIM/x9KtKLkFNtESQAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 640x480 with 1 Axes>"
-      ],
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAnYAAAHWCAYAAAD6oMSKAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy88F64QAAAACXBIWXMAAA9hAAAPYQGoP6dpAABKpElEQVR4nO3dB5hTZfb48UPvHelt6CgoTToo0gR0EUVQEEQF5M+6gOy6UkS6KCiySBFUmoWiyKJLB+lVWEAWEOkdKdI7Q/7PefeXbDKNeWcyk+Tm+3mePDN5c3Nz78nNzMlbU7hcLpcAAAAg5KUM9AEAAADAP0jsAAAAHILEDgAAwCFI7AAAAByCxA4AAMAhSOwAAAAcgsQOAADAIUjsAAAAHCJ1oA8gVNy7d09OnjwpWbJkkRQpUgT6cAAAQJhwuVxy5coVKVCggKRMGXedHIldPGlSV7hw4UAfBgAACFPHjh2TQoUKxbkNiV08aU2dO6hZs2YN9OEAAIAwcfnyZVO55M5F4kJiF0/u5ldN6kjsAABAcotPVzAGTwBhaPz48RIRESHp06eXKlWqyJo1a+L1vHXr1knq1KmlYsWKPuVTp041f3Ci3m7evOnZRvuH9OzZU4oWLSoZMmSQWrVqyc8//+z3cwOAcEZiB4SZWbNmmQSrX79+sm3bNqlbt640bdpUjh49GufzLl26JB06dJAGDRrE+LjWZJ86dcrnpomjW6dOnWTp0qXy5Zdfys6dO6Vx48bSsGFDOXHihN/PEQDCVQqXDrVAvNq3s2XLZv650RSLUFa9enWpXLmyTJgwwVNWrlw5eeaZZ2T48OGxPu+FF16QUqVKSapUqeSf//ynbN++3afGTpPFixcvxvjcGzdumL4h8+bNk+bNm3vKtebvqaeekqFDh/rt/AAgnHMQauyAMHL79m3ZunWrqS3zpvfXr18f6/OmTJkiBw4ckAEDBsS6zdWrV00zq47Y0mRNawPd7t69K5GRkT41eEqbZNeuXZuocwIA/A+JHRBGzp07ZxKsvHnz+pTr/dOnT8f4nH379knv3r3l66+/Nv3rYlK2bFlTa/fDDz/IjBkzTAJXu3Zt81yltXU1a9aUIUOGmKmD9Bi++uor2bRpk2myBQD4B4kdEIaijqzSHhkxjbbSBKxt27YyaNAgKV26dKz7q1Gjhrz00kvyyCOPmD57s2fPNtt/8sknnm20b52+TsGCBSVdunQyZswYs29t2gUA+AfTnQBhJHfu3CaRilo7d+bMmWi1eO6RrFu2bDHNqm+88YZnFRZN0LT2bsmSJfLEE09Ee57OjP7oo496auxUiRIlZNWqVXLt2jXTXyR//vzSpk0bMzoXAOAf1NgBYSRt2rRmehMdnepN7+v0I1FpJ10dwaoDJdy3rl27SpkyZczvOhAjJpr46eOavEWVKVMmU37hwgVZvHixtGjRwo9nCADhjRo7IMz06tVL2rdvL1WrVjX93iZNmmSmOtGETfXp08dMQTJ9+nRT81a+fHmf5+fJk8f0ofMu16ZabY7VUbNaG6fNrJrYjRs3zrONJnGa8GlSuH//fnnrrbfM76+88koynj0AOBuJHRBmtPnz/PnzMnjwYDNwQRO0BQsWmBGtSsvuN6ddVDrNSZcuXUwTrw7Jr1SpkqxevVqqVavm2UaH6WvSePz4ccmZM6c899xzMmzYMEmTJo3fzxEAwhXz2MUT89gBAIBAYB47AACAMERiBwAA4BAkdgAAAA5BYgcAAOAQJHYAAAAOQWIHAADgECR2AAAADkFiBwAA4BAkdgAAAA5BYgcAAOAQJHYAAAAOQWIHAADgECR2AAAADkFiBwAA4BAkdgAAAA5BYgcAAOAQJHYAAAAOQWIHAADgEKkDfQAAkk+x3vMlWB1+v3mgDwEAQl5Q1tiNHz9eIiIiJH369FKlShVZs2ZNvJ63bt06SZ06tVSsWNGnfOrUqZIiRYpot5s3bybRGQAAACS/oEvsZs2aJT179pR+/frJtm3bpG7dutK0aVM5evRonM+7dOmSdOjQQRo0aBDj41mzZpVTp0753DRxBAAAcIqgS+xGjRolr732mnTq1EnKlSsno0ePlsKFC8uECRPifN7rr78ubdu2lZo1a8b4uNbQ5cuXz+cGAADgJEGV2N2+fVu2bt0qjRs39inX++vXr4/1eVOmTJEDBw7IgAEDYt3m6tWrUrRoUSlUqJA89dRTpjYQAADASYJq8MS5c+ckMjJS8ubN61Ou90+fPh3jc/bt2ye9e/c2/fC0f11MypYta/rZVahQQS5fviz/+Mc/pHbt2rJjxw4pVapUjM+5deuWubnp89SdO3fMTaVMmVJSpUpljvnevXuebd3ld+/eFZfL5SnXMn0stnL3ft3c56Pbx6c8TZo05jj0eLxrKnX72MpjO3bOyZnnFMz0XHifOCfOiXPinCTaOUU91pBJ7LwD4E1PKmqZ0kBo8+ugQYOkdOnSse6vRo0a5uamSV3lypXlk08+kTFjxsT4nOHDh5v9RrVkyRLJmDGj+b1IkSJSqVIl+eWXX3z6AJYpU8Ykk5s3b5azZ896ynVQh9Yarl69Wq5cueIp1+bjPHnymH17Xzj169eXDBkyyIIFC3yOoVmzZnLjxg1ZsWKFp0wvmObNm5vkeMOGDZ7yLFmyyBNPPCHHjh2T7du3e8ofeOABqVWrlkmM9+7d6ynnnJx9TsFMz4X3iXPinDgnzkmindP169clvlK4vNPYIGiK1aTp22+/lZYtW3rKe/ToYQK0atUqn+0vXrwoOXLkMFmtm2a8ekpapm+aBjgmnTt3luPHj8vChQvjXWOnff30TdSBGOH+7YFzCs1zCubpTg4Me5L3iXPinDgnzkmin5PmILlz5zYDRd05SEjU2KVNm9ZMb7J06VKfxE7vt2jRItr2enI7d+6MNlXKTz/9JN99952ZMiUmGiRNFLVpNjbp0qUzt6j0jdSbNw2+d3LpFlvTcGzlUfebkHK9GGJqcoutPLZj55yceU7BzH0evE+ck20558Q5Of2c0sRyTDEJur/+vXr1kvbt20vVqlVNdemkSZNM9WTXrl3N43369JETJ07I9OnTTdDKly/v83ytXtVpTLzLtUlVm2K1P51mvdr8qonduHHjkv38AAAAkkrQJXZt2rSR8+fPy+DBg81cc5qgaXu3u3+Qlt1vTruotMm2S5cuZgBGtmzZTHu2trlXq1Ytic4CAAAg+QVVH7tgpjV9mhTGp30bCFbB3MeOJcUAIPE5SHDPfwAAAIB4I7EDAABwCBI7AAAAhyCxAwAAcAgSOwAAAIcgsQMAAHAIEjsAAACHILEDAABwCBI7AAAAhyCxAwAAcAgSOwAAAIcgsQMAAHAIEjsAAACHILEDAABwCBI7AAAAhyCxAwAAcAgSOwAAAIcgsQMAAHAIEjsAAACHILEDAABwCBI7AAAAhyCxAwAAcAgSOwAAAIcgsQMAAHAIEjsAAACHILEDAABwCBI7AAAAhyCxAwAAcAgSOwAAAIcgsQMAAHAIEjsAAACHILEDAABwCBI7AAAAhyCxAwAAcAgSOwAAAIcgsQMAAHAIEjsAAACHILEDAABwCBI7AAAAhyCxAwAAcAgSOwAAAIcgsQMAAHAIEjsAAACHILEDAABwCBI7AAAAhyCxAwAAcAgSOwAAAIcgsQMAAHAIEjsAAACHILEDAAAI98SuUqVKMmHCBLl8+bJ/jwgAAADJm9jt2bNH3njjDcmfP7907NhR1q5dm9BdAQAAIJCJ3enTp+Xjjz+WkiVLyvTp0+Wxxx6TcuXKyahRo+TcuXP+ODYAAAAkR2KXPXt26d69u+zYsUM2b94snTt3llOnTsnf/vY3KVSokLRp00aWLFmS0N0DAAAgEIMnqlatKp9++qlJ7CZPnizVqlWTb7/9Vpo2bSoREREybNgw8xgAAABCZFRshgwZ5E9/+pO0bNlSChQoIC6XS44cOSL9+/eXYsWKmT55169f9+dLAgAAwN+J3bJly+SFF16QggULmubYe/fuSd++fWXv3r0yc+ZMzyhaTe4AAADgf6kT8+STJ0+aptcpU6bI4cOHTVmjRo2kS5cu0qJFC0mVKpUpK1WqlLRu3VqefvppmTdvnn+OHAAAAP5J7DRJW7RokURGRkrevHmld+/eZgCFNrnGplatWrJgwYKEviQAAACSIrGbP3++T+1c6tSp45UMat87AAAABFFid+DAATPi1Ub58uXNDQAAAEE0eGLIkCHyww8/xLmNNru++uqrCX0JAAAAJEdiN3XqVNm+fXuc2+zcuVOmTZuW0JcAAABAoOaxi+rmzZvx6nsHAACAxEtU1pUiRYoYy3Vi4uPHj5umWAZLAAAABGGNXcqUKc3cdO756QYOHOi5733TWjqd9uTnn382kxYDAAAgyGrs6tWr56mlW716tRQpUiTGees0ucuZM6c88cQTZm47AAAABFlit3LlSp/au1deeUXefffdpDguAAAAJFcfO10LFgAAAGEyKhYAAABBWGOnEw1r/7r33nvPrA0b34mH9TlffPFFYo4RAAAA8ZDCpXOTxIP2qdMkbc+ePVK6dGlzP14vkCKFREZGSqi7fPmyZMuWTS5duiRZs2YN9OEACVKs93wJVoffbx7oQwCAkM9B4l1jd+jQIfOzYMGCPvcBAAAQHOKd2BUtWjTO+wAAAAgsBk8AAACEW43d0aNHE/wiOpExAAAAgiSx0xUmYlsbNi76nLt371o/DwAAAEmU2HXo0CFBiR0AAACCLLGbOnVq0h4JAAAAEoXBEwAAAA5BYgcAAOAQLCkGAADgECwpFk8sKQYnYEkxAAg9LCkGAAAQhlhSDAAAwCEYPAEAABBuNXaxWbdunUybNk22b99u2n61DbhSpUrSvn17qVOnjn+OEgAAAEmX2OmYi27dusmkSZPM70oHVNy7d0+2bNkin3/+uXTp0kXGjx/PihUAAADB3BT70UcfycSJE6V8+fLy7bffyunTp82asPpz9uzZ8tBDD5mkb9SoUf49YgAAACRuupOodMoTncZk586dkjFjxmiPX716VR5++GFJnTq1/PbbbxLqmO4ETsB0JwDg7BwkwTV2x44dk2effTbGpE5lzpzZPK7bAQAAIOklOLErVKiQ3Lx5M85tbt26ZbYDAABAECd2uqSY9qX7/fffY3z81KlTMmvWLOnUqZP1vnXARUREhKRPn16qVKkia9asiXXbtWvXSu3atSVXrlySIUMGKVu2rHz88cfRtpszZ448+OCDki5dOvNz7ty51scFAADgiFGxR48e9bn/wgsvyIYNG8zUJj169DBTm+TJk0fOnDljErExY8ZIzZo1pXXr1lYHpMlgz549TXKnCZsO0GjatKns3r1bihQpEm37TJkyyRtvvGH68+nvmui9/vrr5ncdlav0ONu0aSNDhgyRli1bmqROj0u3rV69utXxAQAAOGat2Kj06bGVu5+no2XjSxOtypUry4QJEzxl5cqVk2eeeUaGDx8er31o3z5N7L788ktzX5M67Xi4cOFCzzZPPvmk5MiRQ2bMmBGvfTJ4Ak7A4AkACD1JslZshw4dknw+utu3b8vWrVuld+/ePuWNGzeW9evXx2sf27ZtM9sOHTrUU6Y1dm+++abPdk2aNJHRo0f76cgBAAACL96J3dSpU5P2SETk3LlzZgqVvHnz+pTrfZ0fLy46SOPs2bOmdnDgwIE+ffv0ubb71IEfevPOltWdO3fMzV0bmSpVKnPMOjGzm7tcj8W7QlTL3DWYMZW79+umU8WoqDWesZWnSZPGHIcej5sm47p9bOWxHTvn5MxzCmZ6LrxPnBPnxDlxThLtnKIea5IuKZYUotYMxtbc60379enceRs3bjQ1fiVLlpQXX3wxwfvUZt9BgwZFK1+yZIlnihft86d9DH/55RefPohlypQxgzg2b95skk23ihUrStGiRWX16tVy5coVT7n2RdT+ibpv7wunfv36ZkDIggULfI6hWbNmcuPGDVmxYoWnTC+Y5s2bm+RYayjdsmTJIk888YSZdkaXfXN74IEHpFatWrJv3z7Zu3evp5xzcvY5BTM9F94nzolz4pw4J4l2TtevX5ckn6A4qZpiNWnSlSx0kIObDs7QAK1atSpe+9FmWO1f5w6eBk6bYr2bY3XkrDbFHjlyJN41doULFzZvort9O5y/PXBOoXlOwdzH7sCwJ3mfOCfOiXPinCT6OWkOkjt3bv/2sYuJZsBjx46VZcuWycmTJ30SIe+TOXDgQLz2lzZtWjO9ydKlS30SO73fokWLeB+XBsH7WDQ71314J3aaqWv2HBudFkVvUekbqTdvGny9ReW+GOJbHnW/CSnXiyGmJrfYymM7ds7JmecUzNznwfvEOdmWc06ck9PPKU0sxxSTBP/116pBTYw0adPs0T1iQ2vdtMpSFShQwOpgVK9evaR9+/ZStWpVk5DperNaPdm1a1fzeJ8+feTEiRMyffp0c3/cuHGmRk6rLJVOYfLhhx/KX/7yF58av3r16skHH3xgEsR58+aZZFS3BQAAcIoEJ3Y6QEGTOk2w2rVrZzJNrRF799135eeffzaJlWaaWjNmQ6cmOX/+vAwePNhMcly+fHnT3u3uH6Rl3u3QWnWpyd6hQ4fM65UoUULef/99M5edmyagM2fOlHfeeUf69+9vttH58pjDDgAAOEmC+9jpyhA6QEGbOJVWOWqyp4mdunDhglSoUEHatm0rI0aMkFDHPHZwgmDuY8c8dgCQ+BwkwfMfaM2ZjuRw0xo7dxOs0sl/dcUIHQgBAACApJfgxE4zR+8RJZrIHT9+3GcbzSpjW0sWAAAAQZLYFS9eXA4fPuy5r7V32iz7xx9/mPtae/fjjz/GuL4rAAAAgiix02W+li9f7pk0TwcrnDlzRh555BF5/vnnzaAHHVzRsWNHfx4vAAAA/J3Y6fQjn332mSexe/bZZ2XkyJFm9Yc5c+aY5bp06pK33noroS8BAAAAC35feUJnT9bVGXS5jvstAxZKGBULJ2BULAA4Owfx+/T0Ojo2b968/t4tAAAA7iPRid21a9fMSg66lqtmkppR6sK7usJDpkyZErt7AAAAJEdiN2PGDHnjjTfk4sWLPgvsahNs9uzZzXJfL7zwQmJeAgAAAEmd2OlUJi+99JKkT59eunXrJnXr1jVNsDpv3erVq2XKlCnm8SxZskjz5vSdAQAACNrBE7rO6t69e2Xz5s1SunTpaI//+uuvZpty5crJxo0bJdQxeAJOwOAJAAg9ybKk2M6dO00za0xJnSpbtqx5/JdffknoSwAAAMBCghM7zRi1H11c9HHNMAEAABDEid3TTz8t//rXv8y8dTG5e/euzJ8/X/70pz8l5vgAAACQ1ImdrjKhAyeaNm0qmzZt8nlM+9RpeYYMGeSDDz5I6EsAAAAgKUbFFi9ePFrZ7du3Zdu2bWbN2DRp0kiuXLnk/PnzcufOHfN4/vz5pUqVKmbNWAAAAARJYnfv3r1oS4RpMlekSBGfMk3moj4PAAAAQZTYHT58OGmPBAAAAIHpYwcAAACHrRXrHgH722+/eSbOK1OmjKRO7ZddAwAAIDlq7C5cuCBdunQx89VVqFBB6tSpIw8//LC5r+U6kAIAAADJI3VikrqaNWuamjodDatrxebLl8+sFbtlyxb5/PPPZdWqVbJhwwbJmTOnf48aAAAA/quxGzJkiEnq+vTpI0eOHJGFCxfKlClTZMGCBeZ+v379ZN++fTJ06NCEvgQAAAAspHC5XC5JAJ3XLiIiwsxhF5uGDRvKwYMHzS2cFuAFglWx3vMlWB1+v3mgDwEAQj4HSXCN3cmTJ6VGjRpxblO9enWzHeyNHz/eJM66uodO8rxmzZpYt/3++++lUaNG8sADD5g3XJvIFy9e7LPNZ599ZprLc+TIYW6adG/evDnavk6cOCEvvfSSaV7PmDGjVKxYUbZu3Zok5wgAAPwrwYmdZo7a5BoXfVy3g51Zs2ZJz549TXO2ruyhCZku0Xb06NEYt1+9erVJ7LQZXJOw+vXrm7V89bluK1eulBdffFFWrFhh+j3qxNKNGzc2iZx3v8natWubiae1aX337t3y0UcfmcEwAADAwU2xbdq0kX/+858yf/58U/sTlTbRNmvWTJ555hmTqIS65GyK1ZrOypUry4QJEzxl5cqVM7EcPnx4vPbx0EMPmffo3XffjfHxyMhIU3M3duxY6dChgynr3bu3rFu3Ls7aQYQ2mmIBIPQkS1PsgAEDTM1OkyZNTO3Qhx9+KF9++aX5+dRTT5naoLRp08aaWCBmuv6u1rpp/Lzp/fXr18drH7qM25UrV+IcjXz9+nWzpq/3Nj/88INUrVpVnn/+ecmTJ49UqlTJNOECAACHT3fy4IMPypIlS6Rjx46m1k5vupasuwKwRIkSMnXqVFNzhPg7d+6cqU3LmzevT7neP336dLz2oc2n165dk9atW8e6jdbOFSxY0Ke2VQe5aC1hr169pG/fvqYPXvfu3SVdunSeWj0AABC8ErU8RK1atWTv3r2m+U77c2lVoVYRak2P9tXSRA8JEzV2mjDHJ54zZsyQgQMHyrx580ytW0xGjBhhttN+dzo4w7umT2vs3nvvPXNf38ddu3aZZI/EDgAAByd2r776qlllQjv564oTekPi5c6dW1KlShWtdu7MmTPRavGi0r6Mr732mnz77bcx9ntU2lSuiduyZcvM++ctf/78pibWm/btmzNnToLPBwAAJJ8E97H75ptvzCoT8C/tl6jTmyxdutSnXO9rDWlstAZOm8X1fWnePOZO6CNHjjQTSy9atMjUzEWltaxaA+tNJ6EuWrRogs8HAACEQI1dyZIl5dSpU/49Ghjax619+/Ym+dI56SZNmmSmOunatat5XFf70GlKpk+f7knqtKn0H//4h5lb0F3blyFDBs90M9r82r9/f5P4FStWzLNN5syZzU29+eabJnnUGj3tn6d97PS19QYAABxcY6dNfjpgwnseNPiHTlMyevRoGTx4sJkgWOep0znq3DVnmlB7z2k3ceJEuXv3rvz5z382zanuW48ePXwmPNYRt61atfLZRptm3R599FGZO3euSRTLly9vavf0ONq1a5fMEQAAAMk6j93hw4fljTfekJ07d8rf//53kxRoH7CYOvjrZLihjiXF4ATMYwcAzs5BEtwUq2vFuqc30SkxYqPbaG0SAAAAklaCEzvt08V0JgAAAA5I7HTyYQAAADhg8AQAAAActPKEm65hun37dtOpTzv36UjOuOZcAwAAQJAldjoNR+fOnWX//v3Rlr0qVaqUWUC+bt26/jlSAAAAJE1it2HDBmncuLHcuXNHmjVrZhI4ne5EV6PQhG/hwoXm8RUrVphJcwEAABCkiV3fvn1N7ZwuJB+1Vk7ntVu1apU0adLEbPfTTz/541gBAACQFIMnfv75Z7NCQmxNrY899ph5XJelAgAAQBDX2KVPn14KFiwY5zb6uG6H0F8ZgFUBAABwcI1dgwYN7tvEqo83bNgwoS8BAACA5EjsPvroIzl58qS88sorcuLECZ/H9H7Hjh3l9OnTPovMAwAAIEiXFMuZM6dMnz5dvv76aylatKjkyZNHzpw5I0eOHJHIyEh5+OGHzXbedMDF8uXL/XHsAAAA8Edip6Nh3e7evSsHDhwwN287duyI9jzWlwUAAAiyxO7evXv+PRIAAAAkCmvFAgAAOITfErujR4+aFScAAAAQ4ondlClTpH79+v7aHQAAACzRFAsAAOAQJHYAAAAOQWIHAADgEH5L7LJlyyZFihTx1+4AAAAQqMSuZ8+ecujQIX/tDgAAAJZoigUAAAi3lSfcc9RVq1ZN0qdPbzVnXb169RJ2dAAAAPB/Yvf444+bdV737NkjpUuX9tyPj8jIyPgfEQAAAJI2sXv33XdNIpc7d26f+wAAAAixxG7gwIFx3gcAAEBgMXgCAAAg3BO7q1evytGjR+Xu3bs+5bNmzZJ27dpJp06dZPv27f44RgAAAPizKTaqt99+W6ZNmya///67pE79391MmDBB3njjDXG5XJ4kb8uWLVKmTJmEvgwAAACSusZuzZo10rBhQ8mUKZOnbPjw4VKwYEEzFcrs2bPNaNiRI0cm9CUAAACQHDV2J06cMImd286dO+X48eMyYsQIqVOnjin77rvvZNWqVQl9CQAAACRHjd2NGzckbdq0nvtr16410580btzYU1a8eHGTAAIAACCIE7tChQrJL7/84rk/f/58yZEjh1SoUMFTdv78ecmcOXPijxIAAABJ1xTbtGlTGTdunLz11ltmibFFixZJ+/btfSYt/vXXX6VIkSIJfQkAAAAkR2LXp08f+fHHH+Wjjz4y9/PlyyeDBg3yPK5Toaxbt066d++e0JcAAABAciR2msjt2rVLli9fbu7Xq1dPsmbN6nn8ypUrJulr0qRJQl8CAAAAyZHYqQwZMshTTz0V42MPPfSQuQEAACB5sKQYAACAQySqxk4nINaJiJctWyYnT56UW7duRdtGB1O4m2sBAAAQhIndtWvXzJx1GzduNEuIaQLnXkpMue97j5IFAABAEDbFDh06VDZs2GBGwp47d84kcQMHDpRTp06ZNWIjIiKkVatWMdbiAQAAIIgSu++//15q1Kgh77zzjuTMmdNTnjdvXnn++edl5cqVpgmWtWIBAACCPLHTeeo0sfPsKGVKn9o5XZmiefPmMm3atMQfJQAAAJIuscuUKZNJ5tyyZctmmmGjznWnCSAAAACCOLErWrSoT9JWvnx5+emnnzy1dtrnTpti8+fP758jBQAAQNIkdg0aNJAVK1bI3bt3zf2XX37ZJHo1a9Y068fWqVNHtm/fLs8991xCXwIAAADJMd1J586dJVeuXHL27FlTK/fqq6/Ktm3bZPz48SahU5rU6UhZAAAABHFiV6pUKXn77bd9yj755BN599135eDBg6apVvvYAQAAIARWnojJAw88YG4AAABIXqwVCwAAEO41dsWLF4/Xdrqk2IEDBxL6MgAAAEjqxO7evXsxrgN76dIluXjxovldB1WkTZs2oS8BAACA5EjsDh8+HOdjvXr1kt9//12WLl2a0JcAAABAoPvYFStWTGbNmiUXLlyQfv36JcVLAAAAILkGT6RJk0YaNWoks2fPTqqXAAAAQHKNir1+/br88ccf1s/TSY4jIiIkffr0UqVKFVmzZk2s2+r6tG3btpUyZcqYtWt79uwZbZupU6ea/oBRbzdv3rQ+NgAAgLBL7FavXi0zZswwCZcNbcLV5EybcHUli7p160rTpk191qX1pmvT6rx5uv0jjzwS636zZs1qkkDvmyaOAAAAEu6DJ5544okYy3Xt2BMnTpgBFC6XS9555x2r/Y4aNUpee+016dSpk7k/evRoWbx4sUyYMEGGDx8eY3++f/zjH+b3yZMnx7pfraFjJQwAAOBkCU7sVq5cGWsClSNHDtO/7s0335QmTZrEe5+3b9+WrVu3Su/evX3KGzduLOvXr5fEuHr1qlnmLDIyUipWrChDhgyRSpUqJWqfAAAAjpnHzt/OnTtnEq+8efP6lOv906dPJ3i/ZcuWNf3sKlSoIJcvXzY1fLVr15YdO3aYNW9ja+LVm5s+T925c8fclPbpS5UqlTlm73i4y7X2Umst3bRMH4ut3L3fYKTn6I9zSp36v5ecbh+fch2Eo7HV1/f+8qDbx1Ye2/uRVO9TKJ1TMHNfY7xPnBPnxDlxTil9zskmP0j0WrFnzpwxTa96QAULFvRLc2fUiY/1pGKaDDm+atSoYW5umtRVrlxZPvnkExkzZkyMz9Fm30GDBkUrX7JkiWTMmNH8XqRIEVPr98svv/j0AdR+hZpMbt68Wc6ePesp15pCrTXU/odXrlzxlNesWVPy5Mlj9h2s9u3bl+Bz8v4w1K9fXzJkyCALFizw2X+zZs3kxo0bsmLFCk+ZfgiaN29uEv4NGzZ4yrNkyWK6Ahw7dky2b9/uKde+lrVq1TLHunfvXk95UrxPoXpOwUzPhfeJc+KcOCfOSaKdkw5Gja8ULu80Np60JksTos8++yzacmHaDNu+fXvp0aOH6f9mQ5tiNWn69ttvpWXLlp5y3ZcGaNWqVXE+//HHHzdvpPbLu5/OnTvL8ePHZeHChfGusStcuLB5E3UgRlJ9eyjVPziTuwPDnnT8N6JwOKdivedLsHJfY7xPnBPnxDlxTil9zklzkNy5c5vVvdw5iN9q7DQL1Sx1165d5sUKFChgEh79XROlkydPmqbOL7/8UmbOnCkNGzY0z9PytWvXSuvWrWPdty4/ptOb6GoV3omd3m/RooX4ix6rJoraNBubdOnSmVtU+kbqzZsGX29RuS+G+JZH3W8wcZ+fv87Jplwv8JiaEWMrj+39SOr3KRTOKZi5z4P3iXOyLeecwu+cJk6cKCNHjjQzXDz00EOmQkdn0YiJ1nj99a9/NX34tcase/fuZnvvY9SKqunTp8t//vMfc19zkffee0+qVavm2UZr5vQ1dT/6unPnzpVnnnkmWd4nm/zAqtONZrdaJakn/uKLL8qePXtMMqcnu3HjRvO7lrVr187MX6fJ2KFDh2T//v1Sp04d+fXXX+/7GroU2eeff25GuOq+dACGVk927drVPN6nTx/p0KGDz3M0SdObDpDQN1B/3717t+dxbVLVkbUHDx40j+moW/3p3icAAAgNSTEt2sqVK01eo82tmtNoE6kO3NSuZm7Xrl0zzx87dqwEM6uv9Zoha03dgAEDzC0m2i6stXWlS5c22+jkwTr1iSZ6mgHfT5s2beT8+fMyePBgkxGXL1/etHe7+wdpWdQ3z3t0q2bS33zzjdnevZ7txYsXpUuXLmYARrZs2cz22ubunYkDAIDglxTTon399dc+97UG77vvvpPly5d7KpM0edRbsLNK7HR5sJIlS8q777573211/rqvvvpKNm3aZPrdLVq0yHRMjI9u3bqZW0x0dGtU9+sm+PHHH5sbAAAIXUk5LZo3HaygrZQ5c+aUUGPVFKvNmxq8+IxQ1W3c22pyF9+kDgAAIDmnRYtKE0ed6cM9TiCUWNXYaR82bcqMLx25oR3/tJYPAADAH/w9LZq3ESNGmCVRtd9dKC49apXY6bwvOhAivnQqFH0OAABAYumUHzp6NGrtnM6pG7UWLyE+/PBDMxp22bJl8vDDD0sosmqK1Un9dN63+FR36jbz5883o2EBAAASy3taNG96XycATgydykSXG9UxAVWrVpVQZZXY6fQg2hyrc8xpO3dsdFSrbqOdD19//XV/HCcAAECSTIs2YsQIM+hT96mjaLVySm+6vZv+7t6P0unc9PfYplkJiaZYHQChKzboMOBy5cqZpE2XztAJit2TF+vQYH1cEz+dYkRXgwAAAPCHpJgWbfz48WbEbatWrXyep9O2DRw40Py+ZcsWn4GgmmCql19+OcYZOwLFekkxHY2io0V0+pCYnqplOtuynrDOJxPTTMqhSJfz0IEj8VnOIzGCdcmnw+83D/QhwMHXl+IaA4DE5yDW6w5poqbt0FpbN2XKFDNDs7vPXb58+Uwbd8eOHRkJCwAAEMx97Lxp4jZs2DD56aefTDu13vT3oUOHktQBQJjTpq2IiAgzXYR2dl+zZk2s22rTma5SpCsXaYuPLhcVkzlz5siDDz5o1vHWn7pWpzdtMtMpL7xvWuEAhJMEJ3YAACTXWp7aOqR9q9q3by87duwwP1u3bm0mwPemC8Jroui+7dy5M0nOEQhWJHYAgCRby1MH2ulanjrITtfyjIl7LU8dyRjbJPi6j0aNGpkRj2XLljU/GzRoYMq96aT4WkvnvmnCCIQTEjsAgN/X8tQlJf25lqfW2EXdZ5MmTaLtc9++fVKgQAHTDPzCCy/IwYMHE/yaQCgisQMABP1anvrc++2zevXqMn36dFm8eLGZdksf0wF9OjUGEC6sR8UCABCItTzvt0/tx+dWoUIFs1pSiRIlZNq0aZ45xxDagnXKpsNBNF0TNXYAgKBfy1P7y9nuM1OmTCbB0+ZZIFyQ2AEAgn4tT619i7rPJUuWxLlPHW2rS07lz58/wa8LhBqaYgEAfqXNnjodiS6krgnZpEmToq3leeLECdMfzs29/qb3Wp6aJOp8dapHjx5Sr149+eCDD6RFixYyb948WbZsmaxdu9azj7/97W/y9NNPS5EiRUxtns6rqjP265JPQLggsQMABP1anlozN3PmTLNQe//+/U3fOZ0vTwdMuB0/flxefPFFM4BDpzmpUaOGbNy40fO6QDggsQMA+F23bt3MLSYxLZgen2XLdYH2qIu0e9PEDwh39LEDAABwCBI7AAAAhyCxAwAAcAgSOwAAAIcgsQMAAHAIEjsAAACHYLoTAIDfsJYnEFjU2AEAADgEiR0AAIBDkNgBAAA4BIkdAACAQ5DYAQAAOASJHQAAgEOQ2AEAADgEiR0AAIBDkNgBAAA4BIkdAACAQ5DYAQAAOASJHQAAgEOQ2AEAADgEiR0AAIBDkNgBAAA4BIkdAACAQ5DYAQAAOASJHQAAgEOQ2AEAADgEiR0AAIBDkNgBAAA4BIkdAACAQ5DYAQAAOASJHQAAgEOQ2AEAADgEiR0AAIBDkNgBAAA4BIkdAACAQ5DYAQAAOASJHQAAgEOQ2AEAADgEiR0AAIBDkNgBQDyMHz9eIiIiJH369FKlShVZs2ZNnNuvWrXKbKfbFy9eXD799FOfx7///nupWrWqZM+eXTJlyiQVK1aUL7/80mebgQMHSooUKXxu+fLlS5LzA+AMJHYAcB+zZs2Snj17Sr9+/WTbtm1St25dadq0qRw9ejTG7Q8dOiTNmjUz2+n2ffv2le7du8ucOXM82+TMmdPsb8OGDfLLL7/IK6+8Ym6LFy/22ddDDz0kp06d8tx27tyZ5OcLIHSlDvQBAECwGzVqlLz22mvSqVMnc3/06NEmAZswYYIMHz482vZaO1ekSBGznSpXrpxs2bJFPvzwQ3nuuedM2eOPP+7znB49esi0adNk7dq10qRJE0956tSpqaUDEG/U2AFAHG7fvi1bt26Vxo0b+5Tr/fXr18f4HK2Fi7q9Jmua3N25cyfa9i6XS5YvXy579+6VevXq+Ty2b98+KVCggGkGfuGFF+TgwYN+OS8AzkSNHQDE4dy5cxIZGSl58+b1Kdf7p0+fjvE5Wh7T9nfv3jX7y58/vym7dOmSFCxYUG7duiWpUqUy/fgaNWrkeU716tVl+vTpUrp0afn9999l6NChUqtWLdm1a5fkypUrSc4XQGijxg4A4kEHLkStZYtadr/to5ZnyZJFtm/fLj///LMMGzZMevXqJStXrvQ8rv34tOm2QoUK0rBhQ5k/f74p1yZbOIu/B+d89tlnpo9njhw5zE2vn82bN/tsc+XKFdN3tGjRopIhQwbzpUGvRYQ2EjsAiEPu3LlNbVrU2rkzZ85Eq5Vz0z5xMW2v/eW8a9pSpkwpJUuWNCNi//rXv0qrVq1i7LPnpqNnNcnT5lk4R1IMztEvCC+++KKsWLHCdA3QPp/aPeDEiROebbTP6NKlS81obB2Uo49rAui9DUIPiR0AxCFt2rSmZkT/AXrT+1rDEZOaNWtG237JkiVmepM0adLE+lpaq6fNsrHRx/bs2eNpyoXzBufoQBsddFO4cGEzOCcm3oNzdHt93quvvmoG57h9/fXX0q1bN/OloWzZsqYG7969e6Yvp7px44ZJBEeMGGH6deoXDJ1eR2sNY3tdhAYSOzhCIJoxvGktizax6bduOI82kX7++ecyefJkk1i9+eabpjala9eu5vE+ffpIhw4dPNtr+ZEjR8zzdHt93hdffCF/+9vffK4ZTf50MMSvv/5q/rlrf7qXXnrJs41ur9eq1tBs2rTJ1OhdvnxZXn755WSOAEJ5cI66fv26eUyn2VHa31P7jurfQG/aJKsjsxG6GDwBxzRjaHJXu3ZtmThxomnG2L17t/lWG1szRufOneWrr76SdevWmW+2DzzwgGcqCnczhtbI6B8+/Varf0i107p2dvemfVImTZokDz/8cLKdM5JXmzZt5Pz58zJ48GAzl1z58uVlwYIFpm+S0jLvZjP9kqGPawI4btw4M6p1zJgxnutLXbt2zVx3x48fN/9MtVZFr0d9LTd9TK9DHXCh12eNGjVk48aNntdF6EvKwTneevfubf526ZdUd/9OrVkeMmSIqfXT58+YMcN8gShVqpRfzxHJi8QOIS8p5hjTZoyoNXjfffedacbwrpm5evWqtGvXzjyuIxbhXJqE6S0mU6dOjVb22GOPyb///e9Y96fXy/2umZkzZybgSBGKkmJwjpt+MdWkTb+wetfQad86bcLVhE/7kVauXFnatm0b53WL4EdTLEJaoJox3P785z9L8+bNPd+CASBYBuco/cL63nvvmT6eUVsVSpQoYZr69QvqsWPHTHcT/TunNc4IXSR2CGlJ0YwRk6jNGO7aFP1mG9coRgAI1OCckSNHmqbWRYsWmcfiGm2tzbcXLlwwrR0tWrRI9HkhcGiKhSMkdzOGfrvVJaD0j2nUzscAYEMH2bRv394kX5q0aZ/dqINzdAoSHVyjtHzs2LHmedpXWFshdHCO/p3y/rvVv39/+eabb6RYsWKeL7qZM2c2N6VJnP7tK1OmjOzfv1/eeust87uuWYzQRWKHkJZczRjLli3zacbQ5l99jn7TdtOaw9WrV5s/uO6VBBD6ivX+76TAwebw+80DfQgI4sE5OphMu6roSGpvAwYMMNOauFc+0aRRB+loNxN9vk6UHdeUPAh+JHZwTDNGy5YtPeV6P7bmBP1G/OOPP8arGUM7t+u32qjNGA0aNDATenrTb7k6svHtt98mqQMQ0ME5hw8fvu9rtm7d2tzgLCR2CHmBaMbQqQL0W3XUfipa4xe1HACA5EJih5AXqGYMAACCDYkdHCEQzRhReS/eDgBAIJDYAQAQIAzOgb8xjx0AAIBDkNgBAAA4BE2xCGk0YwAA8D/U2AEAADgEiR0AAIBDkNgBAAA4BIkdAACAQ5DYAQAAOASJHQAAgEOQ2AEAADgEiR0AAIBDkNgBAAA4BIkdAACAQ5DYAQAAOERQJnbjx4+XiIgISZ8+vVSpUkXWrFkT5/arVq0y2+n2xYsXl08//TTaNnPmzJEHH3xQ0qVLZ37OnTs3Cc8AAAAg+QVdYjdr1izp2bOn9OvXT7Zt2yZ169aVpk2bytGjR2Pc/tChQ9KsWTOznW7ft29f6d69u0nk3DZs2CBt2rSR9u3by44dO8zP1q1by6ZNm5LxzAAAAMIssRs1apS89tpr0qlTJylXrpyMHj1aChcuLBMmTIhxe62dK1KkiNlOt9fnvfrqq/Lhhx96ttHHGjVqJH369JGyZcuanw0aNDDlAAAAThFUid3t27dl69at0rhxY59yvb9+/foYn6O1cVG3b9KkiWzZskXu3LkT5zax7RMAACAUpZYgcu7cOYmMjJS8efP6lOv906dPx/gcLY9p+7t375r95c+fP9ZtYtununXrlrm5Xbp0yfz8448/PAljypQpJVWqVOaY792759nWXa7H4HK5POVapo/FVq77vXfrugSjCxcuJPicvKVO/d9LTrePT3maNGlMbDXGbilSpDDba3mwxuv8+fMJPqeYymO7xmyvvWCNl/c15s/Pkz+uvVC8xgJ57QVzvPz9efLHtRfM8UrOv+XxvfaCPV4pkuhv+ZUrV0y59/UWEomddwC86YlELbvf9lHLbfc5fPhwGTRoULRyHdQRjnLSam0lN/GyxjVmh2vMDvGyQ7yCM16a4GXLli10ErvcuXObDDVqTdqZM2ei1bi55cuXL8btNTPOlStXnNvEtk+l/fB69erlua+ZtNbW6T7jSgiDxeXLl03fxGPHjknWrFkDfThBj3jZIV72iJkd4mWHeDk7Xq7/q7UrUKDAfbcNqsQubdq0ZtqSpUuXSsuWLT3ler9FixYxPqdmzZry448/+pQtWbJEqlataqp+3dvoPt58802fbWrVqhXrsei0KHrzlj17dgk1esGGwkUbLIiXHeJlj5jZIV52iJdz43W/mrqgTOyU1pLpdCSamGlCNmnSJDPVSdeuXT01aSdOnJDp06eb+1o+duxY87zOnTubgRJffPGFzJgxw7PPHj16SL169eSDDz4wCeK8efNk2bJlsnbt2oCdJwAAgL8FXWKn881pJ8TBgwfLqVOnpHz58rJgwQIpWrSoeVzLvOe00z5v+rjWxo0bN85UU44ZM0aee+45zzZaMzdz5kx55513pH///lKiRAkzX1716tUDco4AAABhkdipbt26mVtMpk6dGq3ssccek3//+99x7rNVq1bmFi60GXnAgAHRmpMRM+Jlh3jZI2Z2iJcd4mUnnYPjlcIVn7GzAAAACHpBNUExAAAAEo7EDgAAwCFI7AAAAByCxM7h6EKJpMT1haTGNYak5HLg9cXgCQAAAIcIyulOkHi6cLCurrFp0yYpUqSIWa5N5+8rVaqUI4d3J4Z73WBdNk5/12XtEDeur/jj+koYrrH44xqzd9fB1xc1dg714osvyrp16yRnzpxy/PhxyZgxo7lg69evLx07dpRChQoF+hCDyrlz58wH2y0yMtL85A9kzLi+7HB92eMas8M1ZudFJ19fmtjBWb766itX8eLFXStXrvSUrVq1ytWlSxdX7ty5XaVKlfI8du/ePVe4mz17titFihSuBg0auKZMmeK6deuWz+N37951Xbt2zbVhw4Zoj4Ujri87XF/2uMbscI3Z+crh1xc1dg79JqLf3D755BPzrc37G9u1a9fMt5EzZ87IihUrJGVKxs/oiiTHjh2TkiVLyqpVq+TGjRvSoEEDee2116RJkyZmm4ULF0rbtm3lwoULEu64vuxwfdnjGrPDNWbnRYdfX6F3xLivhx9+WNauXWvW3NULVvtd3L59W27duiWZMmUy6+rqmruLFi2ScHfz5k25fv26PP/88/Lxxx/L3LlzzTIzly9flnbt2pm+FxqvESNGmKXr3H0zwhnXV/xxfSUM11j8cY3Ze9jp11egqwzhf7t27XLlz5/f9cwzz7h2794d7fE7d+64cubM6dq8eXPIVjX7y8WLF10fffSRa/r06T7xOXHihGv58uWud99911W5cmXTzPHzzz+bxyMjI13hjOsr/ri+EoZrLP64xuztcvj1RVOsQ0dHbdiwQf7617/KoUOHpGLFivL000+bm96fPHmyrF+/Xn777bdAH27QuHPnjqRJk8Z8c/OuetdvtsOGDZNPP/3UfIMLd1xfCcP1FX9cYwnDNRY/rjC4vkjsHOzAgQOyePFiWbNmjWzdulX2798v2bNnN9Xx3bp1k0aNGkXrXxCuH/K4yvXDrqOlRo0aZf5Ipk7NLEGK6+v+uL4Sh2vs/rjGEu6AQ68vErsw+JCfPn3aDIXXb3PacbZKlSrmd8T+R9FN+1xMnTpVWrZsKXny5Lnv9k7H9WWH68se15gdrjE7rjC4vkjsHMb97eLtt9+W5557TqpVqxZtm6hV9eHMHa/evXubkWVVq1YN9CEFNa4vO1xf9rjG7HCN2YkMg+srdI8cMdILVkdDjRw50vONo2fPnnLy5EnPNqF8wSZVvHTEmLu6vVevXp6+KHzv8cX1ZYfryx7XmB2uMTupwuH6CvDgDfiRTkKpdITUo48+an5fu3atGQ11/vz5AB9d8CFedoiXHeJlj5jZIV527oZJvEI8LYU397eMKVOmSOvWrc3vEydOlA4dOphlU+CLeNkhXnaIlz1iZod42UkZLvEKdGYJ/3DPs7Nv3z5XlixZzBxGSufiWbZsWYCPLvgQLzvEyw7xskfM7BAvO/fCKF7U2DmEe8HnCRMmSI0aNaRAgQLy3XffmaHbderUCfThBR3iZYd42SFe9oiZHeJlJzKM4kVi5xDueYlmz54tL7/8sqeKWUf9pEuXLsBHF3yIlx3iZYd42SNmdoiXndThFK9AVxnCf1XM69atM9XKN27ccF2+fNmVNWtW144dOwJ9eEGHeNkhXnaIlz1iZod42bkXZvGixs4B3JMt6iSLffr0kfTp08u0adOkWLFiZrFj+CJedoiXHeJlj5jZIV52UoRZvFhXxCGuX78uzz77rNy+fdvcv3nzpvTr1y/QhxW0iJcd4mWHeNkjZnaIl53rYRQvVp4IYe41/+bNm2duH3zwgTzwwAOex0NxjbukRLzsEC87xMseMbNDvOzcDdd4BbotGAkXGRlpfpYvX95MsDhkyJBY+xaAeNkiXnaIlz1iZod42YkM03iR2IUo98V46NAhV9q0aV1ffPGFK1OmTK4NGzb4PD5jxgzXmTNnXOGOeNkhXnaIlz1iZod42bkXxvEisQtRd+7cMT/ffPNN15NPPml+79ixo6tp06auW7dumft79+4131KuXr3qCnfEyw7xskO87BEzO8TLzp0wjheJXYjLkSOH65tvvjG/796921W8eHHXrFmzzP2///3vrjp16viskRfuiJcd4mWHeNkjZnaIl50cYRgvErsQduTIEfPt4/bt256yt956y1WmTBnXzZs3XREREa6ZM2c67qJNKOJlh3jZIV72iJkd4mXnSJjGi1GxIe78+fOSK1cuz/0//vjDLI+SP39+2bhxo1y7di2gxxdsiJcd4mWHeNkjZnaIl53z4RivQGeW8P8IIO0Mqv0GXn/9dZ++BvBFvOwQLzvEyx4xs0O87ESGSbyosXOYe/fumbl7vv76a6lXr56UKFHClKVMySIjMSFedoiXHeJlj5jZIV527oVBvEjsAAAAHMI5KWoY0m8ZMeXl/zcoJiDHFMyIl38QLzvEK3Z8Ju0QL/9wOTxeJHYhRte327lzp5w7d85UHbsXN9alUfRDr7TMXR7uiJf//+ARr/8hXvb4TNohXnZcfCZJ7ELJN998IzVq1JCXXnpJihUrJuXLl5dhw4aZUT+63p2T+gj4A/Gyo/1OvP/gxfYH0v3PJNwRL3t8Ju0QLzt8Jv+LPnYhYtWqVfLyyy/LM888I7Vr15Y0adLIypUrZe7cuXLq1Cnp2rWrDBw4UHLmzBnoQw0KxMvOf/7zHxk1apQ0bNhQqlWrJiVLlvR53P0Hkn8k/0W87PGZtEO87PCZ9BLoYbmIn+eff971yiuveO6717k7deqUa+zYsa5HHnnE9f777wfwCIML8bLTrl07V6pUqVzVq1d3NW/e3NW3b1/XDz/84Dp58qRnm02bNrmqVavmuKkBEoJ42eMzaYd42eEz+T+pvZM8BC/9tpYpUybPfXdVc758+eTPf/6znD17Vj7//HNp1aqVGb4d7oiXnX379sl7770nERERsmjRIlm2bJm5FS1aVKpUqWJqDDReqVOnNjft36NNQeGKeNnjM2mHeNnhM+nFK8lDEPvqq6/MhIrTpk1zXbp0KdrjFy9edBUrVsy1fv16n2934Yp4xd+JEydc7du3d40bN85TdvToUdeECRNczz77rKty5cquWrVqmXjOmzfPccvv2CJeCcNn0g7xij8+k77oYxdCevfubb6J1K9fXx5//HEpV66clC5d2jw2bdo06d69u1y6dCnQhxk0iFf8nTlzxnQo1tqAqN9kd+3aJUOGDDGxvHjxYkCPM1gQr4ThM2mHeMUfn8n/oSk2hPTq1UsyZ84ss2fPlh9++MHzAT9w4IBkzJhR3nrrLc/IIK1qDnfEK/7y5Mljfur3PP2DqD/1j6T+/tBDD8mVK1ekadOmZhviRbwSis+kHeIVf3wm/4cauxCk30b+9a9/yfLly82FmzVrVnnqqafMSCC9WPUtdfIcPbaIV8K443L16lVp0aKFDB482PRTcdryO/5CvOKPz6Qd4pUwrjD9TJLYhQB3tbJ+sCtWrCiFChXyPOb0bx4JQbwSFq+FCxdKpUqVTFMGYke87PGZtEO87PCZ9OXclNVB3H0FdN6iEydOmN/nzZsn165d83xbw/8Qr4TFq3PnznLkyBHz+/z58+XGjRthMZmnLeJlj8+kHeJlh8+kLxK7EPgm4p6BXIe/V69eXfbv3y9/+ctfzIdcUQX/P8TLP/H6f//v/5k+KcrJTRa2iJc9PpN2iJcdPpPRhdfZhrCJEydK69atze/jx4+XBx980NNZFNERLzvEyw7xskfM7BAvO8TLS5TpTxBE3PMS/fHHH67MmTO7/vOf/5j7hQsXds2cOTPARxd8iJcd4mWHeNkjZnaIlx3iFTNq7EKgillnyy5TpowZsr1mzRq5deuWPPnkk4E+vKBDvOwQLzvEyx4xs0O87BCvmJHYhUCH0KlTp0q7du08VczNmjWTbNmyBfjogg/xskO87BAve8TMDvGyQ7xiEUtNHgIsMjLS/Ny9e7crR44crtOnT5v7+vtPP/0U4KMLPsTLDvGyQ7zsETM7xMsO8YodNXZByj2KZ8aMGaaKOW/evGbUj/7UCRbhi3jZIV52iJc9YmaHeNkhXrFjguIQcO7cOcmdO7dZDqV48eIybty4QB9SUCNedoiXHeJlj5jZIV52iJcvErsg417qZPPmzXLs2DF57rnnfB7XeXmyZMkSsOMLNsTLDvGyQ7zsETM7xMsO8bo/mmKDtHpZR/b07dtX1q9f7/N4uF+wUREvO8TLDvGyR8zsEC87xOv+SOyClE60WKNGDXniiSfkvffeM4sYa+VquC2NEl/Eyw7xskO87BEzO8TLDvGKQxwDKxAEPvvsM9ejjz7qGjVqVKAPJSQQLzvEyw7xskfM7BAvO8QrOhK7IHft2jXXpEmTXFmzZnW1atXKdeTIEVN+9+7dQB9aUCJedoiXHeJlj5jZIV52iFd0DJ4IEvo26MLOd+/elYsXL8qRI0ekRIkScvnyZfPYtm3bpE+fPlKrVi0ZPXp02PcjIF52iJcd4mWPmNkhXnaIl4UYkj0EcM27QYMGubJnz+6qUqWKK3369K4yZcq4KlSo4EqVKpUrZ86cZvLFRx55xLVp0yZXOCNedoiXHeJlj5jZIV52iFf8UWMXZA4cOCBbtmwxc/IULVpUDh06JPny5ZMcOXLI+fPnzbeV999/X65fv24mYwzrZVOIlzXiZYd42SNmdoiXHeIVDxZJIILEvn37XHny5HHNnDkz0IcSEoiXHeJlh3jZI2Z2iJedfWEeL6Y7CULew7W9K1TdvxcpUkTSpk0r1apVC8jxBRviZYd42SFe9oiZHeJlh3jFjcQuiCdgVNpZNOrvt27dkk8++UQiIiICcnzBhnjZIV52iJc9YmaHeNkhXnGjj10Qjfbx/ibifeHCF/GyQ7zsEC8AoYy/VkFA/4lcuHDB8w/E/U8kthm0wz0XJ152iJcd4pX0iJkd4mXHFebxosYugG7evClLliyRsWPHSpo0acw/jvLly0ubNm2katWqgT68oEO87BAvO8QLgBOQ2AXQgAEDZO7cuWaSxcKFC0tkZKTs2LFDTp06JY8++qj06tUrbDt/xoR42SFedoiXvRUrVsjt27elUqVKkitXLkmVKlW0bTRBpin7v4iXHeKVMCR2AaTz8IwZM0batm1r7l+5ckUOHjwo69evl5kzZ5pag2nTpknBggUDfahBgXjZIV52iJc9nTvs0qVLUr16dXn22WelQYMGJjHWWf/d/2y//vpruXHjhnTq1EnCHfGyQ7wSKMDTrYStvXv3ukqVKuXauXNnjI8fOHDAVbRoUdc777yT7McWjIiXHeJlh3jZ27hxo6tkyZKur776yvXqq6+6smTJ4sqQIYOrWbNmrsmTJ5uYnjlzxhUREeH69NNPzXMiIyNd4Yp42SFeCUdiFyAXL1501apVy9W0aVPXuXPnPMuleBs7dqzr0UcfDevFjN2Ilx3iZYd42fv+++9dTz/9tGv//v2esh9//NHVpEkTs7yTThCrv6dMmdJ148YNV7gjXnaIV8LRMB0gusxJ//795dixY9KzZ0/ZsGGDWQJF+/W47d2711RFa78C7/JwRLzsEC87xMue9jd8/fXXTRO221NPPSWLFi0ysRs6dKgsW7ZMWrVqJenTpw/7mBEvO8Qr4ehjF0Aa+jlz5sjAgQNlz549UrlyZWncuLH5J6Oj806ePCkff/yxNGnSxFy0MXUcDSfEyw7xskO8Ek/jonFMnTq1uZ89e3bTL7FFixbELAbEyw7xih8SuyCxbt060wlU/4HkzZtX8ufPL127dpWGDRsG+tCCEvGyQ7zsEK/E00EnOhDl8OHDgT6UkEC87BCv2JHYBdj27dvNXFnubyDq/PnzZmg3oiNedoiXHeJlb9euXVKuXLloU05oc9nZs2elaNGiTEnhhXjZIV72iEQAuPsCrFmzxjT76AWpc/X8+uuvppqZfyK+iJcd4mWHeCUuZv369TO/37lzRw4cOODZJmPGjOafrgr3f7rEyw7xShyiEUAfffSRuTj1opw8ebJMnDjRZ0Fj+CJedoiXHeKV+Jjpqh2IHfGyQ7wShsQuANwdPFevXm367bgv4CJFigT4yIIT8bJDvOwQL//E7MMPPyRmsSBedohX4pDYBaiK+csvvzRNPPXq1ZPffvvN9OPRNSnhi3jZIV52iJc9YmaHeNkhXolHYhcgkyZNkueff978Pm7cOKlVq5YUKFAg0IcVtIiXHeJlh3jZI2Z2iJcd4pUIiZjcGJbcs9mfPXvWlTlzZteePXvM/QIFCri+/fbbAB9d8CFedoiXHeJlj5jZIV52iJd/UGMXgCpm/SaiUyqULVtWVqxYYcp1IlT4Il52iJcd4mWPmNkhXnaIl3+Q2CUj99xY33zzjTz77LPm9wkTJsif/vQnyZo1a4CPLvgQLzvEyw7xskfM7BAvO8TLT/xU8weLquaVK1e6rl27Zu5nypTJtXz58kAfVtAiXnaIlx3iZY+Y2SFedohX4rHyRDLQEOt8WJcvX/b51nHt2jVZu3atNGrUiAkWvRAvO8TLDvGyR8zsEC87xMu/iFQycE9y2qpVK8+6dnohZ8qUySwoDl/Eyw7xskO87BEzO8TLDvHyLxK7ZHLhwgX5/fff5bPPPvO5kPXi1W8iVJz6Il52iJcd4mWPmNkhXnaIlx/5oTkX8aTDtXUIt/ew7XPnzrkmT57s+vzzzwN6bMGIeNkhXnaIlz1iZod42SFe/vHfIShIFlrNrIsajx8/Xo4ePSrff/+9HDlyxCxu/Pe//91sc+/ePfoS/B/iZYd42SFe9oiZHeJlh3j5B4MnkpDOvaNr3h06dEi+++472b17tyxevFhOnz5tHh8+fLiZp+fJJ5+UdOnS+XQiDUfEyw7xskO87BEzO8TLDvFKGtTYJcNCxi+99JJcv35dSpUqJVOnTjUX7ciRI6VChQrSrFkzz6SMKpwvWOJlh3jZIV72iJkd4mWHeCURPzXpIg47duxwXb9+3aesU6dOrmLFirkOHjwYsOMKVsTLDvGyQ7zsETM7xMsO8fIvmmKTmbsaWb+BNGzYUMqUKSOffvppoA8raBEvO8TLDvGyR8zsEC87xCvx6IGYzPSC1c6fWgXdpUsXzxBuLUN0xMsO8bJDvOwRMzvEyw7xSjxq7ALs9u3bkjZtWjqExhPxskO87BAve8TMDvGyQ7zskdgBAAA4BE2xAAAADkFiBwAA4BAkdgAAAA5BYgcAAOAQJHYAAAAOQWIHAADgECR2AAAADkFiBwAA4BAkdgAAAOIM/x9KtKLkFNtESQAAAABJRU5ErkJggg==\n"
+      ]
      },
      "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 18
+   "source": [
+    "plot_histogram(samples_for_plot)"
+   ]
   },
   {
    "attachments": {},
@@ -681,30 +680,27 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 19,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-12-05T21:44:34.198581Z",
      "start_time": "2025-12-05T21:44:34.196130Z"
     }
    },
+   "outputs": [],
    "source": [
     "rqaoa = RecursiveMinimumEigenOptimizer(qaoa, min_num_vars=1, min_num_vars_optimizer=exact)"
-   ],
-   "outputs": [],
-   "execution_count": 19
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 20,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-12-05T21:44:36.316566Z",
      "start_time": "2025-12-05T21:44:34.209167Z"
     }
    },
-   "source": [
-    "rqaoa_result = rqaoa.solve(qubo)\n",
-    "print(rqaoa_result.prettyprint())"
-   ],
    "outputs": [
     {
      "name": "stderr",
@@ -724,41 +720,38 @@
      ]
     }
    ],
-   "execution_count": 20
+   "source": [
+    "rqaoa_result = rqaoa.solve(qubo)\n",
+    "print(rqaoa_result.prettyprint())"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 21,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-12-05T21:44:36.347034Z",
      "start_time": "2025-12-05T21:44:36.345279Z"
     }
    },
+   "outputs": [],
    "source": [
     "filtered_samples = get_filtered_samples(\n",
     "    rqaoa_result.samples,\n",
     "    threshold=0.005,\n",
     "    allowed_status=(OptimizationResultStatus.SUCCESS,),\n",
     ")"
-   ],
-   "outputs": [],
-   "execution_count": 21
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 22,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-12-05T21:44:36.356266Z",
      "start_time": "2025-12-05T21:44:36.353320Z"
     }
    },
-   "source": [
-    "samples_for_plot = {\n",
-    "    \" \".join(f\"{rqaoa_result.variables[i].name}={int(v)}\" for i, v in enumerate(s.x)): s.probability\n",
-    "    for s in filtered_samples\n",
-    "}\n",
-    "samples_for_plot"
-   ],
    "outputs": [
     {
      "data": {
@@ -771,33 +764,39 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 22
+   "source": [
+    "samples_for_plot = {\n",
+    "    \" \".join(f\"{rqaoa_result.variables[i].name}={int(v)}\" for i, v in enumerate(s.x)): s.probability\n",
+    "    for s in filtered_samples\n",
+    "}\n",
+    "samples_for_plot"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 23,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-12-05T21:44:36.403039Z",
      "start_time": "2025-12-05T21:44:36.363465Z"
     }
    },
-   "source": [
-    "plot_histogram(samples_for_plot)"
-   ],
    "outputs": [
     {
      "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAnYAAAHWCAYAAAD6oMSKAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy88F64QAAAACXBIWXMAAA9hAAAPYQGoP6dpAAA18klEQVR4nO3dB3SU1br/8SeQUAWkB4RAQASkQ6gCKmJoIiICNpoKh+PhInBRKYIUFblcFJFuoXiUrgI3dEUIEOHiJeBBupQICRBqQiSF5L+e7Zn5JyFlksxkJm++n7Xelbz73fPOnrBW+GXvd+/tlZSUlCQAAADI8wq4uwEAAABwDoIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AAMAiCHYAAAAW4e3uBuQViYmJcvHiRSlRooR4eXm5uzkAACCfSEpKkqioKKlcubIUKJBxnxzBzkEa6qpWreruZgAAgHwqLCxMqlSpkmEdgp2DtKfO9kMtWbKku5sDAADyiVu3bpnOJVsWyQjBzkG24VcNdQQ7AACQ2xx5FIzJEwCQQ7t27ZLu3bub51/0F+/333+f6Wt27twpzZo1kyJFikiNGjVkwYIFudJWANZGsAOAHLp9+7Y0atRI5syZ41D9M2fOSNeuXaVdu3Zy8OBBGTdunAwfPlzWrl3r8rYCsDaGYgEgh7p06WIOR2nvnJ+fn8yaNcuc161bVw4cOCD//d//Lb169XJhSwFYHT12AJDLQkJCJDAwMEVZp06dTLiLj493W7sA5H0EOwDIZREREVKxYsUUZXqekJAgkZGRbmsXgLyPYAcAHjC7TRcgTascALKCYAcAuczX19f02iV3+fJl8fb2lrJly7qtXQDyPoIdAOSy1q1by7Zt21KUbd26VQICAsTHx8dt7QKQ9xHsACCHoqOjJTQ01By25Uz0+/Pnz5vzsWPHSv/+/e31hw4dKufOnZNRo0bJ0aNH5csvv5QvvvhCRo8e7bbPAMAaWO4EAHJIZ7M+/vjj9nMNbGrAgAGyZMkSCQ8Pt4c85e/vLxs3bpSRI0fK3LlzzcLGs2fPZqkTADnmlWR7YheZ7tNWqlQpuXnzJluKAQAAj8wgDMUCAABYBMEOAADAIgh2AAAAFkGwAwAAsAiCHQAAgEUQ7AAAACyCYAcAAGARBDsAAACLINgBAABYBMEOAADAIgh2AAAAFkGwAwAAsAiCHQAAgEV4XLDbtWuXdO/eXSpXrixeXl7y/fffZ/qanTt3SrNmzaRIkSJSo0YNWbBgwT111q5dKw8//LAULlzYfP3uu+9c9AkAAADcw+OC3e3bt6VRo0YyZ84ch+qfOXNGunbtKu3atZODBw/KuHHjZPjw4SbI2YSEhEjfvn2lX79+cujQIfO1T58+sm/fPhd+EgAAgNzllZSUlCQeSnvstGftmWeeSbfO22+/LevXr5ejR4/ay4YOHWoCnAY6paHu1q1bsmnTJnudzp07S+nSpWX58uUOtUVfX6pUKbl586aULFkyR58LAADAUVnJIB7XY5dVGt4CAwNTlHXq1EkOHDgg8fHxGdbZu3dvrrYVAADAlbwlj4uIiJCKFSumKNPzhIQEiYyMlEqVKqVbR8vTExsba47kaVlpWLQFxgIFCkjBggXl7t27kpiYaK9rK9c2JO8Q1TK9ll657b423t5//fNofUfKfXx8TDu0Pcl7PbV+euXptZ3PxGfiM/GZ+Ex8Jj6TeMRnSt1WSwc72w8sOds/YPLytOqkLktu2rRpMnny5HvKt27dKsWKFTPf+/n5SZMmTeTw4cNy/vx5e53atWtLnTp1ZP/+/XLlyhV7eePGjaVatWpmgkhUVJS9vHXr1lKhQgVz738EZ/HDAwAAt/qk9V+hr0SJEtKhQwcJCwuT0NBQ+/Xy5ctLmzZt5OTJk3L8+HF7uaM5IiYmJv8EO19f33t63i5fvmyScdmyZTOsk7oXL7mxY8fKqFGjUvTYVa1a1Qzp2sa3NVGrhg0bSv369e11beUtWrS4568E1b59+zTLzXBx8NZs/RwAAIB76CROZesw0rygq3vY2Mpr1aolNWvWtJc7miNso4b5Ithpb9eGDRtSlGnPV0BAgOkmtdXZtm2bjBw5MkUdTc/p0WVR9EhN72m7b/JgZgtnaXXfOlqe+r4AAMDz+aT6/1uDmS2cOZIXMssRWckHHhfsoqOj5dSpUymWM9HuzDJlypguS+1Ju3Dhgixbtsw+A1aXRtHetcGDB5uJEl988UWK2a5vvPGG6SWbPn269OjRQ9atWyfbt2+X3bt3u+UzAgAAuILHzYrV2aw63qyH0sCm30+cONGch4eHpxiH9vf3l40bN8pPP/1knmGbOnWqzJ49W3r16mWvoz1zK1askMWLF5vuziVLlsjKlSulZcuWbviEAAAA+XAdO0+SW+vYVR8T5LJ7AwAA5zv7YTdxpXy1jh0AAAD+QrADAACwCIIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AAMAiCHYAAAAWQbADAACwCIIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AAMAiCHYAAAAWQbADAACwCIIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AAMAiCHYAAAAWQbADAACwCIIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AAMAiCHYAAAAWQbADAACwCIIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AAMAiCHYAAAAWQbADAACwCIIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AAMAiCHYAAAAWQbADAACwCIIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AACC/B7smTZrI/Pnz5datW85tEQAAAHI32B09elSGDRsmlSpVkoEDB8ru3buzeysAAAC4M9hFRETIxx9/LA8++KAsW7ZMHn30Ualbt6589NFHEhkZ6Yy2AQAAIDeC3f333y/Dhw+XQ4cOyf79+2Xw4MESHh4uo0ePlipVqkjfvn1l69at2b09AAAA3DF5IiAgQBYsWGCC3ZdffiktWrSQ1atXS5cuXcTf31/ef/99cw0AAAB5ZFZs0aJF5emnn5aePXtK5cqVJSkpSc6dOycTJkyQ6tWrm2fyYmJinPmWAAAAcHaw2759uzz//PPywAMPmOHYxMREGTdunBw/flxWrFhhn0Wr4Q4AAADO552TF1+8eNEMvS5evFjOnj1ryp588kkZMmSI9OjRQwoWLGjKatWqJX369JHu3bvLunXrnNNyAAAAOCfYaUjbvHmz3L17VypWrChjxowxEyh0yDU9bdq0kY0bN2b3LQEAAOCKYBcUFJSid87b29uhMKjP3gEAAMCDgt3p06fNjNesqF+/vjkAAADgQZMnpk6dKuvXr8+wjg67vvLKK9l9CwAAAORGsFuyZImEhoZmWOfXX3+VpUuXZvne8+bNM72BRYoUkWbNmklwcHC6dXU7My8vr3uOevXqpWhrWnXu3LmT5bYBAADki3XsUtPg5Mizd8mtXLlSRowYIePHj5eDBw9Ku3btzELH58+fT7P+J598YhY/th1hYWFSpkwZ6d27d4p6JUuWTFFPDw2OAAAAVpGjYKe9XmnRhYk1YOlQbFYnS+hes6+++qq89tprZu/ZWbNmSdWqVc0aeGkpVaqU+Pr62o8DBw7I9evXZdCgQfe0NXk9PQAAAPJtsCtQoIBZm862Pt2kSZPs58kP7aXTZU/+93//1yxa7Ki4uDj55ZdfJDAwMEW5nu/du9ehe3zxxRfSsWNHqVatWory6OhoU6b72D711FOmNzAjsbGxcuvWrRSHio+Ptx+61IvSr2mVJyQkpCjXRZszKtfvAQBA3hL/7//P9f93pf+vJ/9/3laeXl5wJEc4KkvjpO3bt7f30u3atUv8/PzSXLdOw50Oh3bo0MGsbeeoyMhI+7p4yel5REREpq/X4dVNmzbJN998k6K8Tp065jm7Bg0amICmw7ePPPKIHDp0yCyenJZp06bJ5MmT7ynfunWrFCtWzHyvn1931Dh8+HCKoeLatWub99y/f79cuXLFXt64cWMTLvVnFxUVZS9v3bq1VKhQwdwbAADkLRv/vUZviRIlTPbRUcvk8xDKly9v1vI9efKk2ZHLxtEckZXtWL2SdNw0G7T3TnvsJk6cKM6iO1nolmTaO6dhx+b999+Xr776So4dO5bh6zWMzZw509ynUKFC6dbTJN20aVMTVGfPnp1uj50eNhoIdUhYw6c+r5e8B1PDqK3XLXm5Ju3kP14t02vplWsirzWBcAcAQF5ycupfI43a+aWjlpoJbL1uycvTywuZ5QjNIOXKlZObN2/aM4jT17FL3gBn0UbrB0ndO3f58uV7evFS0w+u25v169cvw1Bn+4E1b97cJOf0FC5c2Byp+fj4mCO55MPTyaU3cSS98tT3BQAAns8n1f/fmjP0SC29vJBZjshKPnDprNis0kCmy5ts27YtRbmeaxdmRnbu3CmnTp0yEy8yoyFQu0grVaqU4zYDAAB4Cod77HShYe1K/OCDD0zvmaMLD+trdEKDo0aNGmV63QICAsxw7KJFi8y489ChQ831sWPHyoULF2TZsmUpXqfv0bJlyzR3ttBn5Vq1amWep9PuTB1+1WA3d+5ch9sFAABgmWBnW+T37bffNsFOz10R7Pr27StXr16VKVOmmMkQGtT0oUTbLFctS72mnY45r1271kyKSMuNGzfMnrY6xKvLo+iDijqBoUWLFg63CwAAwNM5PHni3Llz5qtObtAxX9u5I1IvPZIXaU+fhkJHHlzMiepjglx2bwAA4HxnP+wmnpJBvLMbzqwQ1gAAAKzEoyZPAAAAIPsc7rFLb69WR+gCfAAAAPCQYKc7TKS3N2xG9DW2rTQAAADgAcGuf//+2Qp2AAAA8MDlTgAAAOC5mDwBAABgEQQ7AAAAi/C4LcUAAADg4p0nChQoYELa0aNH5aGHHjLnDr2Bl5fcvXtX8jp2ngAAAJbZeeLMmTP2LcWSnwMAAMAzsKUYAACARTB5AgAAIL/12KVnz549snTpUgkNDTVjvzoG3KRJE+nXr5+0bdvWOa0EAACA64Kdzrl4/fXXZdGiReZ7pRMqEhMT5cCBA/L555/LkCFDZN68eexYAQAA4MlDsTNnzpSFCxdK/fr1ZfXq1RIREWH2hNWvq1atknr16pnQ99FHHzm3xQAAAMjZciep6ZInuozJr7/+KsWKFbvnenR0tDRs2FC8vb3lxIkTktex3AkAAPD05U6y3WMXFhYmzz77bJqhTt13333mutYDAACA62U72FWpUkXu3LmTYZ3Y2FhTDwAAAB4c7HRLMX2W7tKlS2leDw8Pl5UrV8prr72Wk/YBAADA2bNiz58/n+L8+eefl5CQELO0yRtvvGGWNqlQoYJcvnxZgoODZfbs2dK6dWvp06ePo28BAACA3NwrNjV9eXrlttfpbNm8jskTAADA0ydPONxj179/f9ajAwAA8GAOB7slS5a4tiUAAADIEfaKBQAAsAiCHQAAQH7fK1ZFRUXJnDlzZPv27XLx4kWzbl1q+lze6dOnc/I2AAAAcGWwu3LlirRp08aENp2hYZuxERcXJ3/++aepU7lyZfHx8cnuWwAAACA3hmInTZpkQt2yZcvk+vXrpmzkyJFy+/Zt2bdvn7Ro0UKqV68uR44cye5bAAAAIDeC3caNG+WJJ56Ql19++Z5lUJo3by6bNm2Ss2fPmgAIAAAADw52umWY7jphU7BgQfsQrCpdurR06dJFVq9enfNWAgAAwHXBTp+ni4+PTxHk/vjjjxR19Nm79PaSBQAAgIcEuxo1apihVhvtvdu2bZtcu3bNnGvv3YYNG8TPz885LQUAAIBrgl1gYKD88MMPEhMTY87/9re/yeXLl6VRo0bSu3dvqV+/vplcMXDgwOy+BQAAAHIj2A0dOlQ+++wze7B79tlnZcaMGRIdHS1r166ViIgIGTVqlLz55pvZfQsAAABkgVdSUlKSONHdu3clMjJSKlSocM9s2bzMtk7fzZs3zbODrlJ9TJDL7g0AAJzv7IfdxFMySI52nkiLzo6tWLGis28LAACATOQ42OmCxOvWrZPQ0FCTJDVRNm7cWHr06CHFixfP6e0BAACQG8Fu+fLlMmzYMLlx44YkH9HVIdj7779f5s6dK88//3xO3gIAAACuDna6lInuOlGkSBF5/fXXpV27dmYIVtet27VrlyxevNhcL1GihHTr5tqxZwAAAORg8kTLli3l+PHjsn//fnnooYfuuX7s2DFTp27duvLzzz9LXsfkCQAA4OmTJ7K93Mmvv/5qhlnTCnWqTp065vrhw4ez+xYAAADIgmwHO02M+hxdRvS6JkwAAAB4cLDr3r27/M///I9Zty4tCQkJEhQUJE8//XRO2gcAAABXBzvdZUInTnTp0kX27duX4po+U6flRYsWlenTp2f3LQAAAOCKWbE1atS4pywuLk4OHjxo9oz18fGRsmXLytWrVyU+Pt5cr1SpkjRr1szsGQsAAAAPCXaJiYn3bBGmYc7Pzy9FmYa51K8DAACABwW7s2fPurYlAAAAcM8zdgAAALDYXrG2GbAnTpywL5xXu3Zt8fZ2yq0BAACQGz12169flyFDhpj16ho0aCBt27aVhg0bmnMt14kUAAAAyB3eOQl1rVu3Nj11OhtW94r19fU1e8UeOHBAPv/8c9m5c6eEhIRImTJlnNtqAAAAOK/HburUqSbUjR07Vs6dOyebNm2SxYsXy8aNG835+PHj5eTJk/Lee+9l9y0AAACQBV5JSUlJkg26rp2/v79Zwy49HTt2lN9//90ceV1WNuDNiepjglx2bwAA4HxnP+wmnpJBst1jd/HiRWnVqlWGdVq2bGnqAQAAwPWyHew0OeqQa0b0utYDAACABwe7xx57TFavXi3bt29P87oO0ep1rQcAAAAPnhX77rvvSlBQkHTq1Em6du0qjz76qFSsWNHMiv3pp5/MZIpixYrJxIkTndtiAAAAODfYPfzww7J161YZOHCgCXh66F6ytrkYNWvWlCVLlki9evWy+xYAAADIghxtD9GmTRs5fvy47NmzRw4ePGhmbehsjSZNmsgjjzxigh4AAAA8PNi98sorZpeJESNGmB0n9AAAAEAenDzxzTffmOfpAAAAkMeD3YMPPijh4eHObQ0AAAByP9i9+uqrZsLEhQsXsv/uAAAAcP8zdj179jRr1ekEirfeekuaN29uljtJa8KEn59fTtsJAAAAVwU73SvWtrzJ8OHD062ndRISErL7NgAAAHB1sOvfvz/LmQAAAFgh2OniwwAAALDA5AlXmjdvnvj7+0uRIkWkWbNmEhwcnG5d3b5Mew5TH8eOHUtRb+3atWa3jMKFC5uv3333XS58EgAAgDyy84TN3r17JTQ0VG7evCmlSpWSxo0bm0kV2bFy5Uqz6LGGO929YuHChdKlSxf57bffMpyEoTtg6K4XNuXLl7d/HxISIn379pWpU6eaSR8a6vr06SO7d++Wli1bZqudAAAAnsYryba5azbs2rVLBg8eLKdOnTLneivbc3e1atWSzz77TNq1a5ele2rQatq0qcyfP99eVrduXXnmmWdk2rRpafbYPf7443L9+nW5//7707ynhjrd7mzTpk32ss6dO0vp0qVl+fLlDrVLX6+hVcNr8gDpbNXHBLns3gAAwPnOfthNXCkrGSTbPXbaCxYYGCjx8fHStWtXE+B0uRPdjUIDn4Yovb5jxw5p1aqVQ/eMi4uTX375RcaMGZOiXO+jvYIZ0f1p79y5Y4ZZ33nnHRP2krd15MiRKep36tRJZs2ale79YmNjzZH8h6r08+qhChQoIAULFpS7d+9KYmKiva6tXGcDJ8/NWqbX0iu33RcAAOQd8f/+/1s7t7y9vU0m0GxgYytPLy9kliOykg+yHezGjRtnGqo9Zql75XRdu507d5rwpPV+/PFHh+4ZGRlpPpwGxOT0PCIiIs3XVKpUSRYtWmSexdMg9tVXX8kTTzxh2tW+fXtTR1+blXsq7R2cPHnyPeVbt26VYsWKme91aFgD5eHDh+X8+fP2OrVr15Y6derI/v375cqVK/ZyHaKuVq2aCb5RUVH28tatW0uFChXMvQEAQN6yceNG87VEiRLSoUMHCQsLM4+oJX88TB9RO3nypHl0zMbRHBETE+P6odj77rtPnnvuuQxnxw4YMMBMWoiOjnbonhcvXpQHHnjA9M5p2LF5//33TWBLPSEiPd27dzehc/369ea8UKFCsnTpUnnhhRfsdb7++muze4b28jnaY1e1alUTPm3doK7osas1gXAHAEBecnJqoEt77DSDlCtXzrVDsTpjVUNYRvS61nOUNlo/SOqetMuXL9/T45YRHfr95z//aT/39fXN8j119qweqfn4+JgjOW2zHqnpP2Ja0itPfV8AAOD5fFL9/63BTI/U0ssLmeWIrOSDbC93osOdmQ2x6vWOHTs6fE/tWdMh1W3btqUo1/OszLI9ePCgGaK10d6/1PfUYc/sztwFAADwRNnusZs5c6ZZjmTQoEHy3nvvpei9u3DhgowfP970kq1ZsyZL9x01apT069dPAgICTCDT5+d03Hno0KHm+tixY839ly1bZs51AkT16tWlXr16ZvKF9tTp8K8eNm+88YZ53m769OnSo0cPWbdunWzfvt0sdwIAAGAVOdpSrEyZMiZg6fNqOilAJwDoEOe5c+fMeHHDhg1NveR0nPmHH35I9766NMnVq1dlypQpEh4eLvXr1zcPJer9lZYlf8BQw9zo0aNN2CtatKgJeEFBQWamro32zK1YscLMlp0wYYLUrFnTrJfHGnYAAMBKsj15Iq2xY4fe0MsrxQOFeQXr2AEAAMuuY5d89gYAAADczyP3igUAAIAbg50+96YL7wIAACCPB7vFixen2MYLAAAAuYuhWAAAAIsg2AEAAFgEwQ4AAMAinBbsdH0VPz8/Z90OAAAA7gp2I0aMkDNnzjjrdgAAAMgihmIBAAAswuGdJ2xr1LVo0UKKFCmSpTXr2rdvn73WAQAAwPnB7rHHHjP7vB49elQeeugh+7kj8uLesAAAAJYNdhMnTjRBrly5cinOAQAAkMeC3aRJkzI8BwAAgHsxeQIAACC/B7vo6Gg5f/68JCQkpChfuXKlvPTSS/Laa69JaGioM9oIAAAAZw7Fpvb222/L0qVL5dKlS+Lt/ddt5s+fL8OGDZOkpCR7yDtw4IDUrl07u28DAAAAV/fYBQcHS8eOHaV48eL2smnTpskDDzxglkJZtWqVmQ07Y8aM7L4FAAAAcqPH7sKFCybY2fz666/yxx9/yH/9139J27ZtTdmaNWtk586d2X0LAAAA5EaP3Z9//imFChWyn+/evdssfxIYGGgvq1GjhgmAAAAA8OBgV6VKFTl8+LD9PCgoSEqXLi0NGjSwl129elXuu+++nLcSAAAArhuK7dKli8ydO1fefPNNs8XY5s2bpV+/fikWLT527Jj4+fll9y0AAACQG8Fu7NixsmHDBpk5c6Y59/X1lcmTJ9uv61Ioe/bskeHDh2f3LQAAAJAbwU6D3JEjR+SHH34w5+3bt5eSJUvar0dFRZnQ16lTp+y+BQAAAHIj2KmiRYvKU089lea1evXqmQMAAAC5gy3FAAAALCJHPXa6ALEuRLx9+3a5ePGixMbG3lNHJ1PYhmsBAADggcHu9u3bZs26n3/+2WwhpgHOtpWYsp0nnyULAAAADxyKfe+99yQkJMTMhI2MjDQhbtKkSRIeHm72iPX395fnnnsuzV48AAAAeFCw+/bbb6VVq1byzjvvSJkyZezlFStWlN69e8tPP/1khmDZKxYAAMDDg52uU6fBzn6jAgVS9M7pzhTdunWTpUuX5ryVAAAAcF2wK168uAlzNqVKlTLDsKnXutMACAAAAA8OdtWqVUsR2urXry8//vijvddOn7nTodhKlSo5p6UAAABwTbB74oknZMeOHZKQkGDOBwwYYIJe69atzf6xbdu2ldDQUOnVq1d23wIAAAC5sdzJ4MGDpWzZsnLlyhXTK/fKK6/IwYMHZd68eSbQKQ11OlMWAAAArueVlHzxOSfQoPf777+boVp9xs4qbt26ZZ4jvHnzZoo9cZ2t+pggl90bAAA439kPu4mnZJAc7TyRlvLly5sDAAAAuYu9YgEAACwi2z12NWrUcKiebil2+vTp7L4NAAAAXB3sEhMT09wHVsd/b9y4Yb7XSRWFChXK7lsAAAAgN4Ld2bNnM7w2atQouXTpkmzbti27bwEAAAB3P2NXvXp1WblypVy/fl3Gjx/vircAAABAbk2e8PHxkSeffFJWrVrlqrcAAABAbs2KjYmJkWvXrrnyLQAAAODqYLdr1y5Zvny51K5d21VvAQAAAGdMnujQoUOa5bp37IULF8wECt3U4p133snuWwAAACA3gt1PP/2UZrkugVK6dGnzfN3IkSOlU6dO2X0LAAAA5NY6dgAAAPAcOd4r9vLly2boVYPeAw88IL6+vs5pGQAAAFw/eSI2NlZmzJghDz30kNldIiAgQFq0aGGCXbly5cwQbEYLGAMAAMADgl1YWJg0b95cxowZI6dOnTLBTkOdlun3urzJJ598YsLe9u3b7a+7ePEia9oBAAB4SrCLj4+Xrl27yr/+9S954YUX5OjRo/LHH39ISEiI/Pzzz+Z7LXvppZdMwOvRo4ecOXPGBMC2bdvKsWPHXPdJAAAA8rksPWO3cOFCOXLkiLz77rvmSIuuW/fVV1+ZYVqt8+KLL5phWQ16zZo1c1a7AQAAkJMeOx1KffDBB2XixImZ1tX162rVqiX79u2TuLg42bx5s3Tr1i0rbwcAAABXBbvffvtNAgMDzVp1mdE6troa7h5//PGsvBUAAABcGeyio6OlVKlSDtcvWbKkeHt7m14+AAAAeFCwq1ChgpkI4ajTp0+b1wAAAMDDgl3r1q1l06ZNEhERkWldrRMUFGRmwwIAAMDDgt3QoUPNcGzPnj0lMjIy3XpXr141dWJiYuRvf/ubM9oJAAAAZy53ohMgBg8eLJ999pnUrVvXhLYOHTpI1apV7YsX//DDD+a6Br8hQ4bIY489lpW3AAAAQG7tFTtv3jwzKeLjjz+WadOmmSO5pKQkKVCggIwePfqeawAAAPCgYFewYEGzT6z21i1evNjsOmF75s7X11fatGkjAwcOZCYsAACApwc7Gw1u77//vnNbAwAAgNyZPAEAAADPRbADAACwCIIdAACARRDsAAAALMIjg50uqeLv7y9FihSRZs2aSXBwcLp1v/32W3nyySelfPnyZhkW3R1jy5YtKeosWbJEvLy87jnu3LmTC58GAAAgnwa7lStXyogRI2T8+PFy8OBBadeunXTp0kXOnz+fZv1du3aZYLdx40b55ZdfzCLK3bt3N69NTkNfeHh4ikODIwAAgOT35U5c5aOPPpJXX31VXnvtNXM+a9Ys0wM3f/78NBc81uvJffDBB7Ju3TrZsGGDNGnSxF6uPXS6zh4AAIBVeVSPXVxcnOl1CwwMTFGu53v37nXoHomJiRIVFSVlypRJUa573FarVk2qVKkiTz311D09egAAAHmdR/XY6f6yd+/elYoVK6Yo13Pb7haZmTlzpty+fVv69OljL6tTp455zq5BgwZy69Yt+eSTT+SRRx6RQ4cOSa1atdK8T2xsrDls9HUqPj7eHEq3TtOdOLTNGihtbOUJCQlmizUbLdNr6ZXb7gsAAPKO+H///62jg97e3iYTaDawsZWnlxcyyxFZyQceFeyS/wCS0w+Vuiwty5cvl0mTJpmh2AoVKtjLW7VqZQ4bDXVNmzaVTz/9VGbPnp3mvXTYd/LkyfeUb926VYoVK2a+9/PzM8O9hw8fTvEMYO3atU2Y3L9/v1y5csVe3rhxY9NrqM8Faq+ijU740PbqvQEAQN6yceNG87VEiRLSoUMHCQsLk9DQUPt1neCpW66ePHlSjh8/bi93NEfExMQ43BavpORdRx4wFKuhafXq1dKzZ097+RtvvGF+QDt37sxw0sWgQYPMa7t165bpew0ePFj++OMP2bRpk8M9dlWrVjW9ijoRw1U9drUmEO4AAMhLTk4NdGmPnWaQcuXKyc2bN+0ZJE/02BUqVMgsb7Jt27YUwU7Pe/TokWFP3SuvvGK+OhLq9IekQVGHZtNTuHBhc6Tm4+NjjuT0h69HavqPmJb0ylPfFwAAeD6fVP9/azDTI7X08kJmOSIr+cCjgp0aNWqU9OvXTwICAswQ5aJFi0z35NChQ831sWPHyoULF2TZsmXmXMNc//79zXNzOtxqexavaNGiUqpUKfO9DqnqNX2eTlOvDr9qsJs7d64bPykAAIBzeVyw69u3r1y9elWmTJli1pqrX7++GbvWZ9OUliUfh164cKHpqvzHP/5hDpsBAwaYCRPqxo0bMmTIEBP6NOzpeLY+59aiRQs3fEIAAADX8Khn7DyZ9vRpKHRkfDsnqo8Jctm9AQCA8539MPPHwHIrg3jUOnYAAADIPoIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AAMAiCHYAAAAWQbADAACwCIIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AAMAiCHYAAAAWQbADAACwCIIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AAMAiCHYAAAAWQbADAACwCIIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AAMAiCHYAAAAWQbADAACwCIIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AAMAiCHYAAAAWQbADAACwCIIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AAMAiCHYAAAAWQbADAACwCIIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AAMAiCHYAAAAWQbADAACwCIIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AAMAiCHYAAAAWQbADAACwCIIdAACARRDsAAAALIJgBwAAYBEeGezmzZsn/v7+UqRIEWnWrJkEBwdnWH/nzp2mntavUaOGLFiw4J46a9eulYcfflgKFy5svn733Xcu/AQAAAC5z+OC3cqVK2XEiBEyfvx4OXjwoLRr1066dOki58+fT7P+mTNnpGvXrqae1h83bpwMHz7cBDmbkJAQ6du3r/Tr108OHTpkvvbp00f27duXi58MAADAtbySkpKSxIO0bNlSmjZtKvPnz7eX1a1bV5555hmZNm3aPfXffvttWb9+vRw9etReNnToUBPgNNApDXW3bt2STZs22et07txZSpcuLcuXL3eoXfr6UqVKyc2bN6VkyZLiKtXHBLns3gAAwPnOfthNXCkrGcSjeuzi4uLkl19+kcDAwBTler537940X6PhLXX9Tp06yYEDByQ+Pj7DOundEwAAIC/yFg8SGRkpd+/elYoVK6Yo1/OIiIg0X6PladVPSEgw96tUqVK6ddK7p4qNjTWHjaZkde3aNXtgLFCggBQsWNC0OTEx0V7XVq5tSN4hqmV6Lb1yvW9ibEymPycAAOA5rl69ar56eXmJt7e3yQSaDWxs5enlhcxyRFRUlCl3ZJDVo4Jd8h9AcvpBUpdlVj91eVbvqcO+kydPvqdcJ3UAAADYlJsluUIDng7J5plgV65cOZNQU/ekXb58+Z4eNxtfX98062syLlu2bIZ10runGjt2rIwaNcp+rklae+v0nhkFQgBI7xmZqlWrSlhYmEuf0wVgPbZeu8qVK2da16OCXaFChcyyJdu2bZOePXvay/W8R48eab6mdevWsmHDhhRlW7dulYCAAPHx8bHX0XuMHDkyRZ02bdqk2xZdFkWP5O6///5sfzYAUBrqCHYAsiqznjqPDHZKe8l0ORINZhrIFi1aZJY60Zmutp60CxcuyLJly8y5ls+ZM8e8bvDgwWaixBdffJFitusbb7wh7du3l+nTp5uAuG7dOtm+fbvs3r3bbZ8TAADA2Twu2OnSJPoQ4pQpUyQ8PFzq168vGzdulGrVqpnrWpZ8TTt95k2va2/c3LlzTTfl7NmzpVevXvY62jO3YsUKeeedd2TChAlSs2ZNs16eLq0CAABgFR63jh0AWJHOstdJWTrqkPoxDwBwFoIdAACARXjUAsUAAADIPoIdAACARRDsAAAALIJgBwC5hEeaAbgawQ4Acgm71gDId+vYAYDV6EbeutvNvn37xM/Pz2yfqOtp1qpVi6VPADgVy50AgIu98MILsmfPHilTpoz88ccfUqxYMRPqHn/8cRk4cKBUqVLF3U0EYBEMxQKAC3399deyf/9++eqrryQ0NFQiIyPln//8pzz44IPyySefSIcOHWTnzp2mLn9nA8gpeuwAwMW9dTr0+umnn8rdu3elYMGC9mu3b982PXaXL1+WHTt2SIEC/K0NIGf4LQIALtSwYUPZvXu32QNbQ11iYqLExcWZLcaKFy9u9rnWPbA3b97s7qYCsACCHQC4UI8ePeTSpUvy2muvydGjR02vXKFCheyTJlq0aGFCX/ny5c05gygAcoKhWABwEf31qkuchISEyH/+53/KmTNnpHHjxtK9e3dz6PmXX34pe/fulRMnTri7uQAsgGAHALng9OnTsmXLFgkODpZffvlFTp06Jffff788+uij8vrrr8uTTz55zzN4AJBVBDsAcHGPXXIRERFmZqyPj49cv35dmjVrZr4HAGcg2AGAi9h64N5++23p1auXeZ4uNZ1MwWxYAM7CbxMAcBENdbdu3ZIZM2bYe+VGjBghFy9etNch1AFwJn6jAICLeuvU559/LgEBAdKkSROz+8Ts2bOlSJEi7m4eAIsi2AGAC9h64hYvXix9+vQx3y9cuFD69+9vthYDAFfwdsldASAfs02a0Jmv586dkxdffNGUBwUFyapVq9zdPAAWRo8dALhoGHb+/PnSqlUrqVy5sqxZs8Ysb9K2bVt3Nw+AhRHsAMDJvL3/GgzR3rkBAwbYh2F1ZqxtxwkAcAWWOwEAFwzD6m4SurvEhQsXJD4+XqpUqWIWJ9a9YwHAVeixAwAnsi1IrAsRjx071syAXbp0qVSvXp1QB8DlmDwBAE4WExMjzz77rMTFxZnzO3fuyPjx493dLAD5AEOxAOAECQkJ5tm6devWmWP69OlSvnx5+3X2gQWQGxiKBQAnrlv3zjvvyJIlS8xkieQ01PF3NABXI9gBQA5pYNNgd/bsWTlx4oTZbeLDDz+Un3/+2X5drVy5Uq5cueLm1gKwMoZiAcBJw7CjRo2So0ePyqZNm2TQoEFy6dIl+f7776VQoUIm8NWpU0eioqKkePHi7m4yAIuixw4AnLRunQ7B6pZh6q233pLjx4+bYKe++OILeeSRR0yosy1gDADORrADACc4f/682WXiueeeM+d169Y1CxJPnDhRYmNjZfXq1TJs2DB3NxOAxTEUCwBOcvXqVSlbtqz9/Nq1a2YLsUqVKpnn7W7fvu3W9gGwPnrsAMBJkoe6xMREKVOmjOmx27Fjh/Tr18/+PB4AuAo9dgDgIhruNMh9/fXX0r59e6lZs6Ypsy2NAgDORrADAACwCP5sBAAX0r+d+fsZQG5hr1gAyCZbYPPy8kq3TkbXAMDZ6LEDgGzQZ+c0tNmCW3o9c/pMHQDkFoIdAGTRv/71LxkyZIh88803curUKVOWOuTZAh0TJQDkJiZPAEAWvfzyy7JixQoJCAiQcuXKSaNGjczixHqua9ap/fv3y3/8x3/Inj177DtTAICrEewAIItatmxpdpXw9/eXzZs3mx48Va1aNWnWrJnZOuzzzz+XkydPmmCnW4gVLFjQ3c0GkA/wZyQAZMHFixeldu3act9990nv3r3NERYWJkFBQbJt2zZZtWqVrF+/XkJCQuz7xAJAbqHHDgCy6PLly+YZOl9f33t6444cOSJTp041PXk3btxwazsB5D/02AFAFlWoUMF81b+LNdTZJkvo9/Xq1ZOoqCjp0qWLffYsz9gByC1M1wKAbLLNgtWvttmv0dHRcufOHRk2bJg5Z1YsgNzEUCwAZIFt6HXTpk3SpEkTMxwLAJ6CPyUBIAtsz9MNHjxYzp07Z77XiRN//vmn+Z4FiQG4E8EOALLQW6d0YWIfHx+z7IkuUPz3v//dPFenGHoF4E78BgKALFq4cKH06dPHfD9v3jx5+OGH7RMqAMCdCHYA4ADbDNjr16/L//3f/0n//v1N+Zo1a2TQoEHubh4AGAQ7AMjCMKzuKKELFOuyJsHBwRIbGyudO3d2d/MAwCDYAUAWJk0sWbJEXnrpJfswbNeuXaVUqVJubh0A/IVVMwEgEzrTVSdFHD16VMLDw+XFF1805Vu2bJG1a9e6u3kAYEePHQBkwjbTdfny5WYYtmLFimZmrH595JFH3N08ALBjgWIAyILIyEgpV66c2TKsRo0aMnfuXHc3CQDsCHYAkMkQ7P79+yUsLEx69eqV4rquXVeiRAm3tQ8AUmMoFgAyGYLV2a/jxo2TvXv3prhOqAPgaQh2AJAJXYy4VatW0qFDB/nggw8kOjrarGvH9mEAPA1DsQDgIF3DbtGiRfLCCy/IyJEj3d0cALgHy50AgIN0mRP9W3j06NFmWHbmzJni5+dnFi+2rXMHAO5Ejx0ApKK/Fr28vCQhIUFu3Lgh586dk5o1a8qtW7fMtYMHD8rYsWOlTZs2MmvWLJ61A+AxCHYAkE6wmzJlinz88ccm1B05ckSqVasmhQoVkt9++83sNqH1tMdOh2dbtGjh7mYDAMEOANJz+vRpOXDggFm3TkPdmTNnxNfXV0qXLi1Xr141PXoffvihxMTEmAWL2VoMgLsR7AAgB06dOmV2n5g9e7b07dvX3c0BkM+x3AkAZCD5kibJ/w62fa9DsTo8y1AsAE9AsAMABxYpVvrcXervY2Nj5dNPPxV/f3+3tA8AkmMoFgDSmDiRvLcuebgDAE/GbysASEZD3fXr1+2Bzhbq0ttlgr+NAXgSeuwAQETu3LkjW7dulTlz5oiPj48JcvXr1zcTIgICAtzdPABwCMEOAETk3Xffle+++86sWVe1alWzm8ShQ4ckPDxcmjdvLqNGjWKCBACPR7ADABGzVp0uWaLbhqmoqCj5/fffzdZhK1asML14S5culQceeMDdTQWAdPGMHYB878SJE1KmTBlp2LChvUy3CWvUqJH8/e9/l8WLF5v16hYsWODWdgJAZgh2APK9ihUrSvny5eWtt94yO0qkHsioUaOGvPnmm7JlyxYzRAsAnopgByDf063AJkyYIGFhYTJixAgJCQkx24QlD3HHjx83W4kVLFiQcAfAY3m7uwEA4Ak6deok0dHRMmnSJGnXrp00bdpUAgMDTejT2bIXL16Ujz/+2N3NBIAMMXkCAFLZs2ePfP311ybQ6TBtpUqVZOjQodKxY0d3Nw0AMkSwA4B/Cw0NNWvXeXv//8EMfeaubNmybm0XADiKZ+wA5Gu25+WCg4PNMKzuNBEXFyfHjh0zkygIdQDyEoIdAIjIzJkzpVixYibYffnll7Jw4UL7nrEAkFcQ7ADkazrLVe3atcs8R2cLeX5+fm5uGQBkHcEOgOT3YdivvvrKDLm2b9/eLFasz9XpHrEAkNcQ7ADke4sWLZLevXub7+fOnStt2rSRypUru7tZAJBlBDsA+ZJOjNBh2MjISDMbtn///qZ8zZo1MnDgQHc3DwCyhWAHIF8Pw2pvnS5xUqdOHdmxY4cp14WJASAvItgByJdsa9V988038uyzz5rv58+fL08//bSULFnSza0DgOxhgWIA+Zb++tPZsM2bNzdLndx3332yfv166dChg7ubBgDZQrADkK/orzxdn+7WrVspeuZu374tu3fvlieffNKsZQcAeRG/vQDkK7ZFh5977jk5e/asPewVL15cOnXq5ObWAUDOEOwA5DvXr1+XS5cuyWeffZYi7GnA0946BjIA5FUEOwD5TunSpWXChAkye/Zss7yJzbVr12Tx4sVmSzEAyIv+mhYGAPmMDsUGBwfLvHnz5Pz58/Ltt9/KuXPnJD4+Xt566y1TJzExkeftAOQpTJ4AkC/o+nS6IPGZM2dML91vv/0mW7ZskYiICHN92rRpZi27zp07S+HChVNMtACAvIIeOwD5goY69fLLL0tMTIzUqlVLlixZYoLdjBkzpEGDBtK1a1f7wsWKUAcgr6HHDkC+cvjwYRPqihYtai8bPHiwbN++XX788Ufx9/d3a/sAICcIdgDyLdtQq/bSdezYUWrXri0LFixwd7MAINt4KhhAvqWhTidI6DDtkCFD7MucaBkA5EX02AHAv8XFxUmhQoWYNAEgzyLYAQAAWARDsQAAABZBsAMAALAIgh0AAIBFEOwAAAAsgmAHAABgEQQ7AAAAiyDYAQAAWATBDgAAwCIIdgAAAGIN/w95g49EN9NycAAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 640x480 with 1 Axes>"
-      ],
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAnYAAAHWCAYAAAD6oMSKAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy88F64QAAAACXBIWXMAAA9hAAAPYQGoP6dpAAA18klEQVR4nO3dB3SU1br/8SeQUAWkB4RAQASkQ6gCKmJoIiICNpoKh+PhInBRKYIUFblcFJFuoXiUrgI3dEUIEOHiJeBBupQICRBqQiSF5L+e7Zn5JyFlksxkJm++n7Xelbz73fPOnrBW+GXvd+/tlZSUlCQAAADI8wq4uwEAAABwDoIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AAMAiCHYAAAAW4e3uBuQViYmJcvHiRSlRooR4eXm5uzkAACCfSEpKkqioKKlcubIUKJBxnxzBzkEa6qpWreruZgAAgHwqLCxMqlSpkmEdgp2DtKfO9kMtWbKku5sDAADyiVu3bpnOJVsWyQjBzkG24VcNdQQ7AACQ2xx5FIzJEwCQQ7t27ZLu3bub51/0F+/333+f6Wt27twpzZo1kyJFikiNGjVkwYIFudJWANZGsAOAHLp9+7Y0atRI5syZ41D9M2fOSNeuXaVdu3Zy8OBBGTdunAwfPlzWrl3r8rYCsDaGYgEgh7p06WIOR2nvnJ+fn8yaNcuc161bVw4cOCD//d//Lb169XJhSwFYHT12AJDLQkJCJDAwMEVZp06dTLiLj493W7sA5H0EOwDIZREREVKxYsUUZXqekJAgkZGRbmsXgLyPYAcAHjC7TRcgTascALKCYAcAuczX19f02iV3+fJl8fb2lrJly7qtXQDyPoIdAOSy1q1by7Zt21KUbd26VQICAsTHx8dt7QKQ9xHsACCHoqOjJTQ01By25Uz0+/Pnz5vzsWPHSv/+/e31hw4dKufOnZNRo0bJ0aNH5csvv5QvvvhCRo8e7bbPAMAaWO4EAHJIZ7M+/vjj9nMNbGrAgAGyZMkSCQ8Pt4c85e/vLxs3bpSRI0fK3LlzzcLGs2fPZqkTADnmlWR7YheZ7tNWqlQpuXnzJluKAQAAj8wgDMUCAABYBMEOAADAIgh2AAAAFkGwAwAAsAiCHQAAgEUQ7AAAACyCYAcAAGARBDsAAACLINgBAABYBMEOAADAIgh2AAAAFkGwAwAAsAiCHQAAgEV4XLDbtWuXdO/eXSpXrixeXl7y/fffZ/qanTt3SrNmzaRIkSJSo0YNWbBgwT111q5dKw8//LAULlzYfP3uu+9c9AkAAADcw+OC3e3bt6VRo0YyZ84ch+qfOXNGunbtKu3atZODBw/KuHHjZPjw4SbI2YSEhEjfvn2lX79+cujQIfO1T58+sm/fPhd+EgAAgNzllZSUlCQeSnvstGftmWeeSbfO22+/LevXr5ejR4/ay4YOHWoCnAY6paHu1q1bsmnTJnudzp07S+nSpWX58uUOtUVfX6pUKbl586aULFkyR58LAADAUVnJIB7XY5dVGt4CAwNTlHXq1EkOHDgg8fHxGdbZu3dvrrYVAADAlbwlj4uIiJCKFSumKNPzhIQEiYyMlEqVKqVbR8vTExsba47kaVlpWLQFxgIFCkjBggXl7t27kpiYaK9rK9c2JO8Q1TK9ll657b423t5//fNofUfKfXx8TDu0Pcl7PbV+euXptZ3PxGfiM/GZ+Ex8Jj6TeMRnSt1WSwc72w8sOds/YPLytOqkLktu2rRpMnny5HvKt27dKsWKFTPf+/n5SZMmTeTw4cNy/vx5e53atWtLnTp1ZP/+/XLlyhV7eePGjaVatWpmgkhUVJS9vHXr1lKhQgVz738EZ/HDAwAAt/qk9V+hr0SJEtKhQwcJCwuT0NBQ+/Xy5ctLmzZt5OTJk3L8+HF7uaM5IiYmJv8EO19f33t63i5fvmyScdmyZTOsk7oXL7mxY8fKqFGjUvTYVa1a1Qzp2sa3NVGrhg0bSv369e11beUtWrS4568E1b59+zTLzXBx8NZs/RwAAIB76CROZesw0rygq3vY2Mpr1aolNWvWtJc7miNso4b5Ithpb9eGDRtSlGnPV0BAgOkmtdXZtm2bjBw5MkUdTc/p0WVR9EhN72m7b/JgZgtnaXXfOlqe+r4AAMDz+aT6/1uDmS2cOZIXMssRWckHHhfsoqOj5dSpUymWM9HuzDJlypguS+1Ju3Dhgixbtsw+A1aXRtHetcGDB5uJEl988UWK2a5vvPGG6SWbPn269OjRQ9atWyfbt2+X3bt3u+UzAgAAuILHzYrV2aw63qyH0sCm30+cONGch4eHpxiH9vf3l40bN8pPP/1knmGbOnWqzJ49W3r16mWvoz1zK1askMWLF5vuziVLlsjKlSulZcuWbviEAAAA+XAdO0+SW+vYVR8T5LJ7AwAA5zv7YTdxpXy1jh0AAAD+QrADAACwCIIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AAMAiCHYAAAAWQbADAACwCIIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AAMAiCHYAAAAWQbADAACwCIIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AAMAiCHYAAAAWQbADAACwCIIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AAMAiCHYAAAAWQbADAACwCIIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AAMAiCHYAAAAWQbADAACwCIIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AAMAiCHYAAAAWQbADAACwCIIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AACC/B7smTZrI/Pnz5datW85tEQAAAHI32B09elSGDRsmlSpVkoEDB8ru3buzeysAAAC4M9hFRETIxx9/LA8++KAsW7ZMHn30Ualbt6589NFHEhkZ6Yy2AQAAIDeC3f333y/Dhw+XQ4cOyf79+2Xw4MESHh4uo0ePlipVqkjfvn1l69at2b09AAAA3DF5IiAgQBYsWGCC3ZdffiktWrSQ1atXS5cuXcTf31/ef/99cw0AAAB5ZFZs0aJF5emnn5aePXtK5cqVJSkpSc6dOycTJkyQ6tWrm2fyYmJinPmWAAAAcHaw2759uzz//PPywAMPmOHYxMREGTdunBw/flxWrFhhn0Wr4Q4AAADO552TF1+8eNEMvS5evFjOnj1ryp588kkZMmSI9OjRQwoWLGjKatWqJX369JHu3bvLunXrnNNyAAAAOCfYaUjbvHmz3L17VypWrChjxowxEyh0yDU9bdq0kY0bN2b3LQEAAOCKYBcUFJSid87b29uhMKjP3gEAAMCDgt3p06fNjNesqF+/vjkAAADgQZMnpk6dKuvXr8+wjg67vvLKK9l9CwAAAORGsFuyZImEhoZmWOfXX3+VpUuXZvne8+bNM72BRYoUkWbNmklwcHC6dXU7My8vr3uOevXqpWhrWnXu3LmT5bYBAADki3XsUtPg5Mizd8mtXLlSRowYIePHj5eDBw9Ku3btzELH58+fT7P+J598YhY/th1hYWFSpkwZ6d27d4p6JUuWTFFPDw2OAAAAVpGjYKe9XmnRhYk1YOlQbFYnS+hes6+++qq89tprZu/ZWbNmSdWqVc0aeGkpVaqU+Pr62o8DBw7I9evXZdCgQfe0NXk9PQAAAPJtsCtQoIBZm862Pt2kSZPs58kP7aXTZU/+93//1yxa7Ki4uDj55ZdfJDAwMEW5nu/du9ehe3zxxRfSsWNHqVatWory6OhoU6b72D711FOmNzAjsbGxcuvWrRSHio+Ptx+61IvSr2mVJyQkpCjXRZszKtfvAQBA3hL/7//P9f93pf+vJ/9/3laeXl5wJEc4KkvjpO3bt7f30u3atUv8/PzSXLdOw50Oh3bo0MGsbeeoyMhI+7p4yel5REREpq/X4dVNmzbJN998k6K8Tp065jm7Bg0amICmw7ePPPKIHDp0yCyenJZp06bJ5MmT7ynfunWrFCtWzHyvn1931Dh8+HCKoeLatWub99y/f79cuXLFXt64cWMTLvVnFxUVZS9v3bq1VKhQwdwbAADkLRv/vUZviRIlTPbRUcvk8xDKly9v1vI9efKk2ZHLxtEckZXtWL2SdNw0G7T3TnvsJk6cKM6iO1nolmTaO6dhx+b999+Xr776So4dO5bh6zWMzZw509ynUKFC6dbTJN20aVMTVGfPnp1uj50eNhoIdUhYw6c+r5e8B1PDqK3XLXm5Ju3kP14t02vplWsirzWBcAcAQF5ycupfI43a+aWjlpoJbL1uycvTywuZ5QjNIOXKlZObN2/aM4jT17FL3gBn0UbrB0ndO3f58uV7evFS0w+u25v169cvw1Bn+4E1b97cJOf0FC5c2Byp+fj4mCO55MPTyaU3cSS98tT3BQAAns8n1f/fmjP0SC29vJBZjshKPnDprNis0kCmy5ts27YtRbmeaxdmRnbu3CmnTp0yEy8yoyFQu0grVaqU4zYDAAB4Cod77HShYe1K/OCDD0zvmaMLD+trdEKDo0aNGmV63QICAsxw7KJFi8y489ChQ831sWPHyoULF2TZsmUpXqfv0bJlyzR3ttBn5Vq1amWep9PuTB1+1WA3d+5ch9sFAABgmWBnW+T37bffNsFOz10R7Pr27StXr16VKVOmmMkQGtT0oUTbLFctS72mnY45r1271kyKSMuNGzfMnrY6xKvLo+iDijqBoUWLFg63CwAAwNM5PHni3Llz5qtObtAxX9u5I1IvPZIXaU+fhkJHHlzMiepjglx2bwAA4HxnP+wmnpJBvLMbzqwQ1gAAAKzEoyZPAAAAIPsc7rFLb69WR+gCfAAAAPCQYKc7TKS3N2xG9DW2rTQAAADgAcGuf//+2Qp2AAAA8MDlTgAAAOC5mDwBAABgEQQ7AAAAi/C4LcUAAADg4p0nChQoYELa0aNH5aGHHjLnDr2Bl5fcvXtX8jp2ngAAAJbZeeLMmTP2LcWSnwMAAMAzsKUYAACARTB5AgAAIL/12KVnz549snTpUgkNDTVjvzoG3KRJE+nXr5+0bdvWOa0EAACA64Kdzrl4/fXXZdGiReZ7pRMqEhMT5cCBA/L555/LkCFDZN68eexYAQAA4MlDsTNnzpSFCxdK/fr1ZfXq1RIREWH2hNWvq1atknr16pnQ99FHHzm3xQAAAMjZciep6ZInuozJr7/+KsWKFbvnenR0tDRs2FC8vb3lxIkTktex3AkAAPD05U6y3WMXFhYmzz77bJqhTt13333mutYDAACA62U72FWpUkXu3LmTYZ3Y2FhTDwAAAB4c7HRLMX2W7tKlS2leDw8Pl5UrV8prr72Wk/YBAADA2bNiz58/n+L8+eefl5CQELO0yRtvvGGWNqlQoYJcvnxZgoODZfbs2dK6dWvp06ePo28BAACA3NwrNjV9eXrlttfpbNm8jskTAADA0ydPONxj179/f9ajAwAA8GAOB7slS5a4tiUAAADIEfaKBQAAsAiCHQAAQH7fK1ZFRUXJnDlzZPv27XLx4kWzbl1q+lze6dOnc/I2AAAAcGWwu3LlirRp08aENp2hYZuxERcXJ3/++aepU7lyZfHx8cnuWwAAACA3hmInTZpkQt2yZcvk+vXrpmzkyJFy+/Zt2bdvn7Ro0UKqV68uR44cye5bAAAAIDeC3caNG+WJJ56Ql19++Z5lUJo3by6bNm2Ss2fPmgAIAAAADw52umWY7jphU7BgQfsQrCpdurR06dJFVq9enfNWAgAAwHXBTp+ni4+PTxHk/vjjjxR19Nm79PaSBQAAgIcEuxo1apihVhvtvdu2bZtcu3bNnGvv3YYNG8TPz885LQUAAIBrgl1gYKD88MMPEhMTY87/9re/yeXLl6VRo0bSu3dvqV+/vplcMXDgwOy+BQAAAHIj2A0dOlQ+++wze7B79tlnZcaMGRIdHS1r166ViIgIGTVqlLz55pvZfQsAAABkgVdSUlKSONHdu3clMjJSKlSocM9s2bzMtk7fzZs3zbODrlJ9TJDL7g0AAJzv7IfdxFMySI52nkiLzo6tWLGis28LAACATOQ42OmCxOvWrZPQ0FCTJDVRNm7cWHr06CHFixfP6e0BAACQG8Fu+fLlMmzYMLlx44YkH9HVIdj7779f5s6dK88//3xO3gIAAACuDna6lInuOlGkSBF5/fXXpV27dmYIVtet27VrlyxevNhcL1GihHTr5tqxZwAAAORg8kTLli3l+PHjsn//fnnooYfuuX7s2DFTp27duvLzzz9LXsfkCQAA4OmTJ7K93Mmvv/5qhlnTCnWqTp065vrhw4ez+xYAAADIgmwHO02M+hxdRvS6JkwAAAB4cLDr3r27/M///I9Zty4tCQkJEhQUJE8//XRO2gcAAABXBzvdZUInTnTp0kX27duX4po+U6flRYsWlenTp2f3LQAAAOCKWbE1atS4pywuLk4OHjxo9oz18fGRsmXLytWrVyU+Pt5cr1SpkjRr1szsGQsAAAAPCXaJiYn3bBGmYc7Pzy9FmYa51K8DAACABwW7s2fPurYlAAAAcM8zdgAAALDYXrG2GbAnTpywL5xXu3Zt8fZ2yq0BAACQGz12169flyFDhpj16ho0aCBt27aVhg0bmnMt14kUAAAAyB3eOQl1rVu3Nj11OhtW94r19fU1e8UeOHBAPv/8c9m5c6eEhIRImTJlnNtqAAAAOK/HburUqSbUjR07Vs6dOyebNm2SxYsXy8aNG835+PHj5eTJk/Lee+9l9y0AAACQBV5JSUlJkg26rp2/v79Zwy49HTt2lN9//90ceV1WNuDNiepjglx2bwAA4HxnP+wmnpJBst1jd/HiRWnVqlWGdVq2bGnqAQAAwPWyHew0OeqQa0b0utYDAACABwe7xx57TFavXi3bt29P87oO0ep1rQcAAAAPnhX77rvvSlBQkHTq1Em6du0qjz76qFSsWNHMiv3pp5/MZIpixYrJxIkTndtiAAAAODfYPfzww7J161YZOHCgCXh66F6ytrkYNWvWlCVLlki9evWy+xYAAADIghxtD9GmTRs5fvy47NmzRw4ePGhmbehsjSZNmsgjjzxigh4AAAA8PNi98sorZpeJESNGmB0n9AAAAEAenDzxzTffmOfpAAAAkMeD3YMPPijh4eHObQ0AAAByP9i9+uqrZsLEhQsXsv/uAAAAcP8zdj179jRr1ekEirfeekuaN29uljtJa8KEn59fTtsJAAAAVwU73SvWtrzJ8OHD062ndRISErL7NgAAAHB1sOvfvz/LmQAAAFgh2OniwwAAALDA5AlXmjdvnvj7+0uRIkWkWbNmEhwcnG5d3b5Mew5TH8eOHUtRb+3atWa3jMKFC5uv3333XS58EgAAgDyy84TN3r17JTQ0VG7evCmlSpWSxo0bm0kV2bFy5Uqz6LGGO929YuHChdKlSxf57bffMpyEoTtg6K4XNuXLl7d/HxISIn379pWpU6eaSR8a6vr06SO7d++Wli1bZqudAAAAnsYryba5azbs2rVLBg8eLKdOnTLneivbc3e1atWSzz77TNq1a5ele2rQatq0qcyfP99eVrduXXnmmWdk2rRpafbYPf7443L9+nW5//7707ynhjrd7mzTpk32ss6dO0vp0qVl+fLlDrVLX6+hVcNr8gDpbNXHBLns3gAAwPnOfthNXCkrGSTbPXbaCxYYGCjx8fHStWtXE+B0uRPdjUIDn4Yovb5jxw5p1aqVQ/eMi4uTX375RcaMGZOiXO+jvYIZ0f1p79y5Y4ZZ33nnHRP2krd15MiRKep36tRJZs2ale79YmNjzZH8h6r08+qhChQoIAULFpS7d+9KYmKiva6tXGcDJ8/NWqbX0iu33RcAAOQd8f/+/1s7t7y9vU0m0GxgYytPLy9kliOykg+yHezGjRtnGqo9Zql75XRdu507d5rwpPV+/PFHh+4ZGRlpPpwGxOT0PCIiIs3XVKpUSRYtWmSexdMg9tVXX8kTTzxh2tW+fXtTR1+blXsq7R2cPHnyPeVbt26VYsWKme91aFgD5eHDh+X8+fP2OrVr15Y6derI/v375cqVK/ZyHaKuVq2aCb5RUVH28tatW0uFChXMvQEAQN6yceNG87VEiRLSoUMHCQsLM4+oJX88TB9RO3nypHl0zMbRHBETE+P6odj77rtPnnvuuQxnxw4YMMBMWoiOjnbonhcvXpQHHnjA9M5p2LF5//33TWBLPSEiPd27dzehc/369ea8UKFCsnTpUnnhhRfsdb7++muze4b28jnaY1e1alUTPm3doK7osas1gXAHAEBecnJqoEt77DSDlCtXzrVDsTpjVUNYRvS61nOUNlo/SOqetMuXL9/T45YRHfr95z//aT/39fXN8j119qweqfn4+JgjOW2zHqnpP2Ja0itPfV8AAOD5fFL9/63BTI/U0ssLmeWIrOSDbC93osOdmQ2x6vWOHTs6fE/tWdMh1W3btqUo1/OszLI9ePCgGaK10d6/1PfUYc/sztwFAADwRNnusZs5c6ZZjmTQoEHy3nvvpei9u3DhgowfP970kq1ZsyZL9x01apT069dPAgICTCDT5+d03Hno0KHm+tixY839ly1bZs51AkT16tWlXr16ZvKF9tTp8K8eNm+88YZ53m769OnSo0cPWbdunWzfvt0sdwIAAGAVOdpSrEyZMiZg6fNqOilAJwDoEOe5c+fMeHHDhg1NveR0nPmHH35I9766NMnVq1dlypQpEh4eLvXr1zcPJer9lZYlf8BQw9zo0aNN2CtatKgJeEFBQWamro32zK1YscLMlp0wYYLUrFnTrJfHGnYAAMBKsj15Iq2xY4fe0MsrxQOFeQXr2AEAAMuuY5d89gYAAADczyP3igUAAIAbg50+96YL7wIAACCPB7vFixen2MYLAAAAuYuhWAAAAIsg2AEAAFgEwQ4AAMAinBbsdH0VPz8/Z90OAAAA7gp2I0aMkDNnzjjrdgAAAMgihmIBAAAswuGdJ2xr1LVo0UKKFCmSpTXr2rdvn73WAQAAwPnB7rHHHjP7vB49elQeeugh+7kj8uLesAAAAJYNdhMnTjRBrly5cinOAQAAkMeC3aRJkzI8BwAAgHsxeQIAACC/B7vo6Gg5f/68JCQkpChfuXKlvPTSS/Laa69JaGioM9oIAAAAZw7Fpvb222/L0qVL5dKlS+Lt/ddt5s+fL8OGDZOkpCR7yDtw4IDUrl07u28DAAAAV/fYBQcHS8eOHaV48eL2smnTpskDDzxglkJZtWqVmQ07Y8aM7L4FAAAAcqPH7sKFCybY2fz666/yxx9/yH/9139J27ZtTdmaNWtk586d2X0LAAAA5EaP3Z9//imFChWyn+/evdssfxIYGGgvq1GjhgmAAAAA8OBgV6VKFTl8+LD9PCgoSEqXLi0NGjSwl129elXuu+++nLcSAAAArhuK7dKli8ydO1fefPNNs8XY5s2bpV+/fikWLT527Jj4+fll9y0AAACQG8Fu7NixsmHDBpk5c6Y59/X1lcmTJ9uv61Ioe/bskeHDh2f3LQAAAJAbwU6D3JEjR+SHH34w5+3bt5eSJUvar0dFRZnQ16lTp+y+BQAAAHIj2KmiRYvKU089lea1evXqmQMAAAC5gy3FAAAALCJHPXa6ALEuRLx9+3a5ePGixMbG3lNHJ1PYhmsBAADggcHu9u3bZs26n3/+2WwhpgHOtpWYsp0nnyULAAAADxyKfe+99yQkJMTMhI2MjDQhbtKkSRIeHm72iPX395fnnnsuzV48AAAAeFCw+/bbb6VVq1byzjvvSJkyZezlFStWlN69e8tPP/1khmDZKxYAAMDDg52uU6fBzn6jAgVS9M7pzhTdunWTpUuX5ryVAAAAcF2wK168uAlzNqVKlTLDsKnXutMACAAAAA8OdtWqVUsR2urXry8//vijvddOn7nTodhKlSo5p6UAAABwTbB74oknZMeOHZKQkGDOBwwYYIJe69atzf6xbdu2ldDQUOnVq1d23wIAAAC5sdzJ4MGDpWzZsnLlyhXTK/fKK6/IwYMHZd68eSbQKQ11OlMWAAAArueVlHzxOSfQoPf777+boVp9xs4qbt26ZZ4jvHnzZoo9cZ2t+pggl90bAAA439kPu4mnZJAc7TyRlvLly5sDAAAAuYu9YgEAACwi2z12NWrUcKiebil2+vTp7L4NAAAAXB3sEhMT09wHVsd/b9y4Yb7XSRWFChXK7lsAAAAgN4Ld2bNnM7w2atQouXTpkmzbti27bwEAAAB3P2NXvXp1WblypVy/fl3Gjx/vircAAABAbk2e8PHxkSeffFJWrVrlqrcAAABAbs2KjYmJkWvXrrnyLQAAAODqYLdr1y5Zvny51K5d21VvAQAAAGdMnujQoUOa5bp37IULF8wECt3U4p133snuWwAAACA3gt1PP/2UZrkugVK6dGnzfN3IkSOlU6dO2X0LAAAA5NY6dgAAAPAcOd4r9vLly2boVYPeAw88IL6+vs5pGQAAAFw/eSI2NlZmzJghDz30kNldIiAgQFq0aGGCXbly5cwQbEYLGAMAAMADgl1YWJg0b95cxowZI6dOnTLBTkOdlun3urzJJ598YsLe9u3b7a+7ePEia9oBAAB4SrCLj4+Xrl27yr/+9S954YUX5OjRo/LHH39ISEiI/Pzzz+Z7LXvppZdMwOvRo4ecOXPGBMC2bdvKsWPHXPdJAAAA8rksPWO3cOFCOXLkiLz77rvmSIuuW/fVV1+ZYVqt8+KLL5phWQ16zZo1c1a7AQAAkJMeOx1KffDBB2XixImZ1tX162rVqiX79u2TuLg42bx5s3Tr1i0rbwcAAABXBbvffvtNAgMDzVp1mdE6troa7h5//PGsvBUAAABcGeyio6OlVKlSDtcvWbKkeHt7m14+AAAAeFCwq1ChgpkI4ajTp0+b1wAAAMDDgl3r1q1l06ZNEhERkWldrRMUFGRmwwIAAMDDgt3QoUPNcGzPnj0lMjIy3XpXr141dWJiYuRvf/ubM9oJAAAAZy53ohMgBg8eLJ999pnUrVvXhLYOHTpI1apV7YsX//DDD+a6Br8hQ4bIY489lpW3AAAAQG7tFTtv3jwzKeLjjz+WadOmmSO5pKQkKVCggIwePfqeawAAAPCgYFewYEGzT6z21i1evNjsOmF75s7X11fatGkjAwcOZCYsAACApwc7Gw1u77//vnNbAwAAgNyZPAEAAADPRbADAACwCIIdAACARRDsAAAALMIjg50uqeLv7y9FihSRZs2aSXBwcLp1v/32W3nyySelfPnyZhkW3R1jy5YtKeosWbJEvLy87jnu3LmTC58GAAAgnwa7lStXyogRI2T8+PFy8OBBadeunXTp0kXOnz+fZv1du3aZYLdx40b55ZdfzCLK3bt3N69NTkNfeHh4ikODIwAAgOT35U5c5aOPPpJXX31VXnvtNXM+a9Ys0wM3f/78NBc81uvJffDBB7Ju3TrZsGGDNGnSxF6uPXS6zh4AAIBVeVSPXVxcnOl1CwwMTFGu53v37nXoHomJiRIVFSVlypRJUa573FarVk2qVKkiTz311D09egAAAHmdR/XY6f6yd+/elYoVK6Yo13Pb7haZmTlzpty+fVv69OljL6tTp455zq5BgwZy69Yt+eSTT+SRRx6RQ4cOSa1atdK8T2xsrDls9HUqPj7eHEq3TtOdOLTNGihtbOUJCQlmizUbLdNr6ZXb7gsAAPKO+H///62jg97e3iYTaDawsZWnlxcyyxFZyQceFeyS/wCS0w+Vuiwty5cvl0mTJpmh2AoVKtjLW7VqZQ4bDXVNmzaVTz/9VGbPnp3mvXTYd/LkyfeUb926VYoVK2a+9/PzM8O9hw8fTvEMYO3atU2Y3L9/v1y5csVe3rhxY9NrqM8Faq+ijU740PbqvQEAQN6yceNG87VEiRLSoUMHCQsLk9DQUPt1neCpW66ePHlSjh8/bi93NEfExMQ43BavpORdRx4wFKuhafXq1dKzZ097+RtvvGF+QDt37sxw0sWgQYPMa7t165bpew0ePFj++OMP2bRpk8M9dlWrVjW9ijoRw1U9drUmEO4AAMhLTk4NdGmPnWaQcuXKyc2bN+0ZJE/02BUqVMgsb7Jt27YUwU7Pe/TokWFP3SuvvGK+OhLq9IekQVGHZtNTuHBhc6Tm4+NjjuT0h69HavqPmJb0ylPfFwAAeD6fVP9/azDTI7X08kJmOSIr+cCjgp0aNWqU9OvXTwICAswQ5aJFi0z35NChQ831sWPHyoULF2TZsmXmXMNc//79zXNzOtxqexavaNGiUqpUKfO9DqnqNX2eTlOvDr9qsJs7d64bPykAAIBzeVyw69u3r1y9elWmTJli1pqrX7++GbvWZ9OUliUfh164cKHpqvzHP/5hDpsBAwaYCRPqxo0bMmTIEBP6NOzpeLY+59aiRQs3fEIAAADX8Khn7DyZ9vRpKHRkfDsnqo8Jctm9AQCA8539MPPHwHIrg3jUOnYAAADIPoIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AAMAiCHYAAAAWQbADAACwCIIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AAMAiCHYAAAAWQbADAACwCIIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AAMAiCHYAAAAWQbADAACwCIIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AAMAiCHYAAAAWQbADAACwCIIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AAMAiCHYAAAAWQbADAACwCIIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AAMAiCHYAAAAWQbADAACwCIIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AAMAiCHYAAAAWQbADAACwCIIdAACARRDsAAAALIJgBwAAYBEEOwAAAIsg2AEAAFgEwQ4AAMAiCHYAAAAWQbADAACwCIIdAACARRDsAAAALIJgBwAAYBEeGezmzZsn/v7+UqRIEWnWrJkEBwdnWH/nzp2mntavUaOGLFiw4J46a9eulYcfflgKFy5svn733Xcu/AQAAAC5z+OC3cqVK2XEiBEyfvx4OXjwoLRr1066dOki58+fT7P+mTNnpGvXrqae1h83bpwMHz7cBDmbkJAQ6du3r/Tr108OHTpkvvbp00f27duXi58MAADAtbySkpKSxIO0bNlSmjZtKvPnz7eX1a1bV5555hmZNm3aPfXffvttWb9+vRw9etReNnToUBPgNNApDXW3bt2STZs22et07txZSpcuLcuXL3eoXfr6UqVKyc2bN6VkyZLiKtXHBLns3gAAwPnOfthNXCkrGcSjeuzi4uLkl19+kcDAwBTler537940X6PhLXX9Tp06yYEDByQ+Pj7DOundEwAAIC/yFg8SGRkpd+/elYoVK6Yo1/OIiIg0X6PladVPSEgw96tUqVK6ddK7p4qNjTWHjaZkde3aNXtgLFCggBQsWNC0OTEx0V7XVq5tSN4hqmV6Lb1yvW9ibEymPycAAOA5rl69ar56eXmJt7e3yQSaDWxs5enlhcxyRFRUlCl3ZJDVo4Jd8h9AcvpBUpdlVj91eVbvqcO+kydPvqdcJ3UAAADYlJsluUIDng7J5plgV65cOZNQU/ekXb58+Z4eNxtfX98062syLlu2bIZ10runGjt2rIwaNcp+rklae+v0nhkFQgBI7xmZqlWrSlhYmEuf0wVgPbZeu8qVK2da16OCXaFChcyyJdu2bZOePXvay/W8R48eab6mdevWsmHDhhRlW7dulYCAAPHx8bHX0XuMHDkyRZ02bdqk2xZdFkWP5O6///5sfzYAUBrqCHYAsiqznjqPDHZKe8l0ORINZhrIFi1aZJY60Zmutp60CxcuyLJly8y5ls+ZM8e8bvDgwWaixBdffJFitusbb7wh7du3l+nTp5uAuG7dOtm+fbvs3r3bbZ8TAADA2Twu2OnSJPoQ4pQpUyQ8PFzq168vGzdulGrVqpnrWpZ8TTt95k2va2/c3LlzTTfl7NmzpVevXvY62jO3YsUKeeedd2TChAlSs2ZNs16eLq0CAABgFR63jh0AWJHOstdJWTrqkPoxDwBwFoIdAACARXjUAsUAAADIPoIdAACARRDsAAAALIJgBwC5hEeaAbgawQ4Acgm71gDId+vYAYDV6EbeutvNvn37xM/Pz2yfqOtp1qpVi6VPADgVy50AgIu98MILsmfPHilTpoz88ccfUqxYMRPqHn/8cRk4cKBUqVLF3U0EYBEMxQKAC3399deyf/9++eqrryQ0NFQiIyPln//8pzz44IPyySefSIcOHWTnzp2mLn9nA8gpeuwAwMW9dTr0+umnn8rdu3elYMGC9mu3b982PXaXL1+WHTt2SIEC/K0NIGf4LQIALtSwYUPZvXu32QNbQ11iYqLExcWZLcaKFy9u9rnWPbA3b97s7qYCsACCHQC4UI8ePeTSpUvy2muvydGjR02vXKFCheyTJlq0aGFCX/ny5c05gygAcoKhWABwEf31qkuchISEyH/+53/KmTNnpHHjxtK9e3dz6PmXX34pe/fulRMnTri7uQAsgGAHALng9OnTsmXLFgkODpZffvlFTp06Jffff788+uij8vrrr8uTTz55zzN4AJBVBDsAcHGPXXIRERFmZqyPj49cv35dmjVrZr4HAGcg2AGAi9h64N5++23p1auXeZ4uNZ1MwWxYAM7CbxMAcBENdbdu3ZIZM2bYe+VGjBghFy9etNch1AFwJn6jAICLeuvU559/LgEBAdKkSROz+8Ts2bOlSJEi7m4eAIsi2AGAC9h64hYvXix9+vQx3y9cuFD69+9vthYDAFfwdsldASAfs02a0Jmv586dkxdffNGUBwUFyapVq9zdPAAWRo8dALhoGHb+/PnSqlUrqVy5sqxZs8Ysb9K2bVt3Nw+AhRHsAMDJvL3/GgzR3rkBAwbYh2F1ZqxtxwkAcAWWOwEAFwzD6m4SurvEhQsXJD4+XqpUqWIWJ9a9YwHAVeixAwAnsi1IrAsRjx071syAXbp0qVSvXp1QB8DlmDwBAE4WExMjzz77rMTFxZnzO3fuyPjx493dLAD5AEOxAOAECQkJ5tm6devWmWP69OlSvnx5+3X2gQWQGxiKBQAnrlv3zjvvyJIlS8xkieQ01PF3NABXI9gBQA5pYNNgd/bsWTlx4oTZbeLDDz+Un3/+2X5drVy5Uq5cueLm1gKwMoZiAcBJw7CjRo2So0ePyqZNm2TQoEFy6dIl+f7776VQoUIm8NWpU0eioqKkePHi7m4yAIuixw4AnLRunQ7B6pZh6q233pLjx4+bYKe++OILeeSRR0yosy1gDADORrADACc4f/682WXiueeeM+d169Y1CxJPnDhRYmNjZfXq1TJs2DB3NxOAxTEUCwBOcvXqVSlbtqz9/Nq1a2YLsUqVKpnn7W7fvu3W9gGwPnrsAMBJkoe6xMREKVOmjOmx27Fjh/Tr18/+PB4AuAo9dgDgIhruNMh9/fXX0r59e6lZs6Ypsy2NAgDORrADAACwCP5sBAAX0r+d+fsZQG5hr1gAyCZbYPPy8kq3TkbXAMDZ6LEDgGzQZ+c0tNmCW3o9c/pMHQDkFoIdAGTRv/71LxkyZIh88803curUKVOWOuTZAh0TJQDkJiZPAEAWvfzyy7JixQoJCAiQcuXKSaNGjczixHqua9ap/fv3y3/8x3/Inj177DtTAICrEewAIItatmxpdpXw9/eXzZs3mx48Va1aNWnWrJnZOuzzzz+XkydPmmCnW4gVLFjQ3c0GkA/wZyQAZMHFixeldu3act9990nv3r3NERYWJkFBQbJt2zZZtWqVrF+/XkJCQuz7xAJAbqHHDgCy6PLly+YZOl9f33t6444cOSJTp041PXk3btxwazsB5D/02AFAFlWoUMF81b+LNdTZJkvo9/Xq1ZOoqCjp0qWLffYsz9gByC1M1wKAbLLNgtWvttmv0dHRcufOHRk2bJg5Z1YsgNzEUCwAZIFt6HXTpk3SpEkTMxwLAJ6CPyUBIAtsz9MNHjxYzp07Z77XiRN//vmn+Z4FiQG4E8EOALLQW6d0YWIfHx+z7IkuUPz3v//dPFenGHoF4E78BgKALFq4cKH06dPHfD9v3jx5+OGH7RMqAMCdCHYA4ADbDNjr16/L//3f/0n//v1N+Zo1a2TQoEHubh4AGAQ7AMjCMKzuKKELFOuyJsHBwRIbGyudO3d2d/MAwCDYAUAWJk0sWbJEXnrpJfswbNeuXaVUqVJubh0A/IVVMwEgEzrTVSdFHD16VMLDw+XFF1805Vu2bJG1a9e6u3kAYEePHQBkwjbTdfny5WYYtmLFimZmrH595JFH3N08ALBjgWIAyILIyEgpV66c2TKsRo0aMnfuXHc3CQDsCHYAkMkQ7P79+yUsLEx69eqV4rquXVeiRAm3tQ8AUmMoFgAyGYLV2a/jxo2TvXv3prhOqAPgaQh2AJAJXYy4VatW0qFDB/nggw8kOjrarGvH9mEAPA1DsQDgIF3DbtGiRfLCCy/IyJEj3d0cALgHy50AgIN0mRP9W3j06NFmWHbmzJni5+dnFi+2rXMHAO5Ejx0ApKK/Fr28vCQhIUFu3Lgh586dk5o1a8qtW7fMtYMHD8rYsWOlTZs2MmvWLJ61A+AxCHYAkE6wmzJlinz88ccm1B05ckSqVasmhQoVkt9++83sNqH1tMdOh2dbtGjh7mYDAMEOANJz+vRpOXDggFm3TkPdmTNnxNfXV0qXLi1Xr141PXoffvihxMTEmAWL2VoMgLsR7AAgB06dOmV2n5g9e7b07dvX3c0BkM+x3AkAZCD5kibJ/w62fa9DsTo8y1AsAE9AsAMABxYpVvrcXervY2Nj5dNPPxV/f3+3tA8AkmMoFgDSmDiRvLcuebgDAE/GbysASEZD3fXr1+2Bzhbq0ttlgr+NAXgSeuwAQETu3LkjW7dulTlz5oiPj48JcvXr1zcTIgICAtzdPABwCMEOAETk3Xffle+++86sWVe1alWzm8ShQ4ckPDxcmjdvLqNGjWKCBACPR7ADABGzVp0uWaLbhqmoqCj5/fffzdZhK1asML14S5culQceeMDdTQWAdPGMHYB878SJE1KmTBlp2LChvUy3CWvUqJH8/e9/l8WLF5v16hYsWODWdgJAZgh2APK9ihUrSvny5eWtt94yO0qkHsioUaOGvPnmm7JlyxYzRAsAnopgByDf063AJkyYIGFhYTJixAgJCQkx24QlD3HHjx83W4kVLFiQcAfAY3m7uwEA4Ak6deok0dHRMmnSJGnXrp00bdpUAgMDTejT2bIXL16Ujz/+2N3NBIAMMXkCAFLZs2ePfP311ybQ6TBtpUqVZOjQodKxY0d3Nw0AMkSwA4B/Cw0NNWvXeXv//8EMfeaubNmybm0XADiKZ+wA5Gu25+WCg4PNMKzuNBEXFyfHjh0zkygIdQDyEoIdAIjIzJkzpVixYibYffnll7Jw4UL7nrEAkFcQ7ADkazrLVe3atcs8R2cLeX5+fm5uGQBkHcEOgOT3YdivvvrKDLm2b9/eLFasz9XpHrEAkNcQ7ADke4sWLZLevXub7+fOnStt2rSRypUru7tZAJBlBDsA+ZJOjNBh2MjISDMbtn///qZ8zZo1MnDgQHc3DwCyhWAHIF8Pw2pvnS5xUqdOHdmxY4cp14WJASAvItgByJdsa9V988038uyzz5rv58+fL08//bSULFnSza0DgOxhgWIA+Zb++tPZsM2bNzdLndx3332yfv166dChg7ubBgDZQrADkK/orzxdn+7WrVspeuZu374tu3fvlieffNKsZQcAeRG/vQDkK7ZFh5977jk5e/asPewVL15cOnXq5ObWAUDOEOwA5DvXr1+XS5cuyWeffZYi7GnA0946BjIA5FUEOwD5TunSpWXChAkye/Zss7yJzbVr12Tx4sVmSzEAyIv+mhYGAPmMDsUGBwfLvHnz5Pz58/Ltt9/KuXPnJD4+Xt566y1TJzExkeftAOQpTJ4AkC/o+nS6IPGZM2dML91vv/0mW7ZskYiICHN92rRpZi27zp07S+HChVNMtACAvIIeOwD5goY69fLLL0tMTIzUqlVLlixZYoLdjBkzpEGDBtK1a1f7wsWKUAcgr6HHDkC+cvjwYRPqihYtai8bPHiwbN++XX788Ufx9/d3a/sAICcIdgDyLdtQq/bSdezYUWrXri0LFixwd7MAINt4KhhAvqWhTidI6DDtkCFD7MucaBkA5EX02AHAv8XFxUmhQoWYNAEgzyLYAQAAWARDsQAAABZBsAMAALAIgh0AAIBFEOwAAAAsgmAHAABgEQQ7AAAAiyDYAQAAWATBDgAAwCIIdgAAAGIN/w95g49EN9NycAAAAABJRU5ErkJggg==\n"
+      ]
      },
      "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 23
+   "source": [
+    "plot_histogram(samples_for_plot)"
+   ]
   }
  ],
  "metadata": {

--- a/docs/tutorials/6_tutorial_primitives.ipynb
+++ b/docs/tutorials/6_tutorial_primitives.ipynb
@@ -571,7 +571,7 @@
     "    x = []\n",
     "    y = []\n",
     "    counts = dict(data.creg_a[index].get_int_counts())\n",
-    "    for i in {0, 1, 1022, 1023}:\n",
+    "    for i in (0, 1, 1022, 1023):\n",
     "        counts.setdefault(i, 0)\n",
     "    for k, v in sorted(counts.items()):\n",
     "        x.append(str(k))\n",

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -335,7 +335,7 @@ class _QiskitProgramContext(AbstractProgramContext):
     def handle_parameter_value(self, value: Number | Expr) -> Number | Parameter:
         return _sympy_to_qiskit(value, self._param_map) if isinstance(value, Expr) else value
 
-    def add_measure(self, target: tuple[int], classical_targets: Iterable[int] = None):
+    def add_measure(self, target: tuple[int], classical_targets: Iterable[int] | None = None):
         for iter, qubit in enumerate(target):
             index = classical_targets[iter] if classical_targets else iter
             self._circuit.measure(qubit, index)
@@ -352,7 +352,7 @@ def native_gate_connectivity(properties: DeviceCapabilities) -> list[list[int]] 
         if the device is fully connected.
     """
     device_connectivity = properties.paradigm.connectivity
-    connectivity = (
+    return (
         [
             [int(x), int(y)]
             for x, neighborhood in device_connectivity.connectivityGraph.items()
@@ -361,7 +361,6 @@ def native_gate_connectivity(properties: DeviceCapabilities) -> list[list[int]] 
         if not device_connectivity.fullyConnected
         else None
     )
-    return connectivity
 
 
 def native_gate_set(properties: DeviceCapabilities) -> set[str]:
@@ -746,7 +745,7 @@ def to_braket(
     *args,
     qubit_labels: Sequence[int] | None = None,
     target: Target | None = None,
-    verbatim: bool = None,
+    verbatim: bool | None = None,
     basis_gates: Sequence[str] | None = None,
     coupling_map: list[list[int]] | None = None,
     angle_restrictions: Mapping[str, Mapping[int, set[float] | tuple[float, float]]] | None = None,
@@ -1071,7 +1070,7 @@ def _default_target(circuits: Iterable[QuantumCircuit]) -> Target:
 
 def _default_qubit_labels(circuit: QuantumCircuit) -> tuple[int, ...]:
     bits = sorted(circuit.find_bit(q).index for q in circuit.qubits)
-    return tuple(range(max(bits) + 1)) if bits else tuple()
+    return tuple(range(max(bits) + 1)) if bits else ()
 
 
 def _create_free_parameters(operation):
@@ -1298,7 +1297,7 @@ def _reverse_endianness(matrix: np.ndarray):
     return (
         np.transpose(
             matrix.reshape([2] * n_q * 2),
-            list(range(0, n_q))[::-1] + list(range(n_q, 2 * n_q))[::-1],
+            list(range(n_q))[::-1] + list(range(n_q, 2 * n_q))[::-1],
         ).reshape((2**n_q, 2**n_q))
         if n_q > 1
         else matrix
@@ -1316,7 +1315,7 @@ def _create_qiskit_gate(
     new_gate_params = []
     for param_expression, value in zip(gate_instance.params, gate_params, strict=True):
         # extract the coefficient in the templated gate
-        param = list(param_expression.parameters)[0].sympify()
+        param = next(iter(param_expression.parameters)).sympify()
         coeff = float(param_expression.sympify().subs(param, 1))
         new_gate_params.append(
             _sympy_to_qiskit(coeff * value.expression, param_map)

--- a/qiskit_braket_provider/providers/braket_backend.py
+++ b/qiskit_braket_provider/providers/braket_backend.py
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 
 _TASK_ID_DIVIDER = ";"
 
-T = TypeVar("T", bound=Device, covariant=True)
+T = TypeVar("T", bound=Device, covariant=True)  # noqa: PLC0105
 
 
 class BraketBackend(BackendV2, ABC, Generic[T]):
@@ -165,7 +165,7 @@ class BraketLocalBackend(BraketBackend[LocalSimulator]):
         ]
 
         if shots == 0:
-            circuits = list(map(lambda x: x.state_vector(), circuits))
+            circuits = [x.state_vector() for x in circuits]
         if "meas_level" in options:
             self._validate_meas_level(options["meas_level"])
             del options["meas_level"]
@@ -182,7 +182,7 @@ class BraketLocalBackend(BraketBackend[LocalSimulator]):
                 logger.error("Attempt to cancel %s...", task.id)
                 task.cancel()
                 logger.error("State of %s: %s.", task.id, task.state())
-            raise ex
+            raise
 
         task_id = _TASK_ID_DIVIDER.join(task.id for task in tasks)
 
@@ -456,10 +456,10 @@ class AWSBraketBackend(BraketAwsBackend):
         self,
         device: AwsDevice,
         provider=None,
-        name: str = None,
-        description: str = None,
-        online_date: datetime.datetime = None,
-        backend_version: str = None,
+        name: str | None = None,
+        description: str | None = None,
+        online_date: datetime.datetime | None = None,
+        backend_version: str | None = None,
         **fields,
     ):
         """This throws a deprecation warning on initialization."""

--- a/qiskit_braket_provider/providers/braket_estimator.py
+++ b/qiskit_braket_provider/providers/braket_estimator.py
@@ -126,7 +126,7 @@ class BraketEstimator(BaseEstimatorV2):
         precision_values = {pub.precision for pub in pubs}
         if len(precision_values) > 1:
             raise ValueError(f"All pubs must have the same precision, got: {precision_values}")
-        return list(precision_values)[0]
+        return next(iter(precision_values))
 
     def _translate_pub(
         self, pub: EstimatorPub

--- a/qiskit_braket_provider/providers/braket_quantum_task.py
+++ b/qiskit_braket_provider/providers/braket_quantum_task.py
@@ -1,6 +1,6 @@
 """Amazon Braket task."""
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 from qiskit.providers import BackendV2, JobStatus, JobV1
 from qiskit.quantum_info import Statevector
@@ -87,12 +87,12 @@ class BraketQuantumTask(JobV1):
         self._backend = backend
         self._metadata = metadata
         self._tasks = tasks
-        self._date_of_creation = datetime.now()
+        self._date_of_creation = datetime.now(tz=UTC)
 
     @property
     def shots(self) -> int:
         """int: The number of shots for the task."""
-        return self.metadata["metadata"]["shots"] if "shots" in self.metadata["metadata"] else 0
+        return self.metadata["metadata"].get("shots", 0)
 
     def submit(self):
         return

--- a/qiskit_braket_provider/providers/braket_sampler.py
+++ b/qiskit_braket_provider/providers/braket_sampler.py
@@ -119,7 +119,7 @@ class BraketSampler(BaseSamplerV2):
         shots_values = {pub.shots for pub in pubs}
         if len(shots_values) > 1:
             raise ValueError(f"All pubs must have the same shots, got: {shots_values}")
-        return list(shots_values)[0]
+        return next(iter(shots_values))
 
     def _translate_pub(self, pub: SamplerPub) -> tuple[CircuitBinding | Circuit, np.ndarray | None]:
         backend = self._backend

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 """Setup file for Qiskit-Braket provider."""
 
 import os
-from typing import Any, Dict, Optional
+from typing import Any
 
 import setuptools
 
@@ -15,9 +15,9 @@ version_path = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "qiskit_braket_provider", "version.py")
 )
 
-version_dict: Optional[Dict[str, Any]] = {}
+version_dict: dict[str, Any] | None = {}
 with open(version_path) as fp:
-    exec(fp.read(), version_dict)
+    exec(fp.read(), version_dict)  # noqa: S102
 version = version_dict["__version__"]
 
 setuptools.setup(

--- a/tests/providers/mocks.py
+++ b/tests/providers/mocks.py
@@ -249,7 +249,7 @@ MOCK_GATE_MODEL_SIMULATOR_TN = {
 }
 
 MOCK_GATE_MODEL_QUANTUM_TASK_RESULT = GateModelQuantumTaskResult(
-    task_metadata=TaskMetadata(**{"id": str(uuid.uuid4()), "deviceId": "default", "shots": 3}),
+    task_metadata=TaskMetadata(id=str(uuid.uuid4()), deviceId="default", shots=3),
     additional_metadata=None,
     measurements=np.array([[0, 1], [0, 1], [1, 0]]),
     measured_qubits=[0, 1],
@@ -302,7 +302,7 @@ MOCK_PROGRAM_RESULT = {
             "name": "braket.ir.openqasm.program",
             "version": "1",
         },
-        "source": "OPENQASM 3.0;",  # noqa
+        "source": "OPENQASM 3.0;",
         "inputs": {"theta": [0.12, 2.1]},
     },
     "additionalMetadata": {
@@ -318,18 +318,15 @@ MOCK_PROGRAM_RESULT = {
 # pylint: disable-next=no-value-for-parameter
 MOCK_PROGRAM_SET_RESULT = ProgramSetQuantumTaskResult.from_object(
     ProgramSetTaskResult(
-        **{
-            "braketSchemaHeader": {
+        braketSchemaHeader={
                 "name": "braket.task_result.program_set_task_result",
                 "version": "1",
-            },
-            "programResults": [MOCK_PROGRAM_RESULT] * 2,
-            "taskMetadata": {
+            }, programResults=[MOCK_PROGRAM_RESULT] * 2, taskMetadata={
                 "braketSchemaHeader": {
                     "name": "braket.task_result.program_set_task_metadata",
                     "version": "1",
                 },
-                "id": "TaskID",  # noqa
+                "id": "TaskID",
                 "deviceId": "arn:aws:braket:::device/quantum-simulator/amazon/sv1",
                 "requestedShots": 120,
                 "successfulShots": 100,
@@ -352,8 +349,7 @@ MOCK_PROGRAM_SET_RESULT = ProgramSetQuantumTaskResult.from_object(
                 "endedAt": "2024-10-15T19:07:00.382Z",
                 "status": "COMPLETED",
                 "totalFailedExecutables": 1,
-            },
-        }
+            }
     )
 )
 MOCK_PROGRAM_SET_QUANTUM_TASK = LocalQuantumTask(MOCK_PROGRAM_SET_RESULT)
@@ -380,7 +376,6 @@ class MockBraketBackend(BraketBackend):
         """
         Mock method for run.
         """
-        pass
 
 
 class MockMeasLevelEnum(enum.Enum):

--- a/tests/providers/test_adapter.py
+++ b/tests/providers/test_adapter.py
@@ -260,7 +260,7 @@ class TestAdapter(TestCase):
     def test_standard_gate_decomp(self):
         """Tests adapter decomposition of all standard gates to forms that can be translated"""
         gates = qiskit_gates.get_standard_gate_name_mapping()
-        for name in {"delay", "global_phase", "measure", "reset"}:
+        for name in ("delay", "global_phase", "measure", "reset"):
             gates.pop(name)
         for standard_gate in gates.values():
             qiskit_circuit = QuantumCircuit(standard_gate.num_qubits)
@@ -384,7 +384,7 @@ class TestAdapter(TestCase):
 
         braket_to_qiskit_gate_names = {
             **qiskit_to_braket_gate_names,
-            **{"measure": "measure"},
+            "measure": "measure",
         }
 
         self.assertEqual(
@@ -435,14 +435,12 @@ class TestAdapter(TestCase):
         circuit.h(0)
         with pytest.raises(TypeError, match="Multiple values for basis_gates"):
             to_braket(circuit, {"h, cx"}, basis_gates={"h", "cx"})
-        with pytest.raises(TypeError, match="Multiple values for verbatim"):
-            with pytest.warns(
-                DeprecationWarning,
-                match="Passing basis_gates as a positional argument is deprecated.",
-            ):
-                to_braket(circuit, {"h, cx"}, True, verbatim=True)
-        with pytest.raises(TypeError, match="Multiple values for connectivity"):
-            with pytest.warns(
+        with pytest.raises(TypeError, match="Multiple values for verbatim"), pytest.warns(
+            DeprecationWarning,
+            match="Passing basis_gates as a positional argument is deprecated.",
+        ):
+            to_braket(circuit, {"h, cx"}, True, verbatim=True)
+        with pytest.raises(TypeError, match="Multiple values for connectivity"), pytest.warns(
                 DeprecationWarning, match="Passing verbatim as a positional argument is deprecated."
             ):
                 to_braket(circuit, {"h, cx"}, True, [[0, 1]], connectivity=[[0, 1]])
@@ -527,9 +525,9 @@ class TestAdapter(TestCase):
         braket_device.topology_graph = MOCK_RIGETTI_TOPOLOGY_GRAPH
 
         braket_circuit = to_braket(circuit, braket_device=braket_device)
-        braket_operators = set(
+        braket_operators = {
             type(instruction.operator) for instruction in braket_circuit.instructions
-        )
+        }
         self.assertFalse(len(braket_operators.intersection({braket_gates.H})))
         self.assertTrue(
             braket_operators.issubset(
@@ -891,15 +889,15 @@ class TestAdapter(TestCase):
 
         def gate_matches_connectivity(gate) -> bool:
             return any(
-                (gate.target.union(gate.control).issubset(adjacency) for adjacency in connectivity)
+                gate.target.union(gate.control).issubset(adjacency) for adjacency in connectivity
             )
 
-        assert all((gate_matches_connectivity(gate) for gate in braket_circuit.instructions))
+        assert all(gate_matches_connectivity(gate) for gate in braket_circuit.instructions)
         assert not all(
-            (gate_matches_connectivity(gate) for gate in braket_circuit_unconnected.instructions)
+            gate_matches_connectivity(gate) for gate in braket_circuit_unconnected.instructions
         )
         assert not all(
-            (gate_matches_connectivity(gate) for gate in braket_circuit_verbatim.instructions)
+            gate_matches_connectivity(gate) for gate in braket_circuit_verbatim.instructions
         )
 
     def test_angle_restrictions_rigetti(self):
@@ -1358,7 +1356,7 @@ class TestFromBraket(TestCase):
                         zip(
                             # Need to use qiskit_gate.parameters because
                             # qiskit_circuit.parameters is sorted alphabetically
-                            [list(expr.parameters)[0] for expr in qiskit_gate.params],
+                            [next(iter(expr.parameters)) for expr in qiskit_gate.params],
                             params_qiskit[: len(qiskit_gate.params)],
                             strict=True,
                         )
@@ -1464,17 +1462,16 @@ class TestFromBraket(TestCase):
 
     def test_unsupported_braket_gate(self):
         """Tests if TypeError is raised for unsupported Braket gate."""
-        gate = getattr(Gate, "CNot")
+        gate = Gate.CNot
         op = gate()
         instr = Instruction(op, range(2))
         circuit = Circuit().add_instruction(instr)
 
-        with self.assertRaises(TypeError):
-            with patch.dict(
-                "qiskit_braket_provider.providers.adapter._BRAKET_GATE_NAME_TO_QISKIT_GATE",
-                {"cnot": None},
-            ):
-                to_qiskit(circuit)
+        with self.assertRaises(TypeError), patch.dict(
+            "qiskit_braket_provider.providers.adapter._BRAKET_GATE_NAME_TO_QISKIT_GATE",
+            {"cnot": None},
+        ):
+            to_qiskit(circuit)
 
     def test_measure_subset(self):
         """Tests the measure instruction conversion from braket to qiskit"""

--- a/tests/providers/test_braket_backend.py
+++ b/tests/providers/test_braket_backend.py
@@ -52,16 +52,16 @@ def combine_dicts(dict1: dict[str, float], dict2: dict[str, float]) -> dict[str,
         merged dicts with list of keys
     """
     combined_dict: dict[str, list[float]] = {}
-    for key in dict1.keys():
+    for key, value in dict1.items():
         if key in combined_dict:
-            combined_dict[key].append(dict1[key])
+            combined_dict[key].append(value)
         else:
-            combined_dict[key] = [dict1[key]]
-    for key in dict2.keys():
+            combined_dict[key] = [value]
+    for key, value in dict2.items():
         if key in combined_dict:
-            combined_dict[key].append(dict2[key])
+            combined_dict[key].append(value)
         else:
-            combined_dict[key] = [dict2[key]]
+            combined_dict[key] = [value]
     return combined_dict
 
 
@@ -158,7 +158,7 @@ class TestBraketLocalBackend(TestCase):
         circuit = QuantumCircuit(1)
         circuit.h(0)
 
-        with self.assertRaises(Exception):
+        with self.assertRaises(Exception):  # noqa: B017
             backend.run([circuit, circuit], shots=0)  # First run should pass
         braket_devices_run.assert_called()
 
@@ -311,7 +311,6 @@ class TestBraketAwsBackend(TestCase):
             class SubclassAWSBraketBackend(AWSBraketBackend):  # pylint: disable=unused-variable
                 """A subclass of AWSBraketBackend for testing purposes"""
 
-                pass
 
     def test_run_multiple_circuits(self):
         """Tests run with multiple circuits"""

--- a/tests/providers/test_braket_provider.py
+++ b/tests/providers/test_braket_provider.py
@@ -87,7 +87,6 @@ class TestBraketProvider(TestCase):
             class SubclassAWSBraketProvider(AWSBraketProvider):  # pylint: disable=unused-variable
                 """This is a subclass of AWSBraketProvider for testing purposes."""
 
-                pass
 
     def test_provider_backends_kwargs_local(self):
         """Tests getting local backends using kwargs"""


### PR DESCRIPTION
### Summary
Source files:
- docs/conf.py & setup.py — Added # noqa: S102 to suppress intentional exec() usage for version parsing
- adapter.py — 6 fixes:
  - Iterable[int] = None → Iterable[int] | None = None (RUF013)
  - Removed unnecessary connectivity variable before return (RET504)
  - bool = None → bool | None = None (RUF013)
  - tuple() → () literal (C408)
  - list(...)[0] → next(iter(...)) (RUF015)
- braket_backend.py — 7 fixes:
  - Added # noqa: PLC0105 on TypeVar (renaming T to T_co would be a breaking change)
  - list(map(lambda ...)) → list comprehension (C417)
  - raise ex → raise (TRY201)
  - 4x str = None → str | None = None (RUF013)
- braket_estimator.py & braket_sampler.py — list(...)[0] → next(iter(...)) (RUF015)
- braket_quantum_task.py — datetime.now() → datetime.now(tz=UTC) (DTZ005) and .get() instead of if-else (SIM401)

Test files:
- 4 standalone test scripts — Removed shebangs (EXE001) and suppressed intentional blind exception catches with # noqa: BLE001
- test_adapter.py — Combined nested with statements (SIM117), set comprehension (C401), next(iter(...)) (RUF015)
- test_braket_backend.py — Used .items() on dict iteration (PLC0206), suppressed B017 where mock raises base Exception

### Details and comments

