### PR TITLE
bugfix: global phase with parameter

### DIFF
--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -1036,8 +1036,11 @@ def _translate_to_braket(
                             target=qubit_indices,
                         )
     global_phase = circuit.global_phase
-    if abs(global_phase) > _EPS:
+    has_nonzero_phase = isinstance(global_phase, ParameterExpression) or abs(global_phase) > _EPS
+    if has_nonzero_phase:
         if (target and "global_phase" in target) or (basis_gates and "global_phase" in basis_gates):
+            if isinstance(global_phase, ParameterExpression):
+                global_phase = FreeParameterExpression(rename_parameter(global_phase))
             braket_circuit.gphase(global_phase)
         else:
             warnings.warn(

--- a/tests/providers/test_adapter.py
+++ b/tests/providers/test_adapter.py
@@ -313,6 +313,34 @@ class TestAdapter(TestCase):
         self.assertEqual(braket_circuit_no_gphase.global_phase, 0)
         self.assertEqual(braket_circuit_no_gphase, Circuit().h(0))
 
+    def test_parameterized_global_phase(self):
+        """Tests that to_braket handles parameterized global phase from transpilation."""
+        braket_input = Circuit().phaseshift(0, FreeParameter("theta"))
+
+        mock_ankaa = Mock(spec=AwsDevice)
+        mock_ankaa.properties = MOCK_RIGETTI_GATE_MODEL_QPU_CAPABILITIES
+        mock_ankaa.gate_calibrations = None
+        mock_ankaa.type = "QPU"
+        mock_ankaa.topology_graph = MOCK_RIGETTI_TOPOLOGY_GRAPH
+
+        with self.assertWarns(UserWarning) as cm:
+            result = to_braket(braket_input, optimization_level=1, braket_device=mock_ankaa)
+        self.assertEqual(
+            str(cm.warning),
+            "Device does not support global phase; "
+            "global phase of 0.5*theta will not be included in Braket circuit",
+        )
+        self.assertIsInstance(result, Circuit)
+        self.assertTrue(len(result.instructions) > 0)
+
+    def test_parameterized_global_phase_supported(self):
+        """Tests that parameterized global phase is converted to gphase when supported."""
+        braket_input = Circuit().phaseshift(0, FreeParameter("theta"))
+        result = to_braket(
+            braket_input, basis_gates=["rx", "rz", "cz", "global_phase"]
+        )
+        self.assertIn("0.5*theta", str(result.global_phase))
+
     def test_exponential_gate_decomp(self):
         """Tests adapter translation of exponential gates"""
         qiskit_circuit = QuantumCircuit(2)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
This PR fixes the issue raised in #282 that `to_braket` fails if there are parameters in the `global_phase`.

resolves #282 


### Details and comments

