### PR TITLE
refactor verbatim pass handling

### DIFF
--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -9,7 +9,6 @@ sequences that should not be optimized.
 import warnings
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Mapping, Sequence
-from dataclasses import dataclass
 from math import inf, pi, prod
 from numbers import Number
 from typing import TypeVar
@@ -17,7 +16,7 @@ from typing import TypeVar
 import numpy as np
 import qiskit.circuit.library as qiskit_gates
 import qiskit.quantum_info as qiskit_qi
-from qiskit import QuantumCircuit, transpile
+from qiskit import QuantumCircuit
 from qiskit.circuit import (
     Barrier,
     BoxOp,
@@ -43,6 +42,7 @@ from qiskit.transpiler import (
     Target,
     TransformationPass,
 )
+from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from qiskit_ionq import add_equivalences, ionq_gates
 from sympy import Add, Expr, Mul, Pow, Symbol
 
@@ -101,6 +101,10 @@ from braket.ir.openqasm.modifiers import Control
 from braket.parametric import FreeParameter, FreeParameterExpression, Parameterizable
 from qiskit_braket_provider.exception import QiskitBraketException
 from qiskit_braket_provider.providers import braket_instructions
+from qiskit_braket_provider.providers.verbatim_passes import (
+    ExtractVerbatimBoxes,
+    RestoreVerbatimBoxes,
+)
 
 add_equivalences()
 
@@ -1087,134 +1091,7 @@ def _add_instructions_no_parameter_restrictions(
                     )
 
 
-def _extract_verbatim_boxes(
-    circuit: QuantumCircuit, verbatim_box_name: str
-) -> tuple[QuantumCircuit, list[tuple[QuantumCircuit, list[int]]]]:
-    """Extract BoxOp operations with verbatim box name and replace with barriers.
-
-    Args:
-        circuit: The Qiskit circuit to process
-        verbatim_box_name: The label name used to identify verbatim BoxOp operations
-
-    Returns:
-        A tuple of (modified_circuit, verbatim_boxes) where:
-        - modified_circuit: Circuit with BoxOps replaced by named barriers
-        - verbatim_boxes: List of (box_circuit, qubit_indices) tuples
-    """
-    modified_circuit = QuantumCircuit(circuit.num_qubits, circuit.num_clbits)
-    modified_circuit.global_phase = circuit.global_phase
-
-    verbatim_boxes = []
-
-    for instruction in circuit.data:
-        operation = instruction.operation
-
-        # Convert Qubit objects to integer indices
-        # instruction.qubits contains Qubit objects (circuit-specific)
-        # find_bit(q).index returns the global integer index (0, 1, 2, ...)
-        # We consistently use indices for circuits with physical qubits as they do not go through mapping and routing
-        qubit_indices = [circuit.find_bit(q).index for q in instruction.qubits]
-        clbit_indices = [circuit.find_bit(q).index for q in instruction.clbits]
-
-        if isinstance(operation, BoxOp) and getattr(operation, "label", None) == verbatim_box_name:
-            # Extract the circuit from the BoxOp (first block)
-            box_circuit = operation.blocks[0]
-
-            verbatim_boxes.append((box_circuit, qubit_indices))
-
-            barrier = Barrier(len(instruction.qubits), label=verbatim_box_name)
-            modified_circuit.append(barrier, qubit_indices, clbit_indices)
-        else:
-            modified_circuit.append(operation, qubit_indices, clbit_indices)
-
-    return modified_circuit, verbatim_boxes
-
-
-def _restore_verbatim_boxes(
-    transpiled_circuit: QuantumCircuit,
-    verbatim_boxes: list[tuple[QuantumCircuit, list[int]]],
-    verbatim_box_name: str,
-) -> QuantumCircuit:
-    """Restore verbatim boxes by replacing named barriers with box contents.
-
-    Args:
-        transpiled_circuit: The transpiled circuit with named barriers
-        verbatim_boxes: List of (box_circuit, original_qubit_indices) tuples
-        verbatim_box_name: The label name used to identify verbatim barriers
-
-    Returns:
-        Circuit with verbatim box contents restored
-
-    Raises:
-        ValueError: If barrier count doesn't match verbatim box count
-        ValueError: If qubit mapping fails
-    """
-    reconstructed_circuit = QuantumCircuit(
-        transpiled_circuit.num_qubits, transpiled_circuit.num_clbits
-    )
-    reconstructed_circuit.global_phase = transpiled_circuit.global_phase
-
-    verbatim_box_iter = iter(verbatim_boxes)
-    barrier_count = 0
-
-    for instruction in transpiled_circuit.data:
-        operation = instruction.operation
-
-        if (
-            isinstance(operation, Barrier)
-            and getattr(operation, "label", None) == verbatim_box_name
-        ):
-            barrier_count += 1
-
-            try:
-                box_circuit, _ = next(verbatim_box_iter)
-            except StopIteration:
-                raise ValueError(
-                    f"Compiler error while processing verbatim boxes. Illegal barriers with label '{verbatim_box_name}'"
-                )
-
-            # Insert gates from the verbatim box directly (not as BoxOp)
-            # Since verbatim boxes can only exist in circuits using physical qubits,
-            # and we use trivial layout (identity mapping) with no routing during transpilation,
-            # the qubit indices remain unchanged between the box circuit and the reconstructed circuit.
-            for box_instruction in box_circuit.data:
-                qubit_indices = [box_circuit.find_bit(q).index for q in box_instruction.qubits]
-                clbit_indices = [box_circuit.find_bit(q).index for q in box_instruction.clbits]
-                # Append the gate instruction with the same qubits as in the box
-                reconstructed_circuit.append(
-                    box_instruction.operation, qubit_indices, clbit_indices
-                )
-        else:
-            # Get indices of qubits and clbits and add instruction as-is
-            qubit_indices = [transpiled_circuit.find_bit(q).index for q in instruction.qubits]
-            clbit_indices = [transpiled_circuit.find_bit(q).index for q in instruction.clbits]
-            reconstructed_circuit.append(operation, qubit_indices, clbit_indices)
-
-    remaining_boxes = list(verbatim_box_iter)
-    if remaining_boxes:
-        raise ValueError(
-            f"Compiler error while processing verbatim boxes. Expected {barrier_count} "
-            "verbatim boxes, but found {len(verbatim_boxes)}."
-        )
-
-    return reconstructed_circuit
-
-
-@dataclass(frozen=True)
-class _CompilationContext:
-    """Internal result from _compile containing compiled circuits and resolved state."""
-
-    circuits: list[QuantumCircuit]
-    single_instance: bool
-    target: Target | None
-    qubit_labels: Sequence[int] | None
-    verbatim: bool | None
-    basis_gates: Sequence[str] | None
-    angle_restrictions: Mapping[str, Mapping[int, set[float] | tuple[float, float]]] | None
-    pass_manager: PassManager | None
-
-
-def _compile(
+def to_braket(
     circuits: _Translatable | Iterable[_Translatable] = None,
     *args,
     qubit_labels: Sequence[int] | None = None,
@@ -1274,16 +1151,7 @@ def _compile(
             "Custom pass_manager is not supported with verbatim boxes. "
             "Verbatim boxes require controlled transpilation to preserve gate ordering."
         )
-
-    all_verbatim_boxes = []
-    if has_verbatim_boxes:
-        extracted_circuits = []
-        for circ in circuits:
-            modified_circ, verbatim_boxes = _extract_verbatim_boxes(circ, verbatim_box_name)
-            extracted_circuits.append(modified_circ)
-            all_verbatim_boxes.append(verbatim_boxes)
-        circuits = extracted_circuits
-
+    
     if braket_device:
         if qubit_labels:
             raise ValueError("Cannot specify qubit labels with Braket device")
@@ -1303,19 +1171,7 @@ def _compile(
     elif not verbatim:
         target = target if basis_gates or target else _default_target(circuits)
 
-        if has_verbatim_boxes:
-            warnings.warn(
-                "Overriding layout method to 'trivial' "
-                "and routing method to 'none' as the circuit has verbatim blocks",
-                stacklevel=1,
-            )
-            effective_layout_method = "trivial"
-            effective_routing_method = "none"
-        else:
-            effective_layout_method = layout_method
-            effective_routing_method = routing_method
-
-        if (
+        needs_transpile = (
             target
             or coupling_map
             or (
@@ -1324,171 +1180,42 @@ def _compile(
                     basis_gates
                 )
             )
-        ):
-            circuits = transpile(
-                circuits,
+        )
+
+        if needs_transpile:
+            if has_verbatim_boxes:
+                warnings.warn(
+                    "Overriding layout method to 'trivial' "
+                    "and routing method to 'none' as the circuit has verbatim blocks",
+                    stacklevel=1,
+                )
+            pm = generate_preset_pass_manager(
+                optimization_level=optimization_level or 0,
+                target=target,
                 basis_gates=basis_gates,
                 coupling_map=coupling_map,
-                optimization_level=optimization_level,
-                target=target,
-                callback=callback,
-                num_processes=num_processes,
-                layout_method=effective_layout_method,
-                routing_method=effective_routing_method,
-                seed_transpiler=seed_transpiler,
+                layout_method="trivial" if has_verbatim_boxes else layout_method,
+                routing_method="none" if has_verbatim_boxes else routing_method,
             )
+            if has_verbatim_boxes:
+                pm.pre_init = PassManager([ExtractVerbatimBoxes(verbatim_box_name)])
+                pm.post_optimization = PassManager([RestoreVerbatimBoxes(verbatim_box_name)])
+            circuits = pm.run(circuits, callback=callback, num_processes=num_processes)
+    elif has_verbatim_boxes:
+        circuits = PassManager(
+            [ExtractVerbatimBoxes(verbatim_box_name), RestoreVerbatimBoxes(verbatim_box_name)]
+        ).run(circuits)
+
     if isinstance(target, _SubstitutedTarget):
         circuits = target._substitute(circuits)
 
-    if has_verbatim_boxes:
-        circuits = [
-            _restore_verbatim_boxes(circ, verbatim_boxes, verbatim_box_name)
-            if len(verbatim_boxes) > 0
-            else circ
-            for circ, verbatim_boxes in zip(circuits, all_verbatim_boxes)
-        ]
-
-    return _CompilationContext(
-        circuits=circuits,
-        single_instance=single_instance,
-        target=target,
-        qubit_labels=qubit_labels,
-        verbatim=verbatim,
-        basis_gates=basis_gates,
-        angle_restrictions=angle_restrictions,
-        pass_manager=pass_manager,
-    )
-
-
-def to_braket(
-    circuits: _Translatable | Iterable[_Translatable] = None,
-    *args,
-    qubit_labels: Sequence[int] | None = None,
-    target: Target | None = None,
-    verbatim: bool | None = None,
-    basis_gates: Sequence[str] | None = None,
-    coupling_map: list[list[int]] | None = None,
-    angle_restrictions: Mapping[str, Mapping[int, set[float] | tuple[float, float]]] | None = None,
-    optimization_level: int = 0,
-    callback: Callable | None = None,
-    num_processes: int | None = None,
-    pass_manager: PassManager | None = None,
-    braket_device: Device | None = None,
-    add_measurements: bool = True,
-    circuit: _Translatable | Iterable[_Translatable] | None = None,
-    connectivity: list[list[int]] | None = None,
-    verbatim_box_name: str = _BRAKET_VERBATIM_BOX_NAME,
-    layout_method: str | None = None,
-    routing_method: str | None = None,
-    seed_transpiler: int | None = None,
-) -> Circuit | list[Circuit]:
-    """Converts a single or list of Qiskit QuantumCircuits to a single or list of Braket Circuits.
-
-    The recommended way to use this method is to minimally pass in qubit labels and a target
-    (instead of basis gates and coupling map). This ensures that the translated circuit is actually
-    supported by the device (and doesn't, for example, include unsupported parameters for gates).
-    The latter guarantees that the output Braket circuit uses the qubit labels of the Braket device,
-    which are not necessarily contiguous.
-
-    Args:
-        circuits (QuantumCircuit | Circuit | Program | str | Iterable): Qiskit or Braket
-            circuit(s) or OpenQASM 3 program(s) to transpile and translate to Braket.
-        qubit_labels (Sequence[int] | None): A list of (not necessarily contiguous) indices of
-            qubits in the underlying Amazon Braket device. If not supplied, then the indices are
-            assumed to be contiguous. Default: ``None``.
-        target (Target | None): A backend transpiler target. Can only be provided
-            if basis_gates is ``None``. Default: ``None``.
-        verbatim (bool): Whether to translate the circuit without any modification, in other
-            words without transpiling it. Default: ``False``.
-        basis_gates (Sequence[str] | None): The gateset to transpile to. Can only be provided
-            if target is ``None``. If ``None`` and target is ``None``, the transpiler will use
-            all gates defined in the Braket SDK. Default: ``None``.
-        coupling_map (list[list[int]] | None): If provided, will transpile to a circuit
-            with this coupling map. Default: ``None``.
-        angle_restrictions (Mapping[str, Mapping[int, set[float] | tuple[float, float]]] | None):
-            Mapping of gate names to parameter angle constraints used to
-            validate numeric parameters. Default: ``None``.
-        optimization_level (int | None): The optimization level to pass to ``qiskit.transpile``.
-            From Qiskit:
-
-            * 0: no optimization - basic translation, no optimization, trivial layout
-            * 1: light optimization - routing + potential SaberSwap, some gate cancellation
-              and 1Q gate folding
-            * 2: medium optimization - better routing (noise aware) and commutative cancellation
-            * 3: high optimization - gate resynthesis and unitary-breaking passes
-
-            Default: 0.
-        callback (Callable | None): A callback function that will be called after each transpiler
-            pass execution. Default: ``None``.
-        num_processes (int | None): The maximum number of parallel transpilation processes for
-            multiple circuits. Default: ``None``.
-        pass_manager (PassManager): `PassManager` to transpile the circuit; will raise an error if
-            used in conjunction with a target, basis gates, or connectivity. Default: ``None``.
-        braket_device (Device): Braket device to transpile to. Can only be provided if `target`
-            and ``basis_gates`` are ``None``. Default: ``None``.
-        add_measurements (bool): Whether to add measurements when translating Braket circuits.
-            Default: True.
-        circuit (QuantumCircuit | Circuit | Program | str | Iterable | None): Qiskit or Braket
-            circuit(s) or OpenQASM 3 program(s) to transpile and translate to Braket.
-            Default: ``None``. DEPRECATED: use first positional argument or ``circuits`` instead.
-        connectivity (list[list[int]] | None): If provided, will transpile to a circuit
-            with this connectivity. Default: ``None``. DEPRECATED: use ``coupling_map`` instead.
-        verbatim_box_name (str): The label name used to identify verbatim BoxOp operations
-            in Qiskit circuits. When circuits contain BoxOp operations with this label, they
-            will be preserved during transpilation by temporarily replacing them with barriers.
-            Default: ``"verbatim"``.
-        layout_method (str | None): The layout method to use during transpilation. If ``None``
-            and the circuit contains verbatim boxes, defaults to ``'trivial'`` to preserve
-            physical qubit mappings. Otherwise uses Qiskit's default. Default: ``None``.
-        routing_method (str | None): The routing method to use during transpilation. If ``None``
-            and the circuit contains verbatim boxes, defaults to ``'none'`` to disable routing
-            and preserve physical qubit structure. Otherwise uses Qiskit's default. Default: ``None``.
-        seed_transpiler (int | None): This specifies a seed used for the stochastic parts
-            of the transpiler. Default: ``None``.
-
-    Raises:
-        ValueError: If more than one of `target`, ``basis_gates``
-            or ``coupling_map``/``connectivity``, ``pass_manager``, and ``braket_device``
-            are passed together, or if `qubit_labels` is passed with ``braket_device``.
-
-    Returns:
-        Circuit | list[Circuit]: Braket circuit or circuits
-    """
-    result = _compile(
-        circuits,
-        *args,
-        qubit_labels=qubit_labels,
-        target=target,
-        verbatim=verbatim,
-        basis_gates=basis_gates,
-        coupling_map=coupling_map,
-        angle_restrictions=angle_restrictions,
-        optimization_level=optimization_level,
-        callback=callback,
-        num_processes=num_processes,
-        pass_manager=pass_manager,
-        braket_device=braket_device,
-        add_measurements=add_measurements,
-        circuit=circuit,
-        connectivity=connectivity,
-        verbatim_box_name=verbatim_box_name,
-        layout_method=layout_method,
-        routing_method=routing_method,
-        seed_transpiler=seed_transpiler,
-    )
     translated = [
         _translate_to_braket(
-            circ,
-            result.target,
-            result.qubit_labels,
-            result.verbatim,
-            result.basis_gates,
-            result.angle_restrictions,
-            result.pass_manager,
+            circ, target, qubit_labels, verbatim, basis_gates, angle_restrictions, pass_manager
         )
-        for circ in result.circuits
+        for circ in circuits
     ]
-    return translated[0] if result.single_instance else translated
+    return translated[0] if single_instance else translated
 
 
 def _get_circuits(

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -899,7 +899,7 @@ def to_braket(
     layout_method: str | None = None,
     routing_method: str | None = None,
     seed_transpiler: int | None = None,
-) -> _CompilationContext:
+) -> Circuit | list[Circuit]:
 
     circuits, single_instance = _get_circuits(circuits, circuit, add_measurements)
     if len(args) > 4:

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -1111,7 +1111,7 @@ def to_braket(
     layout_method: str | None = None,
     routing_method: str | None = None,
     seed_transpiler: int | None = None,
-) -> _CompilationContext:
+) -> Circuit | list[Circuit]:
 
     circuits, single_instance = _get_circuits(circuits, circuit, add_measurements)
     if len(args) > 4:

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -80,6 +80,7 @@ from braket.parametric import FreeParameter, FreeParameterExpression, Parameteri
 from qiskit_braket_provider.exception import QiskitBraketException
 from qiskit_braket_provider.providers import braket_instructions
 from qiskit_braket_provider.providers.verbatim_passes import (
+    _BRAKET_VERBATIM_BOX_NAME,
     ExtractVerbatimBoxes,
     RestoreVerbatimBoxes,
 )
@@ -279,8 +280,6 @@ _PAULI_MAP = {
     "Y": braket_observables.Y,
     "Z": braket_observables.Z,
 }
-
-_BRAKET_VERBATIM_BOX_NAME = "verbatim"
 
 _Translatable = QuantumCircuit | Circuit | Program | str
 

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -981,6 +981,7 @@ def to_braket(
                 coupling_map=coupling_map,
                 layout_method="trivial" if has_verbatim_boxes else layout_method,
                 routing_method="none" if has_verbatim_boxes else routing_method,
+                seed_transpiler=seed_transpiler,
             )
             if has_verbatim_boxes:
                 pm.pre_init = PassManager([ExtractVerbatimBoxes(verbatim_box_name)])

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -102,6 +102,7 @@ from braket.parametric import FreeParameter, FreeParameterExpression, Parameteri
 from qiskit_braket_provider.exception import QiskitBraketException
 from qiskit_braket_provider.providers import braket_instructions
 from qiskit_braket_provider.providers.verbatim_passes import (
+    _BRAKET_VERBATIM_BOX_NAME,
     ExtractVerbatimBoxes,
     RestoreVerbatimBoxes,
 )
@@ -301,8 +302,6 @@ _PAULI_MAP = {
     "Y": braket_observables.Y,
     "Z": braket_observables.Z,
 }
-
-_BRAKET_VERBATIM_BOX_NAME = "verbatim"
 
 _Translatable = QuantumCircuit | Circuit | Program | str
 

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -1195,6 +1195,7 @@ def to_braket(
                 coupling_map=coupling_map,
                 layout_method="trivial" if has_verbatim_boxes else layout_method,
                 routing_method="none" if has_verbatim_boxes else routing_method,
+                seed_transpiler=seed_transpiler,
             )
             if has_verbatim_boxes:
                 pm.pre_init = PassManager([ExtractVerbatimBoxes(verbatim_box_name)])

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -1150,7 +1150,7 @@ def to_braket(
             "Custom pass_manager is not supported with verbatim boxes. "
             "Verbatim boxes require controlled transpilation to preserve gate ordering."
         )
-    
+
     if braket_device:
         if qubit_labels:
             raise ValueError("Cannot specify qubit labels with Braket device")

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -9,7 +9,6 @@ sequences that should not be optimized.
 import warnings
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Mapping, Sequence
-from dataclasses import dataclass
 from math import inf, pi, prod
 from numbers import Number
 from typing import TypeVar
@@ -17,7 +16,7 @@ from typing import TypeVar
 import numpy as np
 import qiskit.circuit.library as qiskit_gates
 import qiskit.quantum_info as qiskit_qi
-from qiskit import QuantumCircuit, transpile
+from qiskit import QuantumCircuit
 from qiskit.circuit import (
     Barrier,
     BoxOp,
@@ -42,6 +41,7 @@ from qiskit.transpiler import (
     Target,
     TransformationPass,
 )
+from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from qiskit_ionq import add_equivalences, ionq_gates
 from sympy import Add, Expr, Mul, Pow, Symbol
 
@@ -79,6 +79,10 @@ from braket.ir.openqasm.modifiers import Control
 from braket.parametric import FreeParameter, FreeParameterExpression, Parameterizable
 from qiskit_braket_provider.exception import QiskitBraketException
 from qiskit_braket_provider.providers import braket_instructions
+from qiskit_braket_provider.providers.verbatim_passes import (
+    ExtractVerbatimBoxes,
+    RestoreVerbatimBoxes,
+)
 
 add_equivalences()
 
@@ -875,129 +879,7 @@ def _add_instructions_no_parameter_restrictions(
                     )
 
 
-def _extract_verbatim_boxes(
-    circuit: QuantumCircuit, verbatim_box_name: str
-) -> tuple[QuantumCircuit, list[tuple[QuantumCircuit, list[int]]]]:
-    """Extract BoxOp operations with verbatim box name and replace with barriers.
-
-    Args:
-        circuit: The Qiskit circuit to process
-        verbatim_box_name: The label name used to identify verbatim BoxOp operations
-
-    Returns:
-        A tuple of (modified_circuit, verbatim_boxes) where:
-        - modified_circuit: Circuit with BoxOps replaced by named barriers
-        - verbatim_boxes: List of (box_circuit, qubit_indices) tuples
-    """
-    modified_circuit = QuantumCircuit(circuit.num_qubits, circuit.num_clbits)
-    modified_circuit.global_phase = circuit.global_phase
-
-    verbatim_boxes = []
-
-    for instruction in circuit.data:
-        operation = instruction.operation
-
-        # Convert Qubit objects to integer indices
-        # instruction.qubits contains Qubit objects (circuit-specific)
-        # find_bit(q).index returns the global integer index (0, 1, 2, ...)
-        # We consistently use indices for circuits with physical qubits as they do not go through mapping and routing
-        qubit_indices = [circuit.find_bit(q).index for q in instruction.qubits]
-        clbit_indices = [circuit.find_bit(q).index for q in instruction.clbits]
-
-        if isinstance(operation, BoxOp) and getattr(operation, "label", None) == verbatim_box_name:
-            # Extract the circuit from the BoxOp (first block)
-            box_circuit = operation.blocks[0]
-
-            verbatim_boxes.append((box_circuit, qubit_indices))
-
-            barrier = Barrier(len(instruction.qubits), label=verbatim_box_name)
-            modified_circuit.append(barrier, qubit_indices, clbit_indices)
-        else:
-            modified_circuit.append(operation, qubit_indices, clbit_indices)
-
-    return modified_circuit, verbatim_boxes
-
-
-def _restore_verbatim_boxes(
-    transpiled_circuit: QuantumCircuit,
-    verbatim_boxes: list[tuple[QuantumCircuit, list[int]]],
-    verbatim_box_name: str,
-) -> QuantumCircuit:
-    """Restore verbatim boxes by replacing named barriers with box contents.
-
-    Args:
-        transpiled_circuit: The transpiled circuit with named barriers
-        verbatim_boxes: List of (box_circuit, original_qubit_indices) tuples
-        verbatim_box_name: The label name used to identify verbatim barriers
-
-    Returns:
-        Circuit with verbatim box contents restored
-
-    Raises:
-        ValueError: If barrier count doesn't match verbatim box count
-        ValueError: If qubit mapping fails
-    """
-    reconstructed_circuit = QuantumCircuit(transpiled_circuit.num_qubits, transpiled_circuit.num_clbits)
-    reconstructed_circuit.global_phase = transpiled_circuit.global_phase
-
-    verbatim_box_iter = iter(verbatim_boxes)
-    barrier_count = 0
-
-    for instruction in transpiled_circuit.data:
-        operation = instruction.operation
-
-        if isinstance(operation, Barrier) and getattr(operation, "label", None) == verbatim_box_name:
-            barrier_count += 1
-
-            try:
-                box_circuit, _ = next(verbatim_box_iter)
-            except StopIteration:
-                raise ValueError(
-                    f"Compiler error while processing verbatim boxes. Illegal barriers with label '{verbatim_box_name}'"
-                )
-
-            # Insert gates from the verbatim box directly (not as BoxOp)
-            # Since verbatim boxes can only exist in circuits using physical qubits,
-            # and we use trivial layout (identity mapping) with no routing during transpilation,
-            # the qubit indices remain unchanged between the box circuit and the reconstructed circuit.
-            for box_instruction in box_circuit.data:
-                qubit_indices = [box_circuit.find_bit(q).index for q in box_instruction.qubits]
-                clbit_indices = [box_circuit.find_bit(q).index for q in box_instruction.clbits]
-                # Append the gate instruction with the same qubits as in the box
-                reconstructed_circuit.append(
-                    box_instruction.operation, qubit_indices, clbit_indices
-                )
-        else:
-            # Get indices of qubits and clbits and add instruction as-is
-            qubit_indices = [transpiled_circuit.find_bit(q).index for q in instruction.qubits]
-            clbit_indices = [transpiled_circuit.find_bit(q).index for q in instruction.clbits]
-            reconstructed_circuit.append(operation, qubit_indices, clbit_indices)
-
-    remaining_boxes = list(verbatim_box_iter)
-    if remaining_boxes:
-        raise ValueError(
-            f"Compiler error while processing verbatim boxes. Expected {barrier_count} "
-            "verbatim boxes, but found {len(verbatim_boxes)}."
-        )
-
-    return reconstructed_circuit
-
-
-@dataclass(frozen=True)
-class _CompilationContext:
-    """Internal result from _compile containing compiled circuits and resolved state."""
-
-    circuits: list[QuantumCircuit]
-    single_instance: bool
-    target: Target | None
-    qubit_labels: Sequence[int] | None
-    verbatim: bool | None
-    basis_gates: Sequence[str] | None
-    angle_restrictions: Mapping[str, Mapping[int, set[float] | tuple[float, float]]] | None
-    pass_manager: PassManager | None
-
-
-def _compile(
+def to_braket(
     circuits: _Translatable | Iterable[_Translatable] = None,
     *args,
     qubit_labels: Sequence[int] | None = None,
@@ -1056,15 +938,6 @@ def _compile(
             "Verbatim boxes require controlled transpilation to preserve gate ordering."
         )
     
-    all_verbatim_boxes = []
-    if has_verbatim_boxes:
-        extracted_circuits = []
-        for circ in circuits:
-            modified_circ, verbatim_boxes = _extract_verbatim_boxes(circ, verbatim_box_name)
-            extracted_circuits.append(modified_circ)
-            all_verbatim_boxes.append(verbatim_boxes)
-        circuits = extracted_circuits
-
     if braket_device:
         if qubit_labels:
             raise ValueError("Cannot specify qubit labels with Braket device")
@@ -1083,17 +956,8 @@ def _compile(
         circuits = pass_manager.run(circuits, callback=callback, num_processes=num_processes)
     elif not verbatim:
         target = target if basis_gates or target else _default_target(circuits)
-        
-        if has_verbatim_boxes:
-            warnings.warn("Overriding layout method to 'trivial' "
-            "and routing method to 'none' as the circuit has verbatim blocks", stacklevel=1)
-            effective_layout_method = 'trivial'
-            effective_routing_method = 'none'
-        else:
-            effective_layout_method = layout_method
-            effective_routing_method = routing_method
-        
-        if (
+
+        needs_transpile = (
             target
             or coupling_map
             or (
@@ -1102,153 +966,42 @@ def _compile(
                     basis_gates
                 )
             )
-        ):
-            circuits = transpile(
-                circuits,
+        )
+
+        if needs_transpile:
+            if has_verbatim_boxes:
+                warnings.warn(
+                    "Overriding layout method to 'trivial' "
+                    "and routing method to 'none' as the circuit has verbatim blocks",
+                    stacklevel=1,
+                )
+            pm = generate_preset_pass_manager(
+                optimization_level=optimization_level or 0,
+                target=target,
                 basis_gates=basis_gates,
                 coupling_map=coupling_map,
-                optimization_level=optimization_level,
-                target=target,
-                callback=callback,
-                num_processes=num_processes,
-                layout_method=effective_layout_method,
-                routing_method=effective_routing_method,
-                seed_transpiler=seed_transpiler,
+                layout_method="trivial" if has_verbatim_boxes else layout_method,
+                routing_method="none" if has_verbatim_boxes else routing_method,
             )
+            if has_verbatim_boxes:
+                pm.pre_init = PassManager([ExtractVerbatimBoxes(verbatim_box_name)])
+                pm.post_optimization = PassManager([RestoreVerbatimBoxes(verbatim_box_name)])
+            circuits = pm.run(circuits, callback=callback, num_processes=num_processes)
+    elif has_verbatim_boxes:
+        circuits = PassManager(
+            [ExtractVerbatimBoxes(verbatim_box_name), RestoreVerbatimBoxes(verbatim_box_name)]
+        ).run(circuits)
+
     if isinstance(target, _SubstitutedTarget):
         circuits = target._substitute(circuits)
 
-    if has_verbatim_boxes:
-        circuits = [
-            _restore_verbatim_boxes(circ, verbatim_boxes, verbatim_box_name) if len(verbatim_boxes) > 0 else circ
-            for circ, verbatim_boxes in zip(circuits, all_verbatim_boxes)
-        ]
-
-    return _CompilationContext(
-        circuits=circuits,
-        single_instance=single_instance,
-        target=target,
-        qubit_labels=qubit_labels,
-        verbatim=verbatim,
-        basis_gates=basis_gates,
-        angle_restrictions=angle_restrictions,
-        pass_manager=pass_manager,
-    )
-
-
-def to_braket(
-    circuits: _Translatable | Iterable[_Translatable] = None,
-    *args,
-    qubit_labels: Sequence[int] | None = None,
-    target: Target | None = None,
-    verbatim: bool | None = None,
-    basis_gates: Sequence[str] | None = None,
-    coupling_map: list[list[int]] | None = None,
-    angle_restrictions: Mapping[str, Mapping[int, set[float] | tuple[float, float]]] | None = None,
-    optimization_level: int = 0,
-    callback: Callable | None = None,
-    num_processes: int | None = None,
-    pass_manager: PassManager | None = None,
-    braket_device: Device | None = None,
-    add_measurements: bool = True,
-    circuit: _Translatable | Iterable[_Translatable] | None = None,
-    connectivity: list[list[int]] | None = None,
-    verbatim_box_name: str = _BRAKET_VERBATIM_BOX_NAME,
-    layout_method: str | None = None,
-    routing_method: str | None = None,
-    seed_transpiler: int | None = None,
-) -> Circuit | list[Circuit]:
-    """Converts a single or list of Qiskit QuantumCircuits to a single or list of Braket Circuits.
-
-    The recommended way to use this method is to minimally pass in qubit labels and a target
-    (instead of basis gates and coupling map). This ensures that the translated circuit is actually
-    supported by the device (and doesn't, for example, include unsupported parameters for gates).
-    The latter guarantees that the output Braket circuit uses the qubit labels of the Braket device,
-    which are not necessarily contiguous.
-
-    Args:
-        circuits (QuantumCircuit | Circuit | Program | str | Iterable): Qiskit or Braket
-            circuit(s) or OpenQASM 3 program(s) to transpile and translate to Braket.
-        qubit_labels (Sequence[int] | None): A list of (not necessarily contiguous) indices of
-            qubits in the underlying Amazon Braket device. If not supplied, then the indices are
-            assumed to be contiguous. Default: ``None``.
-        target (Target | None): A backend transpiler target. Can only be provided
-            if basis_gates is ``None``. Default: ``None``.
-        verbatim (bool): Whether to translate the circuit without any modification, in other
-            words without transpiling it. Default: ``False``.
-        basis_gates (Sequence[str] | None): The gateset to transpile to. Can only be provided
-            if target is ``None``. If ``None`` and target is ``None``, the transpiler will use
-            all gates defined in the Braket SDK. Default: ``None``.
-        coupling_map (list[list[int]] | None): If provided, will transpile to a circuit
-            with this coupling map. Default: ``None``.
-        angle_restrictions (Mapping[str, Mapping[int, set[float] | tuple[float, float]]] | None):
-            Mapping of gate names to parameter angle constraints used to
-            validate numeric parameters. Default: ``None``.
-        optimization_level (int | None): The optimization level to pass to ``qiskit.transpile``.
-            From Qiskit:
-
-            * 0: no optimization - basic translation, no optimization, trivial layout
-            * 1: light optimization - routing + potential SaberSwap, some gate cancellation
-              and 1Q gate folding
-            * 2: medium optimization - better routing (noise aware) and commutative cancellation
-            * 3: high optimization - gate resynthesis and unitary-breaking passes
-
-            Default: 0.
-        callback (Callable | None): A callback function that will be called after each transpiler
-            pass execution. Default: ``None``.
-        num_processes (int | None): The maximum number of parallel transpilation processes for
-            multiple circuits. Default: ``None``.
-        pass_manager (PassManager): `PassManager` to transpile the circuit; will raise an error if
-            used in conjunction with a target, basis gates, or connectivity. Default: ``None``.
-        braket_device (Device): Braket device to transpile to. Can only be provided if `target`
-            and ``basis_gates`` are ``None``. Default: ``None``.
-        add_measurements (bool): Whether to add measurements when translating Braket circuits.
-            Default: True.
-        circuit (QuantumCircuit | Circuit | Program | str | Iterable | None): Qiskit or Braket
-            circuit(s) or OpenQASM 3 program(s) to transpile and translate to Braket.
-            Default: ``None``. DEPRECATED: use first positional argument or ``circuits`` instead.
-        connectivity (list[list[int]] | None): If provided, will transpile to a circuit
-            with this connectivity. Default: ``None``. DEPRECATED: use ``coupling_map`` instead.
-        verbatim_box_name (str): The label name used to identify verbatim BoxOp operations
-            in Qiskit circuits. When circuits contain BoxOp operations with this label, they
-            will be preserved during transpilation by temporarily replacing them with barriers.
-            Default: ``"verbatim"``.
-        layout_method (str | None): The layout method to use during transpilation. If ``None``
-            and the circuit contains verbatim boxes, defaults to ``'trivial'`` to preserve
-            physical qubit mappings. Otherwise uses Qiskit's default. Default: ``None``.
-        routing_method (str | None): The routing method to use during transpilation. If ``None``
-            and the circuit contains verbatim boxes, defaults to ``'none'`` to disable routing
-            and preserve physical qubit structure. Otherwise uses Qiskit's default. Default: ``None``.
-        seed_transpiler (int | None): This specifies a seed used for the stochastic parts 
-            of the transpiler. Default: ``None``.
-
-    Raises:
-        ValueError: If more than one of `target`, ``basis_gates``
-            or ``coupling_map``/``connectivity``, ``pass_manager``, and ``braket_device``
-            are passed together, or if `qubit_labels` is passed with ``braket_device``.
-
-    Returns:
-        Circuit | list[Circuit]: Braket circuit or circuits
-    """
-    result = _compile(
-        circuits, *args,
-        qubit_labels=qubit_labels, target=target, verbatim=verbatim,
-        basis_gates=basis_gates, coupling_map=coupling_map,
-        angle_restrictions=angle_restrictions, optimization_level=optimization_level,
-        callback=callback, num_processes=num_processes, pass_manager=pass_manager,
-        braket_device=braket_device, add_measurements=add_measurements,
-        circuit=circuit, connectivity=connectivity, verbatim_box_name=verbatim_box_name,
-        layout_method=layout_method, routing_method=routing_method,
-        seed_transpiler=seed_transpiler,
-    )
     translated = [
         _translate_to_braket(
-            circ, result.target, result.qubit_labels, result.verbatim,
-            result.basis_gates, result.angle_restrictions, result.pass_manager,
+            circ, target, qubit_labels, verbatim, basis_gates, angle_restrictions, pass_manager
         )
-        for circ in result.circuits
+        for circ in circuits
     ]
-    return translated[0] if result.single_instance else translated
+    return translated[0] if single_instance else translated
 
 
 def _get_circuits(

--- a/qiskit_braket_provider/providers/verbatim_passes.py
+++ b/qiskit_braket_provider/providers/verbatim_passes.py
@@ -1,0 +1,119 @@
+"""Transpiler passes for preserving Braket verbatim boxes through compilation.
+
+Braket verbatim boxes (``#pragma braket verbatim``) mark circuit regions that
+must reach hardware unmodified. In Qiskit these are represented as
+:class:`~qiskit.circuit.BoxOp` nodes with a ``"verbatim"`` label.
+
+Since the Qiskit transpiler has no notion of verbatim semantics, these two
+passes bracket the transpilation pipeline:
+
+- :class:`ExtractVerbatimBoxes` (pre-transpilation): swaps each verbatim
+  ``BoxOp`` for a labeled :class:`~qiskit.circuit.Barrier` that the
+  transpiler will leave untouched, and stashes the original circuits in
+  ``property_set["verbatim_boxes"]``.
+
+- :class:`RestoreVerbatimBoxes` (post-transpilation): replaces the labeled
+  barriers with the stashed gate sequences.
+
+Both passes must share a ``property_set``, which happens automatically when
+they live in the same :class:`~qiskit.transpiler.PassManager` or
+:class:`~qiskit.transpiler.StagedPassManager`.
+"""
+
+from qiskit.circuit import Barrier, BoxOp
+from qiskit.converters import circuit_to_dag
+from qiskit.dagcircuit import DAGCircuit
+from qiskit.transpiler.basepasses import TransformationPass
+
+_BRAKET_VERBATIM_BOX_NAME = "verbatim"
+
+
+class ExtractVerbatimBoxes(TransformationPass):
+    """Swap verbatim ``BoxOp`` nodes for labeled barriers before transpilation.
+
+    The original box circuits are stashed in ``property_set["verbatim_boxes"]``
+    as a list of ``QuantumCircuit`` instances for
+    :class:`RestoreVerbatimBoxes` to restore afterwards.
+
+    Args:
+        verbatim_box_name: Label used to identify verbatim ``BoxOp`` nodes.
+    """
+
+    def __init__(self, verbatim_box_name: str = _BRAKET_VERBATIM_BOX_NAME):
+        super().__init__()
+        self._verbatim_box_name = verbatim_box_name
+
+    def run(self, dag: DAGCircuit) -> DAGCircuit:
+        """Replace matching ``BoxOp`` nodes with labeled barriers.
+
+        Raises:
+            ValueError: If the DAG already contains a barrier whose label
+                matches ``verbatim_box_name``.
+        """
+        for node in dag.op_nodes(Barrier):
+            if getattr(node.op, "label", None) == self._verbatim_box_name:
+                raise ValueError(
+                    f"Circuit contains a Barrier with label '{self._verbatim_box_name}' "
+                    "which conflicts with the verbatim box label"
+                )
+
+        verbatim_boxes = []
+        for node in dag.op_nodes(BoxOp):
+            if getattr(node.op, "label", None) != self._verbatim_box_name:
+                continue
+            verbatim_boxes.append(node.op.blocks[0])
+            dag.substitute_node(node, Barrier(len(node.qargs), label=self._verbatim_box_name))
+
+        self.property_set["verbatim_boxes"] = verbatim_boxes
+        return dag
+
+
+class RestoreVerbatimBoxes(TransformationPass):
+    """Replace labeled barriers with the original verbatim gate sequences.
+
+    Reads ``property_set["verbatim_boxes"]`` populated by
+    :class:`ExtractVerbatimBoxes`.
+
+    Args:
+        verbatim_box_name: Label used to identify placeholder barriers.
+    """
+
+    def __init__(self, verbatim_box_name: str = _BRAKET_VERBATIM_BOX_NAME):
+        super().__init__()
+        self._verbatim_box_name = verbatim_box_name
+
+    def run(self, dag: DAGCircuit) -> DAGCircuit:
+        """Splice stashed gate sequences back in place of labeled barriers.
+
+        Raises:
+            ValueError: If the number of labeled barriers does not match
+                the number of stashed verbatim boxes.
+        """
+        verbatim_boxes = self.property_set.get("verbatim_boxes", [])
+        if not verbatim_boxes:
+            return dag
+
+        barrier_nodes = [
+            node
+            for node in dag.op_nodes(Barrier)
+            if getattr(node.op, "label", None) == self._verbatim_box_name
+        ]
+
+        if len(barrier_nodes) > len(verbatim_boxes):
+            raise ValueError(
+                f"Compiler error while processing verbatim boxes. "
+                f"Illegal barriers with label '{self._verbatim_box_name}'"
+            )
+        if len(barrier_nodes) < len(verbatim_boxes):
+            raise ValueError(
+                f"Compiler error while processing verbatim boxes. "
+                f"Expected {len(barrier_nodes)} verbatim boxes, "
+                f"but found {len(verbatim_boxes)}."
+            )
+
+        for node, box_circuit in zip(barrier_nodes, verbatim_boxes):
+            box_dag = circuit_to_dag(box_circuit)
+            wires = dict(zip(box_dag.qubits, node.qargs))
+            dag.substitute_node_with_dag(node, box_dag, wires=wires)
+
+        return dag

--- a/qiskit_braket_provider/providers/verbatim_passes.py
+++ b/qiskit_braket_provider/providers/verbatim_passes.py
@@ -28,6 +28,17 @@ from qiskit.transpiler.basepasses import TransformationPass
 _BRAKET_VERBATIM_BOX_NAME = "verbatim"
 
 
+def _indexed_label(base: str, index: int) -> str:
+    return f"{base}__{index}"
+
+
+def _is_verbatim_label(label: str | None, base: str) -> bool:
+    """Check if a label is a verbatim barrier label (base or indexed)."""
+    if label is None:
+        return False
+    return label == base or (label.startswith(f"{base}__") and label[len(base) + 2 :].isdigit())
+
+
 class ExtractVerbatimBoxes(TransformationPass):
     """Swap verbatim ``BoxOp`` nodes for labeled barriers before transpilation.
 
@@ -51,18 +62,21 @@ class ExtractVerbatimBoxes(TransformationPass):
                 matches ``verbatim_box_name``.
         """
         for node in dag.op_nodes(Barrier):
-            if getattr(node.op, "label", None) == self._verbatim_box_name:
+            if _is_verbatim_label(getattr(node.op, "label", None), self._verbatim_box_name):
                 raise ValueError(
-                    f"Circuit contains a Barrier with label '{self._verbatim_box_name}' "
+                    f"Circuit contains a Barrier with label '{node.op.label}' "
                     "which conflicts with the verbatim box label"
                 )
 
-        verbatim_boxes = []
+        verbatim_boxes = {}
+        index = 0
         for node in dag.op_nodes(BoxOp):
             if getattr(node.op, "label", None) != self._verbatim_box_name:
                 continue
-            verbatim_boxes.append(node.op.blocks[0])
-            dag.substitute_node(node, Barrier(len(node.qargs), label=self._verbatim_box_name))
+            label = _indexed_label(self._verbatim_box_name, index)
+            verbatim_boxes[label] = node.op.blocks[0]
+            dag.substitute_node(node, Barrier(len(node.qargs), label=label))
+            index += 1
 
         self.property_set["verbatim_boxes"] = verbatim_boxes
         return dag
@@ -89,31 +103,30 @@ class RestoreVerbatimBoxes(TransformationPass):
             ValueError: If the number of labeled barriers does not match
                 the number of stashed verbatim boxes.
         """
-        verbatim_boxes = self.property_set.get("verbatim_boxes", [])
+        verbatim_boxes = self.property_set.get("verbatim_boxes", {})
         if not verbatim_boxes:
             return dag
 
-        barrier_nodes = [
-            node
-            for node in dag.op_nodes(Barrier)
-            if getattr(node.op, "label", None) == self._verbatim_box_name
-        ]
+        remaining = dict(verbatim_boxes)
 
-        if len(barrier_nodes) > len(verbatim_boxes):
-            raise ValueError(
-                f"Compiler error while processing verbatim boxes. "
-                f"Illegal barriers with label '{self._verbatim_box_name}'"
-            )
-        if len(barrier_nodes) < len(verbatim_boxes):
-            raise ValueError(
-                f"Compiler error while processing verbatim boxes. "
-                f"Expected {len(barrier_nodes)} verbatim boxes, "
-                f"but found {len(verbatim_boxes)}."
-            )
-
-        for node, box_circuit in zip(barrier_nodes, verbatim_boxes):
+        for node in dag.op_nodes(Barrier):
+            label = getattr(node.op, "label", None)
+            if not _is_verbatim_label(label, self._verbatim_box_name):
+                continue
+            if label not in remaining:
+                raise ValueError(
+                    f"Compiler error while processing verbatim boxes. "
+                    f"Illegal barrier with label '{label}'"
+                )
+            box_circuit = remaining.pop(label)
             box_dag = circuit_to_dag(box_circuit)
             wires = dict(zip(box_dag.qubits, node.qargs))
             dag.substitute_node_with_dag(node, box_dag, wires=wires)
+
+        if remaining:
+            raise ValueError(
+                f"Compiler error while processing verbatim boxes. "
+                f"Missing barriers for: {list(remaining.keys())}"
+            )
 
         return dag

--- a/qiskit_braket_provider/providers/verbatim_passes.py
+++ b/qiskit_braket_provider/providers/verbatim_passes.py
@@ -107,26 +107,24 @@ class RestoreVerbatimBoxes(TransformationPass):
         if not verbatim_boxes:
             return dag
 
-        remaining = dict(verbatim_boxes)
-
         for node in dag.op_nodes(Barrier):
             label = getattr(node.op, "label", None)
             if not _is_verbatim_label(label, self._verbatim_box_name):
                 continue
-            if label not in remaining:
-                raise ValueError(
-                    f"Compiler error while processing verbatim boxes. "
-                    f"Illegal barrier with label '{label}'"
+            if label not in verbatim_boxes:
+                raise RuntimeError(
+                    f"Internal error: verbatim barrier '{label}' has no matching box. "
+                    f"This is a bug in the verbatim pass pipeline."
                 )
-            box_circuit = remaining.pop(label)
+            box_circuit = verbatim_boxes.pop(label)
             box_dag = circuit_to_dag(box_circuit)
-            wires = dict(zip(box_dag.qubits, node.qargs))
-            dag.substitute_node_with_dag(node, box_dag, wires=wires)
+            dag.substitute_node_with_dag(node, box_dag)
 
-        if remaining:
-            raise ValueError(
-                f"Compiler error while processing verbatim boxes. "
-                f"Missing barriers for: {list(remaining.keys())}"
+        if verbatim_boxes:
+            raise RuntimeError(
+                f"Internal error: verbatim boxes lost during transpilation: "
+                f"{list(verbatim_boxes.keys())}. "
+                f"This is a bug in the verbatim pass pipeline."
             )
 
         return dag

--- a/tests/providers/test_adapter.py
+++ b/tests/providers/test_adapter.py
@@ -1,7 +1,7 @@
 """Tests for Qiskit to Braket adapter."""
 
 from unittest import TestCase
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import numpy as np
 import pytest
@@ -867,14 +867,16 @@ class TestAdapter(TestCase):
         with pytest.raises(ValueError, match="Please rename your parameters."):
             to_braket(qiskit_circuit)
 
-    @patch("qiskit_braket_provider.providers.adapter.transpile")
-    def test_invalid_ctrl_state(self, mock_transpile):
+    @patch("qiskit_braket_provider.providers.adapter.generate_preset_pass_manager")
+    def test_invalid_ctrl_state(self, mock_gen_pm):
         """Tests that control states other than all 1s are rejected."""
         qiskit_circuit = QuantumCircuit(2)
         qiskit_circuit.h(0)
         qiskit_circuit.cx(0, 1, ctrl_state=0)
 
-        mock_transpile.return_value = [qiskit_circuit]
+        mock_pm = MagicMock()
+        mock_pm.run.return_value = [qiskit_circuit]
+        mock_gen_pm.return_value = mock_pm
         with pytest.raises(ValueError):
             to_braket(qiskit_circuit)
 

--- a/tests/providers/test_adapter.py
+++ b/tests/providers/test_adapter.py
@@ -2,7 +2,7 @@
 
 import copy
 from unittest import TestCase
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import numpy as np
 import pytest
@@ -872,14 +872,16 @@ class TestAdapter(TestCase):
         with pytest.raises(ValueError, match="Please rename your parameters."):
             to_braket(qiskit_circuit)
 
-    @patch("qiskit_braket_provider.providers.adapter.transpile")
-    def test_invalid_ctrl_state(self, mock_transpile):
+    @patch("qiskit_braket_provider.providers.adapter.generate_preset_pass_manager")
+    def test_invalid_ctrl_state(self, mock_gen_pm):
         """Tests that control states other than all 1s are rejected."""
         qiskit_circuit = QuantumCircuit(2)
         qiskit_circuit.h(0)
         qiskit_circuit.cx(0, 1, ctrl_state=0)
 
-        mock_transpile.return_value = [qiskit_circuit]
+        mock_pm = MagicMock()
+        mock_pm.run.return_value = [qiskit_circuit]
+        mock_gen_pm.return_value = mock_pm
         with pytest.raises(ValueError):
             to_braket(qiskit_circuit)
 

--- a/tests/providers/test_adapter_branching.py
+++ b/tests/providers/test_adapter_branching.py
@@ -4,6 +4,7 @@ import pytest
 from qiskit.circuit import Clbit, IfElseOp
 from qiskit.circuit.library import CXGate, HGate, Measure, XGate, YGate, ZGate
 from qiskit.transpiler import Target
+from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 
 from braket.default_simulator.openqasm.parser.openqasm_ast import (
     ArrayLiteral,
@@ -16,8 +17,6 @@ from braket.default_simulator.openqasm.parser.openqasm_ast import (
     UnaryOperator,
 )
 from qiskit_braket_provider import to_qiskit
-from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
-
 from qiskit_braket_provider.providers.adapter import _QiskitProgramContext
 
 
@@ -398,9 +397,9 @@ if (c[0] == 1) {
 )
 def test_compile_preserves_if_else_ops(qasm, expected_if_else_count, mcm_target):
     """IfElseOps should survive compilation through _compile."""
-    compiled_circuit = generate_preset_pass_manager(
-        optimization_level=0, target=mcm_target
-    ).run(to_qiskit(qasm))
+    compiled_circuit = generate_preset_pass_manager(optimization_level=0, target=mcm_target).run(
+        to_qiskit(qasm)
+    )
     if_else_ops = [
         instr for instr in compiled_circuit.data if isinstance(instr.operation, IfElseOp)
     ]
@@ -420,9 +419,9 @@ if (c[0] == 1) {
     x q[1];
 }
 """
-    compiled_circuit = generate_preset_pass_manager(
-        optimization_level=0, target=mcm_target
-    ).run(to_qiskit(qasm))
+    compiled_circuit = generate_preset_pass_manager(optimization_level=0, target=mcm_target).run(
+        to_qiskit(qasm)
+    )
     op = next(
         instr for instr in compiled_circuit.data if isinstance(instr.operation, IfElseOp)
     ).operation
@@ -443,9 +442,9 @@ if (c[0] == 1) {
     h q[1];
 }
 """
-    compiled_circuit = generate_preset_pass_manager(
-        optimization_level=0, target=mcm_target
-    ).run(to_qiskit(qasm))
+    compiled_circuit = generate_preset_pass_manager(optimization_level=0, target=mcm_target).run(
+        to_qiskit(qasm)
+    )
     instr = next(i for i in compiled_circuit.data if isinstance(i.operation, IfElseOp))
     op = instr.operation
     clbit, value = op.condition

--- a/tests/providers/test_adapter_branching.py
+++ b/tests/providers/test_adapter_branching.py
@@ -16,7 +16,9 @@ from braket.default_simulator.openqasm.parser.openqasm_ast import (
     UnaryOperator,
 )
 from qiskit_braket_provider import to_qiskit
-from qiskit_braket_provider.providers.adapter import _compile, _QiskitProgramContext
+from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
+
+from qiskit_braket_provider.providers.adapter import _QiskitProgramContext
 
 
 def _get_if_else_ops(circuit):
@@ -396,8 +398,9 @@ if (c[0] == 1) {
 )
 def test_compile_preserves_if_else_ops(qasm, expected_if_else_count, mcm_target):
     """IfElseOps should survive compilation through _compile."""
-    result = _compile(qasm, target=mcm_target)
-    compiled_circuit = result.circuits[0]
+    compiled_circuit = generate_preset_pass_manager(
+        optimization_level=0, target=mcm_target
+    ).run(to_qiskit(qasm))
     if_else_ops = [
         instr for instr in compiled_circuit.data if isinstance(instr.operation, IfElseOp)
     ]
@@ -417,8 +420,9 @@ if (c[0] == 1) {
     x q[1];
 }
 """
-    result = _compile(qasm, target=mcm_target)
-    compiled_circuit = result.circuits[0]
+    compiled_circuit = generate_preset_pass_manager(
+        optimization_level=0, target=mcm_target
+    ).run(to_qiskit(qasm))
     op = next(
         instr for instr in compiled_circuit.data if isinstance(instr.operation, IfElseOp)
     ).operation
@@ -439,8 +443,9 @@ if (c[0] == 1) {
     h q[1];
 }
 """
-    result = _compile(qasm, target=mcm_target)
-    compiled_circuit = result.circuits[0]
+    compiled_circuit = generate_preset_pass_manager(
+        optimization_level=0, target=mcm_target
+    ).run(to_qiskit(qasm))
     instr = next(i for i in compiled_circuit.data if isinstance(i.operation, IfElseOp))
     op = instr.operation
     clbit, value = op.condition

--- a/tests/providers/test_adapter_to_braket_verbatim.py
+++ b/tests/providers/test_adapter_to_braket_verbatim.py
@@ -8,10 +8,12 @@ from qiskit.transpiler.passes import Optimize1qGates
 
 from braket.ir.openqasm import Program
 from qiskit_braket_provider.providers.adapter import (
-    _extract_verbatim_boxes,
-    _restore_verbatim_boxes,
     to_braket,
     to_qiskit,
+)
+from qiskit_braket_provider.providers.verbatim_passes import (
+    ExtractVerbatimBoxes,
+    RestoreVerbatimBoxes,
 )
 
 VERBATIM_LABEL = "verbatim"
@@ -106,6 +108,20 @@ def cx_circuit():
     return _make_box_circuit(NUM_QUBITS, [("cx", [0, 1])])
 
 
+def _extract(circuit, label=VERBATIM_LABEL):
+    """Helper: run ExtractVerbatimBoxes and return (modified_circuit, boxes)."""
+    extract_pass = ExtractVerbatimBoxes(label)
+    modified = extract_pass(circuit)
+    return modified, extract_pass.property_set["verbatim_boxes"]
+
+
+def _restore(transpiled, boxes, label=VERBATIM_LABEL):
+    """Helper: run RestoreVerbatimBoxes with pre-populated property_set."""
+    restore_pass = RestoreVerbatimBoxes(label)
+    restore_pass.property_set["verbatim_boxes"] = boxes
+    return restore_pass(transpiled)
+
+
 @pytest.mark.parametrize(
     "inner_gates, expected_gate_names, expected_qubits",
     [
@@ -119,16 +135,14 @@ def test_verbatim_box_extraction(inner_gates, expected_gate_names, expected_qubi
     main = QuantumCircuit(NUM_QUBITS)
     main.append(BoxOp(inner, label=VERBATIM_LABEL), QUBIT_PAIR)
 
-    modified, boxes = _extract_verbatim_boxes(main, VERBATIM_LABEL)
+    modified, boxes = _extract(main)
 
     assert len(modified.data) == 1
     assert isinstance(modified.data[0].operation, Barrier)
     assert modified.data[0].operation.label == VERBATIM_LABEL
 
     assert len(boxes) == 1
-    box_circuit, qubit_indices = boxes[0]
-    assert [d.operation.name for d in box_circuit.data] == expected_gate_names
-    assert qubit_indices == expected_qubits
+    assert [d.operation.name for d in boxes[0].data] == expected_gate_names
 
 
 def test_multiple_verbatim_boxes_extraction(h_circuit, cx_circuit):
@@ -137,7 +151,7 @@ def test_multiple_verbatim_boxes_extraction(h_circuit, cx_circuit):
     main.x(1)
     main.append(BoxOp(cx_circuit, label=VERBATIM_LABEL), QUBIT_PAIR)
 
-    modified, boxes = _extract_verbatim_boxes(main, VERBATIM_LABEL)
+    modified, boxes = _extract(main)
 
     barriers = [i for i in modified.data if isinstance(i.operation, Barrier)]
     assert len(barriers) == 2
@@ -145,13 +159,13 @@ def test_multiple_verbatim_boxes_extraction(h_circuit, cx_circuit):
     assert len([i for i in modified.data if i.operation.name == "x"]) == 1
 
     assert len(boxes) == 2
-    assert boxes[0][0].data[0].operation.name == "h"
-    assert boxes[1][0].data[0].operation.name == "cx"
+    assert boxes[0].data[0].operation.name == "h"
+    assert boxes[1].data[0].operation.name == "cx"
 
 
 def test_circuit_without_verbatim_boxes():
     main = _make_box_circuit(NUM_QUBITS, [("h", [0]), ("cx", [0, 1])])
-    modified, boxes = _extract_verbatim_boxes(main, VERBATIM_LABEL)
+    modified, boxes = _extract(main)
 
     assert len(modified.data) == 2
     assert [d.operation.name for d in modified.data] == ["h", "cx"]
@@ -162,7 +176,7 @@ def test_non_verbatim_boxop_not_extracted(h_circuit):
     main = QuantumCircuit(NUM_QUBITS)
     main.append(BoxOp(h_circuit, label="other_label"), QUBIT_PAIR)
 
-    modified, boxes = _extract_verbatim_boxes(main, VERBATIM_LABEL)
+    modified, boxes = _extract(main)
 
     assert len(boxes) == 0
     assert len(modified.data) == 1
@@ -174,7 +188,7 @@ def test_single_verbatim_box_restoration(h_cx_circuit):
     transpiled = QuantumCircuit(NUM_QUBITS)
     transpiled.append(Barrier(NUM_QUBITS, label=VERBATIM_LABEL), QUBIT_PAIR)
 
-    restored = _restore_verbatim_boxes(transpiled, [(h_cx_circuit, QUBIT_PAIR)], VERBATIM_LABEL)
+    restored = _restore(transpiled, [h_cx_circuit])
 
     assert len(restored.data) == 2
     assert restored.data[0].operation.name == "h"
@@ -190,9 +204,7 @@ def test_multiple_verbatim_boxes_restoration(h_circuit, cx_circuit):
     transpiled.x(1)
     transpiled.append(Barrier(NUM_QUBITS, label=VERBATIM_LABEL), QUBIT_PAIR)
 
-    restored = _restore_verbatim_boxes(
-        transpiled, [(h_circuit, QUBIT_PAIR), (cx_circuit, QUBIT_PAIR)], VERBATIM_LABEL
-    )
+    restored = _restore(transpiled, [h_circuit, cx_circuit])
 
     gate_names = [i.operation.name for i in restored.data]
     assert gate_names == ["h", "x", "cx"]
@@ -211,10 +223,10 @@ def test_barrier_box_count_mismatch(num_barriers, num_boxes, error_match):
     for _ in range(num_barriers):
         transpiled.append(Barrier(NUM_QUBITS, label=VERBATIM_LABEL), QUBIT_PAIR)
 
-    boxes = [(_make_box_circuit(NUM_QUBITS, [("h", [0])]), QUBIT_PAIR) for _ in range(num_boxes)]
+    boxes = [_make_box_circuit(NUM_QUBITS, [("h", [0])]) for _ in range(num_boxes)]
 
     with pytest.raises(ValueError, match=error_match):
-        _restore_verbatim_boxes(transpiled, boxes, VERBATIM_LABEL)
+        _restore(transpiled, boxes)
 
 
 def test_to_braket_with_single_verbatim_box(h_cx_circuit):

--- a/tests/providers/test_adapter_to_braket_verbatim.py
+++ b/tests/providers/test_adapter_to_braket_verbatim.py
@@ -206,10 +206,13 @@ def test_multiple_verbatim_boxes_restoration(h_circuit, cx_circuit):
     transpiled.x(1)
     transpiled.append(Barrier(NUM_QUBITS, label=f"{VERBATIM_LABEL}__1"), QUBIT_PAIR)
 
-    restored = _restore(transpiled, {
-        f"{VERBATIM_LABEL}__0": h_circuit,
-        f"{VERBATIM_LABEL}__1": cx_circuit,
-    })
+    restored = _restore(
+        transpiled,
+        {
+            f"{VERBATIM_LABEL}__0": h_circuit,
+            f"{VERBATIM_LABEL}__1": cx_circuit,
+        },
+    )
 
     gate_names = [i.operation.name for i in restored.data]
     assert gate_names == ["h", "x", "cx"]
@@ -228,7 +231,9 @@ def test_barrier_box_count_mismatch(num_barriers, num_boxes, error_match):
     for i in range(num_barriers):
         transpiled.append(Barrier(NUM_QUBITS, label=f"{VERBATIM_LABEL}__{i}"), QUBIT_PAIR)
 
-    boxes = {f"{VERBATIM_LABEL}__{i}": _make_circuit(NUM_QUBITS, [("h", [0])]) for i in range(num_boxes)}
+    boxes = {
+        f"{VERBATIM_LABEL}__{i}": _make_circuit(NUM_QUBITS, [("h", [0])]) for i in range(num_boxes)
+    }
 
     with pytest.raises(RuntimeError, match=error_match):
         _restore(transpiled, boxes)

--- a/tests/providers/test_adapter_to_braket_verbatim.py
+++ b/tests/providers/test_adapter_to_braket_verbatim.py
@@ -139,10 +139,10 @@ def test_verbatim_box_extraction(inner_gates, expected_gate_names, expected_qubi
 
     assert len(modified.data) == 1
     assert isinstance(modified.data[0].operation, Barrier)
-    assert modified.data[0].operation.label == VERBATIM_LABEL
+    assert modified.data[0].operation.label.startswith(VERBATIM_LABEL)
 
     assert len(boxes) == 1
-    assert [d.operation.name for d in boxes[0].data] == expected_gate_names
+    assert [d.operation.name for d in list(boxes.values())[0].data] == expected_gate_names
 
 
 def test_multiple_verbatim_boxes_extraction(h_circuit, cx_circuit):
@@ -155,12 +155,14 @@ def test_multiple_verbatim_boxes_extraction(h_circuit, cx_circuit):
 
     barriers = [i for i in modified.data if isinstance(i.operation, Barrier)]
     assert len(barriers) == 2
-    assert all(b.operation.label == VERBATIM_LABEL for b in barriers)
+    assert all(b.operation.label.startswith(VERBATIM_LABEL) for b in barriers)
+    assert barriers[0].operation.label != barriers[1].operation.label
     assert len([i for i in modified.data if i.operation.name == "x"]) == 1
 
-    assert len(boxes) == 2
-    assert boxes[0].data[0].operation.name == "h"
-    assert boxes[1].data[0].operation.name == "cx"
+    box_list = list(boxes.values())
+    assert len(box_list) == 2
+    assert box_list[0].data[0].operation.name == "h"
+    assert box_list[1].data[0].operation.name == "cx"
 
 
 def test_circuit_without_verbatim_boxes():
@@ -186,9 +188,9 @@ def test_non_verbatim_boxop_not_extracted(h_circuit):
 
 def test_single_verbatim_box_restoration(h_cx_circuit):
     transpiled = QuantumCircuit(NUM_QUBITS)
-    transpiled.append(Barrier(NUM_QUBITS, label=VERBATIM_LABEL), QUBIT_PAIR)
+    transpiled.append(Barrier(NUM_QUBITS, label=f"{VERBATIM_LABEL}__0"), QUBIT_PAIR)
 
-    restored = _restore(transpiled, [h_cx_circuit])
+    restored = _restore(transpiled, {f"{VERBATIM_LABEL}__0": h_cx_circuit})
 
     assert len(restored.data) == 2
     assert restored.data[0].operation.name == "h"
@@ -200,11 +202,14 @@ def test_single_verbatim_box_restoration(h_cx_circuit):
 
 def test_multiple_verbatim_boxes_restoration(h_circuit, cx_circuit):
     transpiled = QuantumCircuit(NUM_QUBITS)
-    transpiled.append(Barrier(NUM_QUBITS, label=VERBATIM_LABEL), QUBIT_PAIR)
+    transpiled.append(Barrier(NUM_QUBITS, label=f"{VERBATIM_LABEL}__0"), QUBIT_PAIR)
     transpiled.x(1)
-    transpiled.append(Barrier(NUM_QUBITS, label=VERBATIM_LABEL), QUBIT_PAIR)
+    transpiled.append(Barrier(NUM_QUBITS, label=f"{VERBATIM_LABEL}__1"), QUBIT_PAIR)
 
-    restored = _restore(transpiled, [h_circuit, cx_circuit])
+    restored = _restore(transpiled, {
+        f"{VERBATIM_LABEL}__0": h_circuit,
+        f"{VERBATIM_LABEL}__1": cx_circuit,
+    })
 
     gate_names = [i.operation.name for i in restored.data]
     assert gate_names == ["h", "x", "cx"]
@@ -213,17 +218,17 @@ def test_multiple_verbatim_boxes_restoration(h_circuit, cx_circuit):
 @pytest.mark.parametrize(
     "num_barriers, num_boxes, error_match",
     [
-        (2, 1, "Compiler error while processing verbatim boxes.*Illegal barriers"),
-        (1, 2, "Compiler error while processing verbatim boxes.*Expected"),
+        (2, 1, "Compiler error while processing verbatim boxes.*Illegal barrier"),
+        (1, 2, "Compiler error while processing verbatim boxes.*Missing barriers"),
     ],
     ids=["too_many_barriers", "too_few_barriers"],
 )
 def test_barrier_box_count_mismatch(num_barriers, num_boxes, error_match):
     transpiled = QuantumCircuit(NUM_QUBITS)
-    for _ in range(num_barriers):
-        transpiled.append(Barrier(NUM_QUBITS, label=VERBATIM_LABEL), QUBIT_PAIR)
+    for i in range(num_barriers):
+        transpiled.append(Barrier(NUM_QUBITS, label=f"{VERBATIM_LABEL}__{i}"), QUBIT_PAIR)
 
-    boxes = [_make_box_circuit(NUM_QUBITS, [("h", [0])]) for _ in range(num_boxes)]
+    boxes = {f"{VERBATIM_LABEL}__{i}": _make_box_circuit(NUM_QUBITS, [("h", [0])]) for i in range(num_boxes)}
 
     with pytest.raises(ValueError, match=error_match):
         _restore(transpiled, boxes)
@@ -502,3 +507,73 @@ box {
     assert info[x_idx][1] == [1]
     assert info[cnot_indices[0]][1] == QUBIT_PAIR
     assert info[cnot_indices[1]][1] == [1, 2]
+
+
+def test_to_braket_verbatim_box_with_classical_register_and_measure():
+    """Verbatim box with bit[2] register and measurements round-trips correctly."""
+    qasm = """
+OPENQASM 3.0;
+bit[2] c;
+#pragma braket verbatim
+box {
+    h $0;
+    cnot $0, $1;
+}
+c[0] = measure $0;
+c[1] = measure $1;
+"""
+    qc = to_qiskit(qasm)
+    assert qc.num_clbits == 2
+
+    bc = to_braket(qc, verbatim=False, add_measurements=False)
+    names = [instr.operator.name for instr in bc.instructions]
+
+    assert "H" in names
+    assert "CNot" in names
+    assert names.count("Measure") == 2
+
+
+def test_to_braket_verbatim_box_with_ccnot_and_classical_bits():
+    """3-qubit gate inside verbatim box with classical register."""
+    qasm = """
+OPENQASM 3.0;
+bit[3] c;
+h $0;
+h $1;
+#pragma braket verbatim
+box {
+    ccnot $0, $1, $2;
+}
+c[0] = measure $0;
+c[1] = measure $1;
+c[2] = measure $2;
+"""
+    qc = to_qiskit(qasm)
+    bc = to_braket(qc, verbatim=False, add_measurements=False)
+    names = [instr.operator.name for instr in bc.instructions]
+
+    assert names == ["H", "H", "CCNot", "Measure", "Measure", "Measure"]
+
+
+def test_to_braket_verbatim_box_standalone_bit_collision():
+    """Known limitation: standalone bit vars each get classical_target=0."""
+    qasm = """
+OPENQASM 3.0;
+bit c0;
+bit c1;
+#pragma braket verbatim
+box {
+    h $0;
+    cnot $0, $1;
+}
+c0 = measure $0;
+c1 = measure $1;
+"""
+    qc = to_qiskit(qasm)
+    assert qc.num_clbits == 2
+
+    bc = to_braket(qc, verbatim=False, add_measurements=False)
+    names = [instr.operator.name for instr in bc.instructions]
+
+    # Second measure overwrites first due to both targeting clbit 0
+    assert names.count("Measure") == 1

--- a/tests/providers/test_adapter_to_braket_verbatim.py
+++ b/tests/providers/test_adapter_to_braket_verbatim.py
@@ -142,7 +142,7 @@ def test_verbatim_box_extraction(inner_gates, expected_gate_names, expected_qubi
     assert modified.data[0].operation.label.startswith(VERBATIM_LABEL)
 
     assert len(boxes) == 1
-    assert [d.operation.name for d in list(boxes.values())[0].data] == expected_gate_names
+    assert [d.operation.name for d in next(iter(boxes.values())).data] == expected_gate_names
 
 
 def test_multiple_verbatim_boxes_extraction(h_circuit, cx_circuit):

--- a/tests/providers/test_adapter_to_braket_verbatim.py
+++ b/tests/providers/test_adapter_to_braket_verbatim.py
@@ -139,10 +139,10 @@ def test_verbatim_box_extraction(inner_gates, expected_gate_names, expected_qubi
 
     assert len(modified.data) == 1
     assert isinstance(modified.data[0].operation, Barrier)
-    assert modified.data[0].operation.label == VERBATIM_LABEL
+    assert modified.data[0].operation.label.startswith(VERBATIM_LABEL)
 
     assert len(boxes) == 1
-    assert [d.operation.name for d in boxes[0].data] == expected_gate_names
+    assert [d.operation.name for d in list(boxes.values())[0].data] == expected_gate_names
 
 
 def test_multiple_verbatim_boxes_extraction(h_circuit, cx_circuit):
@@ -155,12 +155,14 @@ def test_multiple_verbatim_boxes_extraction(h_circuit, cx_circuit):
 
     barriers = [i for i in modified.data if isinstance(i.operation, Barrier)]
     assert len(barriers) == 2
-    assert all(b.operation.label == VERBATIM_LABEL for b in barriers)
+    assert all(b.operation.label.startswith(VERBATIM_LABEL) for b in barriers)
+    assert barriers[0].operation.label != barriers[1].operation.label
     assert len([i for i in modified.data if i.operation.name == "x"]) == 1
 
-    assert len(boxes) == 2
-    assert boxes[0].data[0].operation.name == "h"
-    assert boxes[1].data[0].operation.name == "cx"
+    box_list = list(boxes.values())
+    assert len(box_list) == 2
+    assert box_list[0].data[0].operation.name == "h"
+    assert box_list[1].data[0].operation.name == "cx"
 
 
 def test_circuit_without_verbatim_boxes():
@@ -186,9 +188,9 @@ def test_non_verbatim_boxop_not_extracted(h_circuit):
 
 def test_single_verbatim_box_restoration(h_cx_circuit):
     transpiled = QuantumCircuit(NUM_QUBITS)
-    transpiled.append(Barrier(NUM_QUBITS, label=VERBATIM_LABEL), QUBIT_PAIR)
+    transpiled.append(Barrier(NUM_QUBITS, label=f"{VERBATIM_LABEL}__0"), QUBIT_PAIR)
 
-    restored = _restore(transpiled, [h_cx_circuit])
+    restored = _restore(transpiled, {f"{VERBATIM_LABEL}__0": h_cx_circuit})
 
     assert len(restored.data) == 2
     assert restored.data[0].operation.name == "h"
@@ -200,11 +202,14 @@ def test_single_verbatim_box_restoration(h_cx_circuit):
 
 def test_multiple_verbatim_boxes_restoration(h_circuit, cx_circuit):
     transpiled = QuantumCircuit(NUM_QUBITS)
-    transpiled.append(Barrier(NUM_QUBITS, label=VERBATIM_LABEL), QUBIT_PAIR)
+    transpiled.append(Barrier(NUM_QUBITS, label=f"{VERBATIM_LABEL}__0"), QUBIT_PAIR)
     transpiled.x(1)
-    transpiled.append(Barrier(NUM_QUBITS, label=VERBATIM_LABEL), QUBIT_PAIR)
+    transpiled.append(Barrier(NUM_QUBITS, label=f"{VERBATIM_LABEL}__1"), QUBIT_PAIR)
 
-    restored = _restore(transpiled, [h_circuit, cx_circuit])
+    restored = _restore(transpiled, {
+        f"{VERBATIM_LABEL}__0": h_circuit,
+        f"{VERBATIM_LABEL}__1": cx_circuit,
+    })
 
     gate_names = [i.operation.name for i in restored.data]
     assert gate_names == ["h", "x", "cx"]
@@ -213,17 +218,17 @@ def test_multiple_verbatim_boxes_restoration(h_circuit, cx_circuit):
 @pytest.mark.parametrize(
     "num_barriers, num_boxes, error_match",
     [
-        (2, 1, "Compiler error while processing verbatim boxes.*Illegal barriers"),
-        (1, 2, "Compiler error while processing verbatim boxes.*Expected"),
+        (2, 1, "Compiler error while processing verbatim boxes.*Illegal barrier"),
+        (1, 2, "Compiler error while processing verbatim boxes.*Missing barriers"),
     ],
     ids=["too_many_barriers", "too_few_barriers"],
 )
 def test_barrier_box_count_mismatch(num_barriers, num_boxes, error_match):
     transpiled = QuantumCircuit(NUM_QUBITS)
-    for _ in range(num_barriers):
-        transpiled.append(Barrier(NUM_QUBITS, label=VERBATIM_LABEL), QUBIT_PAIR)
+    for i in range(num_barriers):
+        transpiled.append(Barrier(NUM_QUBITS, label=f"{VERBATIM_LABEL}__{i}"), QUBIT_PAIR)
 
-    boxes = [_make_box_circuit(NUM_QUBITS, [("h", [0])]) for _ in range(num_boxes)]
+    boxes = {f"{VERBATIM_LABEL}__{i}": _make_box_circuit(NUM_QUBITS, [("h", [0])]) for i in range(num_boxes)}
 
     with pytest.raises(ValueError, match=error_match):
         _restore(transpiled, boxes)
@@ -507,3 +512,73 @@ box {
     assert info[x_idx][1] == [1]
     assert info[cnot_indices[0]][1] == QUBIT_PAIR
     assert info[cnot_indices[1]][1] == [1, 2]
+
+
+def test_to_braket_verbatim_box_with_classical_register_and_measure():
+    """Verbatim box with bit[2] register and measurements round-trips correctly."""
+    qasm = """
+OPENQASM 3.0;
+bit[2] c;
+#pragma braket verbatim
+box {
+    h $0;
+    cnot $0, $1;
+}
+c[0] = measure $0;
+c[1] = measure $1;
+"""
+    qc = to_qiskit(qasm)
+    assert qc.num_clbits == 2
+
+    bc = to_braket(qc, verbatim=False, add_measurements=False)
+    names = [instr.operator.name for instr in bc.instructions]
+
+    assert "H" in names
+    assert "CNot" in names
+    assert names.count("Measure") == 2
+
+
+def test_to_braket_verbatim_box_with_ccnot_and_classical_bits():
+    """3-qubit gate inside verbatim box with classical register."""
+    qasm = """
+OPENQASM 3.0;
+bit[3] c;
+h $0;
+h $1;
+#pragma braket verbatim
+box {
+    ccnot $0, $1, $2;
+}
+c[0] = measure $0;
+c[1] = measure $1;
+c[2] = measure $2;
+"""
+    qc = to_qiskit(qasm)
+    bc = to_braket(qc, verbatim=False, add_measurements=False)
+    names = [instr.operator.name for instr in bc.instructions]
+
+    assert names == ["H", "H", "CCNot", "Measure", "Measure", "Measure"]
+
+
+def test_to_braket_verbatim_box_standalone_bit_collision():
+    """Known limitation: standalone bit vars each get classical_target=0."""
+    qasm = """
+OPENQASM 3.0;
+bit c0;
+bit c1;
+#pragma braket verbatim
+box {
+    h $0;
+    cnot $0, $1;
+}
+c0 = measure $0;
+c1 = measure $1;
+"""
+    qc = to_qiskit(qasm)
+    assert qc.num_clbits == 2
+
+    bc = to_braket(qc, verbatim=False, add_measurements=False)
+    names = [instr.operator.name for instr in bc.instructions]
+
+    # Second measure overwrites first due to both targeting clbit 0
+    assert names.count("Measure") == 1

--- a/tests/providers/test_adapter_to_braket_verbatim.py
+++ b/tests/providers/test_adapter_to_braket_verbatim.py
@@ -21,7 +21,7 @@ NUM_QUBITS = 2
 QUBIT_PAIR = [0, 1]
 
 
-def _make_box_circuit(num_qubits, gates):
+def _make_circuit(num_qubits, gates):
     """Create a QuantumCircuit with the given gates applied.
 
     Args:
@@ -93,19 +93,19 @@ y $1;
 @pytest.fixture
 def h_cx_circuit():
     """2-qubit circuit with H on q0 and CX on q0,q1."""
-    return _make_box_circuit(NUM_QUBITS, [("h", [0]), ("cx", [0, 1])])
+    return _make_circuit(NUM_QUBITS, [("h", [0]), ("cx", [0, 1])])
 
 
 @pytest.fixture
 def h_circuit():
     """1-qubit circuit with H on q0."""
-    return _make_box_circuit(NUM_QUBITS, [("h", [0])])
+    return _make_circuit(NUM_QUBITS, [("h", [0])])
 
 
 @pytest.fixture
 def cx_circuit():
     """2-qubit circuit with CX on q0,q1."""
-    return _make_box_circuit(NUM_QUBITS, [("cx", [0, 1])])
+    return _make_circuit(NUM_QUBITS, [("cx", [0, 1])])
 
 
 def _extract(circuit, label=VERBATIM_LABEL):
@@ -131,7 +131,7 @@ def _restore(transpiled, boxes, label=VERBATIM_LABEL):
     ids=["single_box_with_gates", "empty_box"],
 )
 def test_verbatim_box_extraction(inner_gates, expected_gate_names, expected_qubits):
-    inner = _make_box_circuit(NUM_QUBITS, inner_gates)
+    inner = _make_circuit(NUM_QUBITS, inner_gates)
     main = QuantumCircuit(NUM_QUBITS)
     main.append(BoxOp(inner, label=VERBATIM_LABEL), QUBIT_PAIR)
 
@@ -166,7 +166,7 @@ def test_multiple_verbatim_boxes_extraction(h_circuit, cx_circuit):
 
 
 def test_circuit_without_verbatim_boxes():
-    main = _make_box_circuit(NUM_QUBITS, [("h", [0]), ("cx", [0, 1])])
+    main = _make_circuit(NUM_QUBITS, [("h", [0]), ("cx", [0, 1])])
     modified, boxes = _extract(main)
 
     assert len(modified.data) == 2
@@ -218,8 +218,8 @@ def test_multiple_verbatim_boxes_restoration(h_circuit, cx_circuit):
 @pytest.mark.parametrize(
     "num_barriers, num_boxes, error_match",
     [
-        (2, 1, "Compiler error while processing verbatim boxes.*Illegal barrier"),
-        (1, 2, "Compiler error while processing verbatim boxes.*Missing barriers"),
+        (2, 1, "Internal error.*no matching box"),
+        (1, 2, "Internal error.*lost during transpilation"),
     ],
     ids=["too_many_barriers", "too_few_barriers"],
 )
@@ -228,9 +228,9 @@ def test_barrier_box_count_mismatch(num_barriers, num_boxes, error_match):
     for i in range(num_barriers):
         transpiled.append(Barrier(NUM_QUBITS, label=f"{VERBATIM_LABEL}__{i}"), QUBIT_PAIR)
 
-    boxes = {f"{VERBATIM_LABEL}__{i}": _make_box_circuit(NUM_QUBITS, [("h", [0])]) for i in range(num_boxes)}
+    boxes = {f"{VERBATIM_LABEL}__{i}": _make_circuit(NUM_QUBITS, [("h", [0])]) for i in range(num_boxes)}
 
-    with pytest.raises(ValueError, match=error_match):
+    with pytest.raises(RuntimeError, match=error_match):
         _restore(transpiled, boxes)
 
 
@@ -294,7 +294,7 @@ def test_to_braket_with_custom_verbatim_box_name(h_cx_circuit):
 
 
 def test_to_braket_backward_compatibility():
-    qc = _make_box_circuit(NUM_QUBITS, [("h", [0]), ("cx", [0, 1])])
+    qc = _make_circuit(NUM_QUBITS, [("h", [0]), ("cx", [0, 1])])
     bc = to_braket(qc, verbatim=False)
     info = _gate_info(bc)
     names = [n for n, _ in info]
@@ -367,12 +367,12 @@ def test_to_braket_with_multiple_circuits_with_verbatim_boxes(h_cx_circuit):
     qc1.x(0)
     qc1.append(BoxOp(h_cx_circuit, label=VERBATIM_LABEL), QUBIT_PAIR)
 
-    inner2 = _make_box_circuit(3, [("h", [0]), ("h", [1]), ("ccx", [0, 1, 2])])
+    inner2 = _make_circuit(3, [("h", [0]), ("h", [1]), ("ccx", [0, 1, 2])])
     qc2 = QuantumCircuit(3)
     qc2.append(BoxOp(inner2, label=VERBATIM_LABEL), [0, 1, 2])
     qc2.z(2)
 
-    qc3 = _make_box_circuit(NUM_QUBITS, [("h", [0]), ("cx", [0, 1])])
+    qc3 = _make_circuit(NUM_QUBITS, [("h", [0]), ("cx", [0, 1])])
 
     results = to_braket([qc1, qc2, qc3], verbatim=False)
 
@@ -531,11 +531,14 @@ c[1] = measure $1;
     assert qc.num_clbits == 2
 
     bc = to_braket(qc, verbatim=False, add_measurements=False)
-    names = [instr.operator.name for instr in bc.instructions]
+    info = _gate_info(bc)
 
-    assert "H" in names
-    assert "CNot" in names
-    assert names.count("Measure") == 2
+    assert info == [
+        ("H", [0]),
+        ("CNot", [0, 1]),
+        ("Measure", [0]),
+        ("Measure", [1]),
+    ]
 
 
 def test_to_braket_verbatim_box_with_ccnot_and_classical_bits():
@@ -555,9 +558,16 @@ c[2] = measure $2;
 """
     qc = to_qiskit(qasm)
     bc = to_braket(qc, verbatim=False, add_measurements=False)
-    names = [instr.operator.name for instr in bc.instructions]
+    info = _gate_info(bc)
 
-    assert names == ["H", "H", "CCNot", "Measure", "Measure", "Measure"]
+    assert info == [
+        ("H", [0]),
+        ("H", [1]),
+        ("CCNot", [0, 1, 2]),
+        ("Measure", [0]),
+        ("Measure", [1]),
+        ("Measure", [2]),
+    ]
 
 
 def test_to_braket_verbatim_box_standalone_bit_collision():
@@ -578,7 +588,10 @@ c1 = measure $1;
     assert qc.num_clbits == 2
 
     bc = to_braket(qc, verbatim=False, add_measurements=False)
-    names = [instr.operator.name for instr in bc.instructions]
+    info = _gate_info(bc)
 
-    # Second measure overwrites first due to both targeting clbit 0
-    assert names.count("Measure") == 1
+    assert info == [
+        ("H", [0]),
+        ("CNot", [0, 1]),
+        ("Measure", [1]),
+    ]

--- a/tests/providers/test_adapter_to_braket_verbatim.py
+++ b/tests/providers/test_adapter_to_braket_verbatim.py
@@ -21,7 +21,7 @@ NUM_QUBITS = 2
 QUBIT_PAIR = [0, 1]
 
 
-def _make_box_circuit(num_qubits, gates):
+def _make_circuit(num_qubits, gates):
     """Create a QuantumCircuit with the given gates applied.
 
     Args:
@@ -93,19 +93,19 @@ y $1;
 @pytest.fixture
 def h_cx_circuit():
     """2-qubit circuit with H on q0 and CX on q0,q1."""
-    return _make_box_circuit(NUM_QUBITS, [("h", [0]), ("cx", [0, 1])])
+    return _make_circuit(NUM_QUBITS, [("h", [0]), ("cx", [0, 1])])
 
 
 @pytest.fixture
 def h_circuit():
     """1-qubit circuit with H on q0."""
-    return _make_box_circuit(NUM_QUBITS, [("h", [0])])
+    return _make_circuit(NUM_QUBITS, [("h", [0])])
 
 
 @pytest.fixture
 def cx_circuit():
     """2-qubit circuit with CX on q0,q1."""
-    return _make_box_circuit(NUM_QUBITS, [("cx", [0, 1])])
+    return _make_circuit(NUM_QUBITS, [("cx", [0, 1])])
 
 
 def _extract(circuit, label=VERBATIM_LABEL):
@@ -131,7 +131,7 @@ def _restore(transpiled, boxes, label=VERBATIM_LABEL):
     ids=["single_box_with_gates", "empty_box"],
 )
 def test_verbatim_box_extraction(inner_gates, expected_gate_names, expected_qubits):
-    inner = _make_box_circuit(NUM_QUBITS, inner_gates)
+    inner = _make_circuit(NUM_QUBITS, inner_gates)
     main = QuantumCircuit(NUM_QUBITS)
     main.append(BoxOp(inner, label=VERBATIM_LABEL), QUBIT_PAIR)
 
@@ -166,7 +166,7 @@ def test_multiple_verbatim_boxes_extraction(h_circuit, cx_circuit):
 
 
 def test_circuit_without_verbatim_boxes():
-    main = _make_box_circuit(NUM_QUBITS, [("h", [0]), ("cx", [0, 1])])
+    main = _make_circuit(NUM_QUBITS, [("h", [0]), ("cx", [0, 1])])
     modified, boxes = _extract(main)
 
     assert len(modified.data) == 2
@@ -218,8 +218,8 @@ def test_multiple_verbatim_boxes_restoration(h_circuit, cx_circuit):
 @pytest.mark.parametrize(
     "num_barriers, num_boxes, error_match",
     [
-        (2, 1, "Compiler error while processing verbatim boxes.*Illegal barrier"),
-        (1, 2, "Compiler error while processing verbatim boxes.*Missing barriers"),
+        (2, 1, "Internal error.*no matching box"),
+        (1, 2, "Internal error.*lost during transpilation"),
     ],
     ids=["too_many_barriers", "too_few_barriers"],
 )
@@ -228,9 +228,9 @@ def test_barrier_box_count_mismatch(num_barriers, num_boxes, error_match):
     for i in range(num_barriers):
         transpiled.append(Barrier(NUM_QUBITS, label=f"{VERBATIM_LABEL}__{i}"), QUBIT_PAIR)
 
-    boxes = {f"{VERBATIM_LABEL}__{i}": _make_box_circuit(NUM_QUBITS, [("h", [0])]) for i in range(num_boxes)}
+    boxes = {f"{VERBATIM_LABEL}__{i}": _make_circuit(NUM_QUBITS, [("h", [0])]) for i in range(num_boxes)}
 
-    with pytest.raises(ValueError, match=error_match):
+    with pytest.raises(RuntimeError, match=error_match):
         _restore(transpiled, boxes)
 
 
@@ -294,7 +294,7 @@ def test_to_braket_with_custom_verbatim_box_name(h_cx_circuit):
 
 
 def test_to_braket_backward_compatibility():
-    qc = _make_box_circuit(NUM_QUBITS, [("h", [0]), ("cx", [0, 1])])
+    qc = _make_circuit(NUM_QUBITS, [("h", [0]), ("cx", [0, 1])])
     bc = to_braket(qc, verbatim=False)
     info = _gate_info(bc)
     names = [n for n, _ in info]
@@ -362,12 +362,12 @@ def test_to_braket_with_multiple_circuits_with_verbatim_boxes(h_cx_circuit):
     qc1.x(0)
     qc1.append(BoxOp(h_cx_circuit, label=VERBATIM_LABEL), QUBIT_PAIR)
 
-    inner2 = _make_box_circuit(3, [("h", [0]), ("h", [1]), ("ccx", [0, 1, 2])])
+    inner2 = _make_circuit(3, [("h", [0]), ("h", [1]), ("ccx", [0, 1, 2])])
     qc2 = QuantumCircuit(3)
     qc2.append(BoxOp(inner2, label=VERBATIM_LABEL), [0, 1, 2])
     qc2.z(2)
 
-    qc3 = _make_box_circuit(NUM_QUBITS, [("h", [0]), ("cx", [0, 1])])
+    qc3 = _make_circuit(NUM_QUBITS, [("h", [0]), ("cx", [0, 1])])
 
     results = to_braket([qc1, qc2, qc3], verbatim=False)
 
@@ -526,11 +526,14 @@ c[1] = measure $1;
     assert qc.num_clbits == 2
 
     bc = to_braket(qc, verbatim=False, add_measurements=False)
-    names = [instr.operator.name for instr in bc.instructions]
+    info = _gate_info(bc)
 
-    assert "H" in names
-    assert "CNot" in names
-    assert names.count("Measure") == 2
+    assert info == [
+        ("H", [0]),
+        ("CNot", [0, 1]),
+        ("Measure", [0]),
+        ("Measure", [1]),
+    ]
 
 
 def test_to_braket_verbatim_box_with_ccnot_and_classical_bits():
@@ -550,9 +553,16 @@ c[2] = measure $2;
 """
     qc = to_qiskit(qasm)
     bc = to_braket(qc, verbatim=False, add_measurements=False)
-    names = [instr.operator.name for instr in bc.instructions]
+    info = _gate_info(bc)
 
-    assert names == ["H", "H", "CCNot", "Measure", "Measure", "Measure"]
+    assert info == [
+        ("H", [0]),
+        ("H", [1]),
+        ("CCNot", [0, 1, 2]),
+        ("Measure", [0]),
+        ("Measure", [1]),
+        ("Measure", [2]),
+    ]
 
 
 def test_to_braket_verbatim_box_standalone_bit_collision():
@@ -573,7 +583,10 @@ c1 = measure $1;
     assert qc.num_clbits == 2
 
     bc = to_braket(qc, verbatim=False, add_measurements=False)
-    names = [instr.operator.name for instr in bc.instructions]
+    info = _gate_info(bc)
 
-    # Second measure overwrites first due to both targeting clbit 0
-    assert names.count("Measure") == 1
+    assert info == [
+        ("H", [0]),
+        ("CNot", [0, 1]),
+        ("Measure", [1]),
+    ]

--- a/tests/providers/test_verbatim_passes.py
+++ b/tests/providers/test_verbatim_passes.py
@@ -9,7 +9,6 @@ from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from qiskit_braket_provider.providers.verbatim_passes import (
     ExtractVerbatimBoxes,
     RestoreVerbatimBoxes,
-    _is_verbatim_label,
 )
 
 VERBATIM_LABEL = "verbatim"
@@ -70,7 +69,7 @@ def test_extract_single_box(h_cx_circuit):
 
     boxes = extract.property_set["verbatim_boxes"]
     assert len(boxes) == 1
-    assert _gate_info(list(boxes.values())[0]) == [("h", [0]), ("cx", [0, 1])]
+    assert _gate_info(next(iter(boxes.values()))) == [("h", [0]), ("cx", [0, 1])]
 
 
 def test_extract_multiple_boxes_preserves_interleaved_gates(h_circuit, cx_circuit):
@@ -129,7 +128,7 @@ def test_extract_empty_box():
     extract = ExtractVerbatimBoxes()
     extract(qc)
 
-    assert list(extract.property_set["verbatim_boxes"].values())[0].data == []
+    assert next(iter(extract.property_set["verbatim_boxes"].values())).data == []
 
 
 def test_restore_single_box(h_cx_circuit):

--- a/tests/providers/test_verbatim_passes.py
+++ b/tests/providers/test_verbatim_passes.py
@@ -1,0 +1,204 @@
+"""Tests for ExtractVerbatimBoxes and RestoreVerbatimBoxes transpiler passes."""
+
+import pytest
+from qiskit import QuantumCircuit
+from qiskit.circuit import Barrier, BoxOp
+from qiskit.transpiler import PassManager
+from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
+
+from qiskit_braket_provider.providers.verbatim_passes import (
+    ExtractVerbatimBoxes,
+    RestoreVerbatimBoxes,
+)
+
+VERBATIM_LABEL = "verbatim"
+NUM_QUBITS = 2
+QUBIT_PAIR = [0, 1]
+
+
+def _make_box_circuit(num_qubits: int, gates: list[tuple[str, list[int]]]) -> QuantumCircuit:
+    """Create a QuantumCircuit with the given gates applied.
+
+    Args:
+        num_qubits: Number of qubits.
+        gates: List of (gate_name, qubit_args) tuples.
+    """
+    qc = QuantumCircuit(num_qubits)
+    for gate_name, qubits in gates:
+        getattr(qc, gate_name)(*qubits)
+    return qc
+
+
+def _gate_info(circuit: QuantumCircuit) -> list[tuple[str, list[int]]]:
+    """Extract (name, qubit_indices) for each instruction in a circuit."""
+    return [
+        (inst.operation.name, [circuit.find_bit(q).index for q in inst.qubits])
+        for inst in circuit.data
+    ]
+
+
+@pytest.fixture
+def h_cx_circuit():
+    """2-qubit circuit with H on q0 and CX on q0,q1."""
+    return _make_box_circuit(NUM_QUBITS, [("h", [0]), ("cx", [0, 1])])
+
+
+@pytest.fixture
+def h_circuit():
+    """2-qubit circuit with H on q0."""
+    return _make_box_circuit(NUM_QUBITS, [("h", [0])])
+
+
+@pytest.fixture
+def cx_circuit():
+    """2-qubit circuit with CX on q0,q1."""
+    return _make_box_circuit(NUM_QUBITS, [("cx", [0, 1])])
+
+
+def test_extract_single_box(h_cx_circuit):
+    """Single verbatim BoxOp is replaced with a labeled barrier on the same qubits."""
+    qc = QuantumCircuit(NUM_QUBITS)
+    qc.append(BoxOp(h_cx_circuit, label=VERBATIM_LABEL), QUBIT_PAIR)
+
+    extract = ExtractVerbatimBoxes()
+    result = extract(qc)
+
+    assert _gate_info(result) == [("barrier", QUBIT_PAIR)]
+    assert isinstance(result.data[0].operation, Barrier)
+    assert result.data[0].operation.label == VERBATIM_LABEL
+
+    boxes = extract.property_set["verbatim_boxes"]
+    assert len(boxes) == 1
+    assert _gate_info(boxes[0]) == [("h", [0]), ("cx", [0, 1])]
+
+
+def test_extract_multiple_boxes_preserves_interleaved_gates(h_circuit, cx_circuit):
+    """Multiple verbatim BoxOps are extracted while non-verbatim gates stay in place."""
+    qc = QuantumCircuit(NUM_QUBITS)
+    qc.append(BoxOp(h_circuit, label=VERBATIM_LABEL), QUBIT_PAIR)
+    qc.x(1)
+    qc.append(BoxOp(cx_circuit, label=VERBATIM_LABEL), QUBIT_PAIR)
+
+    extract = ExtractVerbatimBoxes()
+    result = extract(qc)
+
+    assert _gate_info(result) == [("barrier", QUBIT_PAIR), ("x", [1]), ("barrier", QUBIT_PAIR)]
+    assert all(
+        isinstance(result.data[i].operation, Barrier)
+        and result.data[i].operation.label == VERBATIM_LABEL
+        for i in [0, 2]
+    )
+
+    boxes = extract.property_set["verbatim_boxes"]
+    assert _gate_info(boxes[0]) == [("h", [0])]
+    assert _gate_info(boxes[1]) == [("cx", [0, 1])]
+
+
+def test_extract_only_matches_configured_label(h_circuit):
+    """BoxOps with non-matching labels are left untouched; custom labels are matched."""
+    qc = QuantumCircuit(NUM_QUBITS)
+    qc.append(BoxOp(h_circuit, label="other"), QUBIT_PAIR)
+    qc.append(BoxOp(h_circuit, label="custom"), QUBIT_PAIR)
+
+    extract = ExtractVerbatimBoxes("custom")
+    result = extract(qc)
+
+    assert isinstance(result.data[0].operation, BoxOp)
+    assert result.data[0].operation.label == "other"
+    assert isinstance(result.data[1].operation, Barrier)
+    assert result.data[1].operation.label == "custom"
+    assert len(extract.property_set["verbatim_boxes"]) == 1
+
+
+def test_extract_raises_on_barrier_label_collision():
+    """ExtractVerbatimBoxes rejects circuits with barriers using the verbatim label."""
+    qc = QuantumCircuit(NUM_QUBITS)
+    qc.barrier(QUBIT_PAIR, label=VERBATIM_LABEL)
+
+    with pytest.raises(ValueError, match="conflicts with the verbatim box label"):
+        ExtractVerbatimBoxes()(qc)
+
+
+def test_extract_empty_box():
+    """An empty verbatim BoxOp produces an empty stashed circuit."""
+    qc = QuantumCircuit(NUM_QUBITS)
+    qc.append(BoxOp(QuantumCircuit(NUM_QUBITS), label=VERBATIM_LABEL), QUBIT_PAIR)
+
+    extract = ExtractVerbatimBoxes()
+    extract(qc)
+
+    assert extract.property_set["verbatim_boxes"][0].data == []
+
+
+def test_restore_single_box(h_cx_circuit):
+    """A labeled barrier is replaced with the exact stashed gate sequence and qubits."""
+    qc = QuantumCircuit(NUM_QUBITS)
+    qc.barrier(QUBIT_PAIR, label=VERBATIM_LABEL)
+
+    restore = RestoreVerbatimBoxes()
+    restore.property_set["verbatim_boxes"] = [h_cx_circuit]
+    result = restore(qc)
+
+    assert _gate_info(result) == [("h", [0]), ("cx", [0, 1])]
+
+
+def test_restore_multiple_boxes_in_order(h_circuit, cx_circuit):
+    """Multiple barriers are restored in order with interleaved gates preserved."""
+    qc = QuantumCircuit(NUM_QUBITS)
+    qc.barrier(QUBIT_PAIR, label=VERBATIM_LABEL)
+    qc.x(1)
+    qc.barrier(QUBIT_PAIR, label=VERBATIM_LABEL)
+
+    restore = RestoreVerbatimBoxes()
+    restore.property_set["verbatim_boxes"] = [h_circuit, cx_circuit]
+    result = restore(qc)
+
+    assert _gate_info(result) == [("h", [0]), ("x", [1]), ("cx", [0, 1])]
+
+
+def test_restore_raises_on_count_mismatch(h_circuit):
+    """RestoreVerbatimBoxes raises when barrier count doesn't match box count."""
+    qc = QuantumCircuit(NUM_QUBITS)
+    qc.barrier(QUBIT_PAIR, label=VERBATIM_LABEL)
+
+    restore = RestoreVerbatimBoxes()
+    restore.property_set["verbatim_boxes"] = [h_circuit, h_circuit]
+
+    with pytest.raises(ValueError, match="Compiler error while processing verbatim boxes"):
+        restore(qc)
+
+
+def test_round_trip_preserves_exact_sequence(h_cx_circuit):
+    """Extract->restore round-trip produces the exact original gate sequence and qubits."""
+    qc = QuantumCircuit(3)
+    qc.x(0)
+    qc.append(BoxOp(h_cx_circuit, label=VERBATIM_LABEL), QUBIT_PAIR)
+    qc.y(2)
+
+    result = PassManager([ExtractVerbatimBoxes(), RestoreVerbatimBoxes()]).run(qc)
+
+    assert _gate_info(result) == [("x", [0]), ("h", [0]), ("cx", [0, 1]), ("y", [2])]
+
+
+def test_staged_pass_manager_protects_verbatim_decomposes_rest(h_cx_circuit):
+    """Verbatim h+cx survive on exact qubits while non-verbatim h is fully decomposed."""
+    qc = QuantumCircuit(NUM_QUBITS)
+    qc.h(0)
+    qc.append(BoxOp(h_cx_circuit, label=VERBATIM_LABEL), QUBIT_PAIR)
+    qc.h(1)
+
+    pm = generate_preset_pass_manager(
+        optimization_level=0,
+        basis_gates=["rz", "sx", "cz"],
+    )
+    pm.pre_init = PassManager([ExtractVerbatimBoxes()])
+    pm.post_optimization = PassManager([RestoreVerbatimBoxes()])
+
+    result = pm.run(qc)
+    info = _gate_info(result)
+
+    assert ("h", [0]) in info
+    assert ("cx", [0, 1]) in info
+    assert sum(1 for name, _ in info if name == "h") == 1
+    basis = {"rz", "sx", "cz", "h", "cx"}
+    assert all(name in basis for name, _ in info)

--- a/tests/providers/test_verbatim_passes.py
+++ b/tests/providers/test_verbatim_passes.py
@@ -9,6 +9,7 @@ from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from qiskit_braket_provider.providers.verbatim_passes import (
     ExtractVerbatimBoxes,
     RestoreVerbatimBoxes,
+    _is_verbatim_label,
 )
 
 VERBATIM_LABEL = "verbatim"
@@ -220,3 +221,26 @@ def test_staged_pass_manager_protects_verbatim_decomposes_rest(h_cx_circuit):
     assert sum(1 for name, _ in info if name == "h") == 1
     basis = {"rz", "sx", "cz", "h", "cx"}
     assert all(name in basis for name, _ in info)
+
+
+def test_is_verbatim_label_none():
+    """_is_verbatim_label returns False for None labels."""
+    qc = QuantumCircuit(NUM_QUBITS)
+    qc.barrier(QUBIT_PAIR)  # barrier with no label
+
+    extract = ExtractVerbatimBoxes()
+    result = extract(qc)
+
+    assert _gate_info(result) == [("barrier", QUBIT_PAIR)]
+
+
+def test_restore_raises_on_unexpected_verbatim_barrier():
+    """Barrier with verbatim label not in stashed dict raises."""
+    qc = QuantumCircuit(NUM_QUBITS)
+    qc.barrier(QUBIT_PAIR, label=f"{VERBATIM_LABEL}__5")
+
+    restore = RestoreVerbatimBoxes()
+    restore.property_set["verbatim_boxes"] = {f"{VERBATIM_LABEL}__0": QuantumCircuit(NUM_QUBITS)}
+
+    with pytest.raises(ValueError, match="Illegal barrier"):
+        restore(qc)

--- a/tests/providers/test_verbatim_passes.py
+++ b/tests/providers/test_verbatim_passes.py
@@ -233,6 +233,20 @@ def test_is_verbatim_label_none():
     assert _gate_info(result) == [("barrier", QUBIT_PAIR)]
 
 
+def test_restore_skips_non_verbatim_barriers(h_cx_circuit):
+    """Non-verbatim barriers are left untouched during restore."""
+    qc = QuantumCircuit(NUM_QUBITS)
+    qc.barrier(QUBIT_PAIR)
+    qc.barrier(QUBIT_PAIR, label=f"{VERBATIM_LABEL}__0")
+
+    restore = RestoreVerbatimBoxes()
+    restore.property_set["verbatim_boxes"] = {f"{VERBATIM_LABEL}__0": h_cx_circuit}
+    result = restore(qc)
+
+    info = _gate_info(result)
+    assert info == [("barrier", QUBIT_PAIR), ("h", [0]), ("cx", [0, 1])]
+
+
 def test_restore_raises_on_unexpected_verbatim_barrier():
     """Barrier with verbatim label not in stashed dict raises."""
     qc = QuantumCircuit(NUM_QUBITS)

--- a/tests/providers/test_verbatim_passes.py
+++ b/tests/providers/test_verbatim_passes.py
@@ -65,11 +65,11 @@ def test_extract_single_box(h_cx_circuit):
 
     assert _gate_info(result) == [("barrier", QUBIT_PAIR)]
     assert isinstance(result.data[0].operation, Barrier)
-    assert result.data[0].operation.label == VERBATIM_LABEL
+    assert result.data[0].operation.label.startswith(VERBATIM_LABEL)
 
     boxes = extract.property_set["verbatim_boxes"]
     assert len(boxes) == 1
-    assert _gate_info(boxes[0]) == [("h", [0]), ("cx", [0, 1])]
+    assert _gate_info(list(boxes.values())[0]) == [("h", [0]), ("cx", [0, 1])]
 
 
 def test_extract_multiple_boxes_preserves_interleaved_gates(h_circuit, cx_circuit):
@@ -85,13 +85,14 @@ def test_extract_multiple_boxes_preserves_interleaved_gates(h_circuit, cx_circui
     assert _gate_info(result) == [("barrier", QUBIT_PAIR), ("x", [1]), ("barrier", QUBIT_PAIR)]
     assert all(
         isinstance(result.data[i].operation, Barrier)
-        and result.data[i].operation.label == VERBATIM_LABEL
+        and result.data[i].operation.label.startswith(VERBATIM_LABEL)
         for i in [0, 2]
     )
+    assert result.data[0].operation.label != result.data[2].operation.label
 
-    boxes = extract.property_set["verbatim_boxes"]
-    assert _gate_info(boxes[0]) == [("h", [0])]
-    assert _gate_info(boxes[1]) == [("cx", [0, 1])]
+    box_list = list(extract.property_set["verbatim_boxes"].values())
+    assert _gate_info(box_list[0]) == [("h", [0])]
+    assert _gate_info(box_list[1]) == [("cx", [0, 1])]
 
 
 def test_extract_only_matches_configured_label(h_circuit):
@@ -106,7 +107,7 @@ def test_extract_only_matches_configured_label(h_circuit):
     assert isinstance(result.data[0].operation, BoxOp)
     assert result.data[0].operation.label == "other"
     assert isinstance(result.data[1].operation, Barrier)
-    assert result.data[1].operation.label == "custom"
+    assert result.data[1].operation.label.startswith("custom")
     assert len(extract.property_set["verbatim_boxes"]) == 1
 
 
@@ -127,16 +128,16 @@ def test_extract_empty_box():
     extract = ExtractVerbatimBoxes()
     extract(qc)
 
-    assert extract.property_set["verbatim_boxes"][0].data == []
+    assert list(extract.property_set["verbatim_boxes"].values())[0].data == []
 
 
 def test_restore_single_box(h_cx_circuit):
     """A labeled barrier is replaced with the exact stashed gate sequence and qubits."""
     qc = QuantumCircuit(NUM_QUBITS)
-    qc.barrier(QUBIT_PAIR, label=VERBATIM_LABEL)
+    qc.barrier(QUBIT_PAIR, label=f"{VERBATIM_LABEL}__0")
 
     restore = RestoreVerbatimBoxes()
-    restore.property_set["verbatim_boxes"] = [h_cx_circuit]
+    restore.property_set["verbatim_boxes"] = {f"{VERBATIM_LABEL}__0": h_cx_circuit}
     result = restore(qc)
 
     assert _gate_info(result) == [("h", [0]), ("cx", [0, 1])]
@@ -145,24 +146,30 @@ def test_restore_single_box(h_cx_circuit):
 def test_restore_multiple_boxes_in_order(h_circuit, cx_circuit):
     """Multiple barriers are restored in order with interleaved gates preserved."""
     qc = QuantumCircuit(NUM_QUBITS)
-    qc.barrier(QUBIT_PAIR, label=VERBATIM_LABEL)
+    qc.barrier(QUBIT_PAIR, label=f"{VERBATIM_LABEL}__0")
     qc.x(1)
-    qc.barrier(QUBIT_PAIR, label=VERBATIM_LABEL)
+    qc.barrier(QUBIT_PAIR, label=f"{VERBATIM_LABEL}__1")
 
     restore = RestoreVerbatimBoxes()
-    restore.property_set["verbatim_boxes"] = [h_circuit, cx_circuit]
+    restore.property_set["verbatim_boxes"] = {
+        f"{VERBATIM_LABEL}__0": h_circuit,
+        f"{VERBATIM_LABEL}__1": cx_circuit,
+    }
     result = restore(qc)
 
     assert _gate_info(result) == [("h", [0]), ("x", [1]), ("cx", [0, 1])]
 
 
 def test_restore_raises_on_count_mismatch(h_circuit):
-    """RestoreVerbatimBoxes raises when barrier count doesn't match box count."""
+    """RestoreVerbatimBoxes raises when stashed boxes outnumber barriers."""
     qc = QuantumCircuit(NUM_QUBITS)
-    qc.barrier(QUBIT_PAIR, label=VERBATIM_LABEL)
+    qc.barrier(QUBIT_PAIR, label=f"{VERBATIM_LABEL}__0")
 
     restore = RestoreVerbatimBoxes()
-    restore.property_set["verbatim_boxes"] = [h_circuit, h_circuit]
+    restore.property_set["verbatim_boxes"] = {
+        f"{VERBATIM_LABEL}__0": h_circuit,
+        f"{VERBATIM_LABEL}__1": h_circuit,
+    }
 
     with pytest.raises(ValueError, match="Compiler error while processing verbatim boxes"):
         restore(qc)

--- a/tests/providers/test_verbatim_passes.py
+++ b/tests/providers/test_verbatim_passes.py
@@ -17,7 +17,7 @@ NUM_QUBITS = 2
 QUBIT_PAIR = [0, 1]
 
 
-def _make_box_circuit(num_qubits: int, gates: list[tuple[str, list[int]]]) -> QuantumCircuit:
+def _make_circuit(num_qubits: int, gates: list[tuple[str, list[int]]]) -> QuantumCircuit:
     """Create a QuantumCircuit with the given gates applied.
 
     Args:
@@ -41,19 +41,19 @@ def _gate_info(circuit: QuantumCircuit) -> list[tuple[str, list[int]]]:
 @pytest.fixture
 def h_cx_circuit():
     """2-qubit circuit with H on q0 and CX on q0,q1."""
-    return _make_box_circuit(NUM_QUBITS, [("h", [0]), ("cx", [0, 1])])
+    return _make_circuit(NUM_QUBITS, [("h", [0]), ("cx", [0, 1])])
 
 
 @pytest.fixture
 def h_circuit():
     """2-qubit circuit with H on q0."""
-    return _make_box_circuit(NUM_QUBITS, [("h", [0])])
+    return _make_circuit(NUM_QUBITS, [("h", [0])])
 
 
 @pytest.fixture
 def cx_circuit():
     """2-qubit circuit with CX on q0,q1."""
-    return _make_box_circuit(NUM_QUBITS, [("cx", [0, 1])])
+    return _make_circuit(NUM_QUBITS, [("cx", [0, 1])])
 
 
 def test_extract_single_box(h_cx_circuit):
@@ -172,7 +172,7 @@ def test_restore_raises_on_count_mismatch(h_circuit):
         f"{VERBATIM_LABEL}__1": h_circuit,
     }
 
-    with pytest.raises(ValueError, match="Compiler error while processing verbatim boxes"):
+    with pytest.raises(RuntimeError, match="Internal error"):
         restore(qc)
 
 
@@ -226,7 +226,7 @@ def test_staged_pass_manager_protects_verbatim_decomposes_rest(h_cx_circuit):
 def test_is_verbatim_label_none():
     """_is_verbatim_label returns False for None labels."""
     qc = QuantumCircuit(NUM_QUBITS)
-    qc.barrier(QUBIT_PAIR)  # barrier with no label
+    qc.barrier(QUBIT_PAIR)
 
     extract = ExtractVerbatimBoxes()
     result = extract(qc)
@@ -242,5 +242,5 @@ def test_restore_raises_on_unexpected_verbatim_barrier():
     restore = RestoreVerbatimBoxes()
     restore.property_set["verbatim_boxes"] = {f"{VERBATIM_LABEL}__0": QuantumCircuit(NUM_QUBITS)}
 
-    with pytest.raises(ValueError, match="Illegal barrier"):
+    with pytest.raises(RuntimeError, match="Internal error"):
         restore(qc)

--- a/tests/providers/test_verbatim_passes.py
+++ b/tests/providers/test_verbatim_passes.py
@@ -168,6 +168,17 @@ def test_restore_raises_on_count_mismatch(h_circuit):
         restore(qc)
 
 
+def test_restore_no_op_when_no_boxes():
+    """RestoreVerbatimBoxes is a no-op when property_set has no verbatim boxes."""
+    qc = QuantumCircuit(NUM_QUBITS)
+    qc.h(0)
+
+    restore = RestoreVerbatimBoxes()
+    result = restore(qc)
+
+    assert _gate_info(result) == [("h", [0])]
+
+
 def test_round_trip_preserves_exact_sequence(h_cx_circuit):
     """Extract->restore round-trip produces the exact original gate sequence and qubits."""
     qc = QuantumCircuit(3)


### PR DESCRIPTION
## Refactor: verbatim box handling as transpiler passes

Replace _extract_verbatim_boxes / _restore_verbatim_boxes with proper Qiskit TransformationPass subclasses that operate on the DAG and compose into a StagedPassManager.

### Changes

- **verbatim_passes.py** (new): ExtractVerbatimBoxes and RestoreVerbatimBoxes passes
- **adapter.py**: Delete old functions, replace transpile() with generate_preset_pass_manager() with verbatim passes injected  at pre_init / post_optimization
- **Tests**: Updated to use new passes; added 10 dedicated pass tests

### Why

The old functions manually rebuilt circuits instruction-by-instruction outside the transpiler pipeline. The new passes use dag.substitute_node / dag.substitute_node_with_dag, compose naturally into any PassManager, and are reusable independently of to_braket().