### PR TITLE
feat: Changes to support branching statements using midcircuit measurements

### DIFF
--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -9,6 +9,7 @@ sequences that should not be optimized.
 import warnings
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Mapping, Sequence
+from copy import deepcopy
 from dataclasses import dataclass
 from math import inf, pi, prod
 from numbers import Number
@@ -25,6 +26,7 @@ from qiskit.circuit import (
     Clbit,
     ControlledGate,
     Gate,
+    IfElseOp,
     Measure,
     Parameter,
     ParameterExpression,
@@ -52,13 +54,28 @@ from braket.circuits import Observable as BraketObservable
 from braket.circuits import gates as braket_gates
 from braket.circuits import noises as braket_noises
 from braket.circuits import observables as braket_observables
+from braket.default_simulator.openqasm._helpers.arrays import convert_range_def_to_range
+from braket.default_simulator.openqasm._helpers.casting import cast_to
 from braket.default_simulator.openqasm.interpreter import Interpreter, VerbatimBoxDelimiter
 from braket.default_simulator.openqasm.parser.openqasm_ast import (
+    BinaryExpression,
     BitType,
+    BooleanLiteral,
+    BranchingStatement,
     ClassicalType,
+    ForInLoop,
+    Identifier,
+    IndexedIdentifier,
+    IndexExpression,
     IntegerLiteral,
+    RangeDefinition,
+    WhileLoop,
 )
-from braket.default_simulator.openqasm.program_context import AbstractProgramContext
+from braket.default_simulator.openqasm.program_context import (
+    AbstractProgramContext,
+    _BreakSignal,
+    _ContinueSignal,
+)
 from braket.device_schema import (
     DeviceActionType,
     DeviceCapabilities,
@@ -336,6 +353,8 @@ class _QiskitProgramContext(AbstractProgramContext):
         self._in_verbatim_box = False
         self._verbatim_circuit: QuantumCircuit | None = None
         self._verbatim_box_name = verbatim_box_name
+        self._visitor: Callable | None = None
+        self._clbit_offset: dict[str, int] = {}
 
     @property
     def circuit(self):
@@ -380,6 +399,8 @@ class _QiskitProgramContext(AbstractProgramContext):
             else:
                 size = 1
             
+            # this is used deal with Qiskit circuit storing all classical bits in a flat list
+            self._clbit_offset[name] = self._circuit.num_clbits
             self._circuit.add_bits([Clbit() for _ in range(size)])
 
     def is_builtin_gate(self, name: str) -> bool:
@@ -474,6 +495,103 @@ class _QiskitProgramContext(AbstractProgramContext):
         
         else:
             raise ValueError("Verbatim box created using invalid marker")
+
+    @property
+    def supports_midcircuit_measurement(self) -> bool:
+        return True
+
+    def set_visitor(self, visitor: Callable) -> None:
+        self._visitor = visitor
+
+    def handle_branching_statement(self, node: BranchingStatement) -> None:
+        # Try static evaluation first; fall back to MCM if the condition
+        # can't be resolved (e.g. it depends on a measurement result) due to
+        # NameError (uninitialized variable, i.e. measurement result) or
+        # TypeError (can't cast to boolean)
+        try:
+            condition = cast_to(BooleanLiteral, self._visitor(node.condition))
+        except (NameError, TypeError):
+            pass
+        else:
+            if condition.value:
+                self._visitor(node.if_block)
+            elif node.else_block:
+                self._visitor(node.else_block)
+            return
+
+        condition = self._resolve_condition(node.condition)
+        main_circuit = self._circuit
+
+        # Visit if block into a separate circuit
+        true_body = QuantumCircuit(main_circuit.num_qubits, main_circuit.num_clbits)
+        self._circuit = true_body
+        for statement in node.if_block:
+            self._visitor(statement)
+
+        # Visit else block if present
+        false_body = None
+        if node.else_block:
+            false_body = QuantumCircuit(main_circuit.num_qubits, main_circuit.num_clbits)
+            self._circuit = false_body
+            for statement in node.else_block:
+                self._visitor(statement)
+
+        self._circuit = main_circuit
+
+        if_else_op = IfElseOp(condition, true_body, false_body)
+        qubits = list(range(main_circuit.num_qubits))
+        clbits = list(range(main_circuit.num_clbits))
+        self._circuit.append(if_else_op, qubits, clbits)
+
+    def handle_for_loop(self, node: ForInLoop) -> None:
+        index = self._visitor(node.set_declaration)
+        if isinstance(index, RangeDefinition):
+            index_values = [IntegerLiteral(x) for x in convert_range_def_to_range(index)]
+        else:
+            index_values = index.values
+        for i in index_values:
+            with self.enter_scope():
+                self.declare_variable(node.identifier.name, node.type, i)
+                try:
+                    self._visitor(deepcopy(node.block))
+                except _BreakSignal:
+                    break
+                except _ContinueSignal:
+                    continue
+
+    def handle_while_loop(self, node: WhileLoop) -> None:
+        while cast_to(BooleanLiteral, self._visitor(node.while_condition)).value:
+            try:
+                self._visitor(deepcopy(node.block))
+            except _BreakSignal:
+                break
+            except _ContinueSignal:
+                continue
+
+    def _resolve_condition(
+        self, condition: BinaryExpression
+    ) -> tuple[Clbit, int]:
+        """Convert an OpenQASM condition AST node to a Qiskit (Clbit, int) condition."""
+        if isinstance(condition.lhs, (Identifier, IndexedIdentifier, IndexExpression)):
+            clbit_index = self._resolve_clbit_index(condition.lhs)
+            value = condition.rhs.value
+        else:
+            clbit_index = self._resolve_clbit_index(condition.rhs)
+            value = condition.lhs.value
+        return (self._circuit.clbits[clbit_index], int(value))
+
+    def _resolve_clbit_index(self, node: Identifier | IndexExpression) -> int:
+        """Resolve an identifier or indexed identifier to a classical bit index."""
+        if isinstance(node, IndexExpression):
+            name = node.collection.name
+            index = node.index[0].value
+        elif isinstance(node, Identifier):
+            name = node.name
+            index = 0
+        else:
+            raise TypeError(f"Unsupported condition operand type: {type(node)}")
+
+        return self._clbit_offset[name] + index
 
 
 def native_gate_connectivity(properties: DeviceCapabilities) -> list[list[int]] | None:

--- a/tests/providers/test_adapter_branching.py
+++ b/tests/providers/test_adapter_branching.py
@@ -1,0 +1,630 @@
+"""Tests for branching statement (if/else) support in the Qiskit adapter."""
+
+import pytest
+from qiskit.circuit import Clbit, IfElseOp
+from qiskit.circuit.library import CXGate, HGate, Measure, XGate, YGate, ZGate
+from qiskit.transpiler import Target
+
+from qiskit_braket_provider import to_qiskit
+from qiskit_braket_provider.providers.adapter import _compile
+
+
+def _get_if_else_ops(circuit):
+    """Extract all IfElseOp instructions from a circuit."""
+    return [instr for instr in circuit.data if isinstance(instr.operation, IfElseOp)]
+
+
+def _get_gate_names(circuit):
+    """Get gate names from a circuit, excluding measurements."""
+    return [instr.operation.name for instr in circuit.data if instr.operation.name != "measure"]
+
+
+def _get_ops_with_qubits(circuit):
+    """Get (gate_name, qubit_indices) tuples for all non-measure ops in a circuit."""
+    return [
+        (instr.operation.name, [circuit.find_bit(q).index for q in instr.qubits])
+        for instr in circuit.data
+        if instr.operation.name != "measure"
+    ]
+
+
+@pytest.mark.parametrize(
+    "qasm, expected_true_ops, expected_false_ops",
+    [
+        pytest.param(
+            """
+OPENQASM 3.0;
+qubit[2] q;
+bit[1] c;
+c[0] = measure q[0];
+if (c[0] == 1) {
+    h q[1];
+} else {
+    x q[1];
+}
+""",
+            [("h", [1])],
+            [("x", [1])],
+            id="if_else_with_single_gates",
+        ),
+        pytest.param(
+            """
+OPENQASM 3.0;
+qubit[2] q;
+bit[1] c;
+c[0] = measure q[0];
+if (c[0] == 1) {
+    h q[1];
+    x q[0];
+} else {
+    y q[0];
+    z q[1];
+}
+""",
+            [("h", [1]), ("x", [0])],
+            [("y", [0]), ("z", [1])],
+            id="if_else_with_multiple_gates_different_qubits",
+        ),
+        pytest.param(
+            """
+OPENQASM 3.0;
+qubit[3] q;
+bit[1] c;
+c[0] = measure q[0];
+if (c[0] == 0) {
+    h q[1];
+    x q[2];
+} else {
+    y q[0];
+}
+""",
+            [("h", [1]), ("x", [2])],
+            [("y", [0])],
+            id="asymmetric_branches_different_qubits",
+        ),
+    ],
+)
+def test_if_else_branch_bodies(qasm, expected_true_ops, expected_false_ops):
+    qc = to_qiskit(qasm)
+    if_else_ops = _get_if_else_ops(qc)
+    assert len(if_else_ops) == 1
+
+    op = if_else_ops[0].operation
+    true_body, false_body = op.params
+
+    assert _get_ops_with_qubits(true_body) == expected_true_ops
+    assert _get_ops_with_qubits(false_body) == expected_false_ops
+
+
+def test_if_only_no_else():
+    qasm = """
+OPENQASM 3.0;
+qubit[2] q;
+bit[1] c;
+c[0] = measure q[0];
+if (c[0] == 1) {
+    h q[1];
+}
+"""
+    qc = to_qiskit(qasm)
+    if_else_ops = _get_if_else_ops(qc)
+    assert len(if_else_ops) == 1
+
+    op = if_else_ops[0].operation
+    true_body, false_body = op.params
+
+    assert _get_ops_with_qubits(true_body) == [("h", [1])]
+    assert false_body is None
+
+
+@pytest.mark.parametrize(
+    "condition_value, expected_value",
+    [
+        ("1", 1),
+        ("0", 0),
+    ],
+    ids=["condition_1", "condition_0"],
+)
+def test_condition_value(condition_value, expected_value):
+    qasm = f"""
+OPENQASM 3.0;
+qubit[2] q;
+bit[1] c;
+c[0] = measure q[0];
+if (c[0] == {condition_value}) {{
+    h q[1];
+}}
+"""
+    qc = to_qiskit(qasm)
+    op = _get_if_else_ops(qc)[0].operation
+    clbit, value = op.condition
+    assert isinstance(clbit, Clbit)
+    assert qc.clbits.index(clbit) == 0
+    assert value == expected_value
+
+
+def test_condition_references_correct_clbit():
+    """When multiple bit variables are declared, the condition should reference the right clbit."""
+    qasm = """
+OPENQASM 3.0;
+qubit[3] q;
+bit[2] a;
+bit[2] b;
+a[0] = measure q[0];
+b[1] = measure q[1];
+if (b[1] == 1) {
+    h q[2];
+}
+"""
+    qc = to_qiskit(qasm)
+    instr = _get_if_else_ops(qc)[0]
+    op = instr.operation
+    clbit, value = op.condition
+
+    # b starts at offset 2 (after a's 2 bits), b[1] is clbit index 3
+    assert qc.clbits.index(clbit) == 3
+    assert value == 1
+
+    # IfElseOp should span all qubits and clbits
+    assert [qc.find_bit(q).index for q in instr.qubits] == [0, 1, 2]
+    assert [qc.find_bit(c).index for c in instr.clbits] == [0, 1, 2, 3]
+
+    # Branch body gate targets correct qubit
+    true_body = op.params[0]
+    assert _get_ops_with_qubits(true_body) == [("h", [2])]
+
+
+def test_if_else_circuit_dimensions():
+    """Branch body circuits should have the same qubit/clbit counts as the main circuit."""
+    qasm = """
+OPENQASM 3.0;
+qubit[3] q;
+bit[2] c;
+c[0] = measure q[0];
+if (c[0] == 1) {
+    h q[1];
+} else {
+    x q[2];
+}
+"""
+    qc = to_qiskit(qasm)
+    instr = _get_if_else_ops(qc)[0]
+    op = instr.operation
+    true_body, false_body = op.params
+
+    assert true_body.num_qubits == qc.num_qubits
+    assert true_body.num_clbits == qc.num_clbits
+    assert false_body.num_qubits == qc.num_qubits
+    assert false_body.num_clbits == qc.num_clbits
+
+    assert _get_ops_with_qubits(true_body) == [("h", [1])]
+    assert _get_ops_with_qubits(false_body) == [("x", [2])]
+
+    # IfElseOp spans all qubits/clbits on the main circuit
+    assert [qc.find_bit(q).index for q in instr.qubits] == [0, 1, 2]
+    assert [qc.find_bit(c).index for c in instr.clbits] == [0, 1]
+
+
+def test_gates_before_and_after_branch():
+    """Gates outside the branch should appear on the main circuit, not inside the branch."""
+    qasm = """
+OPENQASM 3.0;
+qubit[2] q;
+bit[1] c;
+x q[0];
+c[0] = measure q[0];
+if (c[0] == 1) {
+    h q[1];
+}
+y q[1];
+"""
+    qc = to_qiskit(qasm)
+
+    main_ops = [(instr.operation.name, [qc.find_bit(q).index for q in instr.qubits]) for instr in qc.data]
+    assert main_ops[0] == ("x", [0])
+    assert main_ops[1] == ("measure", [0])
+    assert main_ops[2][0] == "if_else"
+    assert main_ops[2][1] == [0, 1]
+    assert main_ops[3] == ("y", [1])
+
+
+def test_multiple_branches():
+    """Multiple sequential if/else blocks should each produce their own IfElseOp."""
+    qasm = """
+OPENQASM 3.0;
+qubit[2] q;
+bit[2] c;
+c[0] = measure q[0];
+if (c[0] == 1) {
+    h q[1];
+}
+c[1] = measure q[1];
+if (c[1] == 1) {
+    x q[0];
+}
+"""
+    qc = to_qiskit(qasm)
+    if_else_ops = _get_if_else_ops(qc)
+    assert len(if_else_ops) == 2
+
+    # First branch: condition on c[0], h on q[1]
+    op0 = if_else_ops[0].operation
+    assert qc.clbits.index(op0.condition[0]) == 0
+    assert _get_ops_with_qubits(op0.params[0]) == [("h", [1])]
+
+    # Second branch: condition on c[1], x on q[0]
+    op1 = if_else_ops[1].operation
+    assert qc.clbits.index(op1.condition[0]) == 1
+    assert _get_ops_with_qubits(op1.params[0]) == [("x", [0])]
+
+
+def test_for_loop_before_measurement_works():
+    """For loops that appear before any measurement should work normally."""
+    qasm = """
+OPENQASM 3.0;
+qubit[2] q;
+bit[1] c;
+for int[8] i in [0:1] {
+    h q[0];
+}
+c[0] = measure q[0];
+"""
+    qc = to_qiskit(qasm)
+    main_ops = [(instr.operation.name, [qc.find_bit(q).index for q in instr.qubits]) for instr in qc.data]
+    assert main_ops[0] == ("h", [0])
+    assert main_ops[1] == ("h", [0])
+    assert main_ops[2] == ("measure", [0])
+
+
+def test_for_loop_after_unrelated_measurement_works():
+    """A for loop after a measurement on a different qubit should work."""
+    qasm = """
+OPENQASM 3.0;
+qubit[2] q;
+bit[1] c;
+c[0] = measure q[0];
+for int[8] i in [0:1] {
+    h q[1];
+}
+"""
+    qc = to_qiskit(qasm)
+    main_ops = [(instr.operation.name, [qc.find_bit(q).index for q in instr.qubits]) for instr in qc.data]
+    assert main_ops[0] == ("measure", [0])
+    assert main_ops[1] == ("h", [1])
+    assert main_ops[2] == ("h", [1])
+
+
+def test_mcm_branch_inside_for_loop():
+    """An MCM branching statement inside a for loop should produce IfElseOps."""
+    qasm = """
+OPENQASM 3.0;
+qubit[2] q;
+bit[1] c;
+c[0] = measure q[0];
+for int[8] i in [0:1] {
+    if (c[0] == 1) {
+        h q[1];
+    } else {
+        x q[1];
+    }
+}
+"""
+    qc = to_qiskit(qasm)
+    if_else_ops = _get_if_else_ops(qc)
+    assert len(if_else_ops) == 2
+
+    for op_instr in if_else_ops:
+        true_body, false_body = op_instr.operation.params
+        assert _get_ops_with_qubits(true_body) == [("h", [1])]
+        assert _get_ops_with_qubits(false_body) == [("x", [1])]
+        assert qc.clbits.index(op_instr.operation.condition[0]) == 0
+
+
+@pytest.fixture
+def mcm_target():
+    t = Target(num_qubits=3)
+    t.add_instruction(HGate())
+    t.add_instruction(XGate())
+    t.add_instruction(YGate())
+    t.add_instruction(ZGate())
+    t.add_instruction(CXGate())
+    t.add_instruction(Measure())
+    t.add_instruction(IfElseOp, name="if_else")
+    return t
+
+
+@pytest.mark.parametrize(
+    "qasm, expected_if_else_count",
+    [
+        pytest.param(
+            """
+OPENQASM 3.0;
+qubit[2] q;
+bit[1] c;
+c[0] = measure q[0];
+if (c[0] == 1) {
+    h q[1];
+} else {
+    x q[1];
+}
+""",
+            1,
+            id="single_if_else",
+        ),
+        pytest.param(
+            """
+OPENQASM 3.0;
+qubit[2] q;
+bit[2] c;
+c[0] = measure q[0];
+if (c[0] == 1) {
+    h q[1];
+}
+c[1] = measure q[1];
+if (c[1] == 1) {
+    x q[0];
+}
+""",
+            2,
+            id="multiple_if_else",
+        ),
+        pytest.param(
+            """
+OPENQASM 3.0;
+qubit[2] q;
+bit[1] c;
+c[0] = measure q[0];
+if (c[0] == 1) {
+    h q[1];
+}
+""",
+            1,
+            id="if_only_no_else",
+        ),
+    ],
+)
+def test_compile_preserves_if_else_ops(qasm, expected_if_else_count, mcm_target):
+    """IfElseOps should survive compilation through _compile."""
+    result = _compile(qasm, target=mcm_target)
+    compiled_circuit = result.circuits[0]
+    if_else_ops = [instr for instr in compiled_circuit.data if isinstance(instr.operation, IfElseOp)]
+    assert len(if_else_ops) == expected_if_else_count
+
+
+def test_compile_if_else_branch_bodies_intact(mcm_target):
+    """Branch body gate content and qubit targets should be preserved after compilation."""
+    qasm = """
+OPENQASM 3.0;
+qubit[2] q;
+bit[1] c;
+c[0] = measure q[0];
+if (c[0] == 1) {
+    h q[1];
+} else {
+    x q[1];
+}
+"""
+    result = _compile(qasm, target=mcm_target)
+    compiled_circuit = result.circuits[0]
+    op = next(instr for instr in compiled_circuit.data if isinstance(instr.operation, IfElseOp)).operation
+    true_body, false_body = op.params
+
+    assert _get_ops_with_qubits(true_body) == [("h", [1])]
+    assert _get_ops_with_qubits(false_body) == [("x", [1])]
+
+
+def test_compile_if_else_condition_preserved(mcm_target):
+    """The condition clbit and value should be preserved after compilation."""
+    qasm = """
+OPENQASM 3.0;
+qubit[2] q;
+bit[1] c;
+c[0] = measure q[0];
+if (c[0] == 1) {
+    h q[1];
+}
+"""
+    result = _compile(qasm, target=mcm_target)
+    compiled_circuit = result.circuits[0]
+    instr = next(i for i in compiled_circuit.data if isinstance(i.operation, IfElseOp))
+    op = instr.operation
+    clbit, value = op.condition
+    assert isinstance(clbit, Clbit)
+    assert compiled_circuit.clbits.index(clbit) == 0
+    assert value == 1
+
+    # Verify the IfElseOp spans the right qubits on the compiled circuit
+    qubit_indices = [compiled_circuit.find_bit(q).index for q in instr.qubits]
+    assert 0 in qubit_indices
+    assert 1 in qubit_indices
+
+
+# --- Coverage: static branching ---
+
+
+def test_static_true_condition_takes_if_branch():
+    """A static true condition should execute only the if block."""
+    qasm = """
+OPENQASM 3.0;
+qubit[1] q;
+bit[1] c;
+if (1 == 1) {
+    h q[0];
+} else {
+    x q[0];
+}
+c[0] = measure q[0];
+"""
+    qc = to_qiskit(qasm)
+    ops = _get_ops_with_qubits(qc)
+    assert ("h", [0]) in ops
+    assert ("x", [0]) not in ops
+
+
+def test_static_false_condition_takes_else_branch():
+    """A static false condition should execute only the else block."""
+    qasm = """
+OPENQASM 3.0;
+qubit[1] q;
+bit[1] c;
+if (0 == 1) {
+    h q[0];
+} else {
+    x q[0];
+}
+c[0] = measure q[0];
+"""
+    qc = to_qiskit(qasm)
+    ops = _get_ops_with_qubits(qc)
+    assert ("x", [0]) in ops
+    assert ("h", [0]) not in ops
+
+
+# --- Coverage: while loop ---
+
+
+def test_while_loop_before_measurement():
+    """A while loop with a static condition should execute normally."""
+    qasm = """
+OPENQASM 3.0;
+qubit[1] q;
+bit[1] c;
+int[8] i = 0;
+while (i < 2) {
+    h q[0];
+    i += 1;
+}
+c[0] = measure q[0];
+"""
+    qc = to_qiskit(qasm)
+    h_count = sum(1 for name, _ in _get_ops_with_qubits(qc) if name == "h")
+    assert h_count == 2
+
+
+# --- Coverage: for loop with break/continue and DiscreteSet ---
+
+
+def test_for_loop_with_break():
+    qasm = """
+OPENQASM 3.0;
+qubit[1] q;
+bit[1] c;
+for int[8] i in {0, 1, 2} {
+    h q[0];
+    break;
+}
+c[0] = measure q[0];
+"""
+    qc = to_qiskit(qasm)
+    h_count = sum(1 for name, _ in _get_ops_with_qubits(qc) if name == "h")
+    assert h_count == 1
+
+
+def test_for_loop_with_continue():
+    qasm = """
+OPENQASM 3.0;
+qubit[1] q;
+bit[1] c;
+for int[8] i in {0, 1} {
+    continue;
+    h q[0];
+}
+c[0] = measure q[0];
+"""
+    qc = to_qiskit(qasm)
+    h_count = sum(1 for name, _ in _get_ops_with_qubits(qc) if name == "h")
+    assert h_count == 0
+
+
+# --- Coverage: _resolve_condition with literal on LHS ---
+
+
+def test_condition_literal_on_lhs():
+    """Condition with literal on the left side: if (1 == c[0])."""
+    qasm = """
+OPENQASM 3.0;
+qubit[2] q;
+bit[1] c;
+c[0] = measure q[0];
+if (1 == c[0]) {
+    h q[1];
+}
+"""
+    qc = to_qiskit(qasm)
+    op = _get_if_else_ops(qc)[0].operation
+    clbit, value = op.condition
+    assert qc.clbits.index(clbit) == 0
+    assert value == 1
+
+
+# --- Coverage: _resolve_clbit_index for bare Identifier ---
+
+
+def test_condition_bare_identifier():
+    """Condition on a single-bit variable without indexing: if (c == 1)."""
+    qasm = """
+OPENQASM 3.0;
+qubit[2] q;
+bit c;
+c = measure q[0];
+if (c == 1) {
+    h q[1];
+}
+"""
+    qc = to_qiskit(qasm)
+    op = _get_if_else_ops(qc)[0].operation
+    clbit, value = op.condition
+    assert qc.clbits.index(clbit) == 0
+    assert value == 1
+    assert _get_ops_with_qubits(op.params[0]) == [("h", [1])]
+
+
+# --- Coverage: while loop break/continue ---
+
+
+def test_while_loop_with_break():
+    qasm = """
+OPENQASM 3.0;
+qubit[1] q;
+bit[1] c;
+int[8] i = 0;
+while (i < 5) {
+    h q[0];
+    i += 1;
+    break;
+}
+c[0] = measure q[0];
+"""
+    qc = to_qiskit(qasm)
+    h_count = sum(1 for name, _ in _get_ops_with_qubits(qc) if name == "h")
+    assert h_count == 1
+
+
+def test_while_loop_with_continue():
+    qasm = """
+OPENQASM 3.0;
+qubit[1] q;
+bit[1] c;
+int[8] i = 0;
+while (i < 2) {
+    i += 1;
+    continue;
+    h q[0];
+}
+c[0] = measure q[0];
+"""
+    qc = to_qiskit(qasm)
+    h_count = sum(1 for name, _ in _get_ops_with_qubits(qc) if name == "h")
+    assert h_count == 0
+
+
+# --- Coverage: _resolve_clbit_index unsupported type ---
+
+
+def test_resolve_clbit_index_unsupported_type():
+    from braket.default_simulator.openqasm.parser.openqasm_ast import IntegerLiteral
+    from qiskit_braket_provider.providers.adapter import _QiskitProgramContext
+
+    ctx = _QiskitProgramContext()
+    with pytest.raises(TypeError, match="Unsupported condition operand type"):
+        ctx._resolve_clbit_index(IntegerLiteral(value=0))

--- a/tests/providers/test_adapter_branching.py
+++ b/tests/providers/test_adapter_branching.py
@@ -439,8 +439,6 @@ if (c[0] == 1) {
     assert 1 in qubit_indices
 
 
-# --- Coverage: static branching ---
-
 
 def test_static_true_condition_takes_if_branch():
     """A static true condition should execute only the if block."""
@@ -480,9 +478,6 @@ c[0] = measure q[0];
     assert ("h", [0]) not in ops
 
 
-# --- Coverage: while loop ---
-
-
 def test_while_loop_before_measurement():
     """A while loop with a static condition should execute normally."""
     qasm = """
@@ -499,9 +494,6 @@ c[0] = measure q[0];
     qc = to_qiskit(qasm)
     h_count = sum(1 for name, _ in _get_ops_with_qubits(qc) if name == "h")
     assert h_count == 2
-
-
-# --- Coverage: for loop with break/continue and DiscreteSet ---
 
 
 def test_for_loop_with_break():
@@ -536,9 +528,6 @@ c[0] = measure q[0];
     assert h_count == 0
 
 
-# --- Coverage: _resolve_condition with literal on LHS ---
-
-
 def test_condition_literal_on_lhs():
     """Condition with literal on the left side: if (1 == c[0])."""
     qasm = """
@@ -555,9 +544,6 @@ if (1 == c[0]) {
     clbit, value = op.condition
     assert qc.clbits.index(clbit) == 0
     assert value == 1
-
-
-# --- Coverage: _resolve_clbit_index for bare Identifier ---
 
 
 def test_condition_bare_identifier():
@@ -577,9 +563,6 @@ if (c == 1) {
     assert qc.clbits.index(clbit) == 0
     assert value == 1
     assert _get_ops_with_qubits(op.params[0]) == [("h", [1])]
-
-
-# --- Coverage: while loop break/continue ---
 
 
 def test_while_loop_with_break():
@@ -616,9 +599,6 @@ c[0] = measure q[0];
     qc = to_qiskit(qasm)
     h_count = sum(1 for name, _ in _get_ops_with_qubits(qc) if name == "h")
     assert h_count == 0
-
-
-# --- Coverage: _resolve_clbit_index unsupported type ---
 
 
 def test_resolve_clbit_index_unsupported_type():


### PR DESCRIPTION
## Summary

### What
Converts OpenQASM 3 if/else statements conditioned on measurement results into Qiskit IfElseOp operations during the OpenQASM → Qiskit conversion.

### Changes

qiskit_braket_provider/providers/adapter.py
- `supports_midcircuit_measurement` → returns True, enabling the interpreter to delegate control flow to the context
- `set_visitor()` — stores the interpreter's visit method for use in control flow handlers
- `handle_branching_statement()` — tries static evaluation first; if the condition can't be resolved (measurement result), creates separate QuantumCircuit 
objects for each branch by swapping self._circuit, visits the blocks via the stored visitor, then wraps them in an IfElseOp
- `handle_for_loop()` / `handle_while_loop()` — replicate the interpreter's default loop logic so `supports_midcircuit_measurement=True` doesn't break non-MCM loops,
while still allowing MCM branches inside loop bodies
- `_resolve_condition()` / `_resolve_clbit_index()` — map OpenQASM AST condition nodes to Qiskit (Clbit, int) tuples using a `_clbit_offset` map populated during 
`declare_variable()`
- `declare_variable()` — now tracks the starting clbit index for each bit variable in `_clbit_offset`


## Details and comments

### Design decisions
- Static vs MCM detection uses try/except on condition evaluation rather than variable tracking — avoids false positives from input bit variables
- Branch circuits are built by temporarily swapping `self._circuit`, so all existing instruction routing (`add_gate_instruction`, `add_measure`, etc.) works without 
modification
- Loop handlers replicate interpreter logic directly (rather than toggling `supports_midcircuit_measurement`) so MCM branches inside loops are handled correctly
