### PR TITLE
Feature: handle branching using Qiskit

### DIFF
--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -353,8 +353,7 @@ class _QiskitProgramContext(AbstractProgramContext):
                 Default: "verbatim"
         """
         super().__init__()
-        self._circuit = QuantumCircuit()
-        self._circuit_stack: list[QuantumCircuit] = []
+        self._circuit_stack: list[QuantumCircuit] = [QuantumCircuit()]
         self._param_map = {}
         self._in_verbatim_box = False
         self._verbatim_circuit: QuantumCircuit | None = None
@@ -363,8 +362,8 @@ class _QiskitProgramContext(AbstractProgramContext):
 
     @property
     def _active_circuit(self) -> QuantumCircuit:
-        """The circuit that instructions should be added to (top of stack or main)."""
-        return self._circuit_stack[-1] if self._circuit_stack else self._circuit
+        """The circuit that instructions should be added to (top of stack)."""
+        return self._circuit_stack[-1]
 
     @property
     def circuit(self):
@@ -373,7 +372,7 @@ class _QiskitProgramContext(AbstractProgramContext):
                 "Unclosed verbatim box at end of program. "
                 "Every verbatim box start marker must have a matching end marker."
             )
-        return self._circuit
+        return self._circuit_stack[0]
 
     def add_qubits(self, name: str, num_qubits: int | None = 1) -> None:
         super().add_qubits(name, num_qubits)
@@ -525,7 +524,10 @@ class _QiskitProgramContext(AbstractProgramContext):
         # Try static evaluation first
         try:
             result = cast_to(BooleanLiteral, self._evaluate_expression(condition))
-        except (NameError, TypeError, ValueError, AttributeError):
+        except (TypeError, ValueError, AttributeError):
+            # TypeError: unsupported node type (e.g., FunctionCall) in _evaluate_expression
+            # ValueError: binary expression with None operand (unresolved measurement)
+            # AttributeError: cast_to on None.value (bare bit with pending measurement)
             pass
         else:
             yield result.value
@@ -556,7 +558,8 @@ class _QiskitProgramContext(AbstractProgramContext):
         yield True
         self._circuit_stack.pop()
 
-        # Push circuit for else-block
+        # Push circuit for else-block (the interpreter always consumes this yield
+        # even for if-only blocks; the empty circuit is discarded below)
         false_body = QuantumCircuit(main.num_qubits, main.num_clbits)
         self._circuit_stack.append(false_body)
         yield False
@@ -627,14 +630,14 @@ class _QiskitProgramContext(AbstractProgramContext):
         else:
             clbit_index = self._resolve_clbit_index(condition.rhs)
             value = condition.lhs.value
-        return (self._circuit.clbits[clbit_index], int(value))
+        return (self.circuit.clbits[clbit_index], int(value))
 
     def _resolve_condition_from_identifier(
         self, condition: Identifier | IndexExpression
     ) -> tuple[Clbit, int]:
         """Convert a bare identifier condition (e.g., `c` or `c[0]`) to (Clbit, 1)."""
         clbit_index = self._resolve_clbit_index(condition)
-        return (self._circuit.clbits[clbit_index], 1)
+        return (self.circuit.clbits[clbit_index], 1)
 
     def _resolve_clbit_index(self, node: Identifier | IndexExpression) -> int:
         """Resolve an identifier or indexed identifier to a classical bit index."""

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -9,6 +9,7 @@ sequences that should not be optimized.
 import warnings
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Mapping, Sequence
+from copy import deepcopy
 from dataclasses import dataclass
 from math import inf, pi, prod
 from numbers import Number
@@ -25,6 +26,7 @@ from qiskit.circuit import (
     Clbit,
     ControlledGate,
     Gate,
+    IfElseOp,
     Measure,
     Parameter,
     ParameterExpression,
@@ -52,13 +54,28 @@ from braket.circuits import Observable as BraketObservable
 from braket.circuits import gates as braket_gates
 from braket.circuits import noises as braket_noises
 from braket.circuits import observables as braket_observables
+from braket.default_simulator.openqasm._helpers.arrays import convert_range_def_to_range
+from braket.default_simulator.openqasm._helpers.casting import cast_to
 from braket.default_simulator.openqasm.interpreter import Interpreter, VerbatimBoxDelimiter
 from braket.default_simulator.openqasm.parser.openqasm_ast import (
+    BinaryExpression,
     BitType,
+    BooleanLiteral,
+    BranchingStatement,
     ClassicalType,
+    ForInLoop,
+    Identifier,
+    IndexedIdentifier,
+    IndexExpression,
     IntegerLiteral,
+    RangeDefinition,
+    WhileLoop,
 )
-from braket.default_simulator.openqasm.program_context import AbstractProgramContext
+from braket.default_simulator.openqasm.program_context import (
+    AbstractProgramContext,
+    _BreakSignal,
+    _ContinueSignal,
+)
 from braket.device_schema import (
     DeviceActionType,
     DeviceCapabilities,
@@ -336,6 +353,8 @@ class _QiskitProgramContext(AbstractProgramContext):
         self._in_verbatim_box = False
         self._verbatim_circuit: QuantumCircuit | None = None
         self._verbatim_box_name = verbatim_box_name
+        self._visitor: Callable | None = None
+        self._clbit_offset: dict[str, int] = {}
 
     @property
     def circuit(self):
@@ -380,6 +399,8 @@ class _QiskitProgramContext(AbstractProgramContext):
             else:
                 size = 1
             
+            # this is used deal with Qiskit circuit storing all classical bits in a flat list
+            self._clbit_offset[name] = self._circuit.num_clbits
             self._circuit.add_bits([Clbit() for _ in range(size)])
 
     def is_builtin_gate(self, name: str) -> bool:
@@ -474,6 +495,103 @@ class _QiskitProgramContext(AbstractProgramContext):
         
         else:
             raise ValueError("Verbatim box created using invalid marker")
+
+    @property
+    def supports_midcircuit_measurement(self) -> bool:
+        return True
+
+    def set_visitor(self, visitor: Callable) -> None:
+        self._visitor = visitor
+
+    def handle_branching_statement(self, node: BranchingStatement) -> None:
+        # Try static evaluation first; fall back to MCM if the condition
+        # can't be resolved (e.g. it depends on a measurement result) due to
+        # NameError (uninitialized variable, i.e. measurement result) or
+        # TypeError (can't cast to boolean)
+        try:
+            condition = cast_to(BooleanLiteral, self._visitor(node.condition))
+        except (NameError, TypeError):
+            pass
+        else:
+            if condition.value:
+                self._visitor(node.if_block)
+            elif node.else_block:
+                self._visitor(node.else_block)
+            return
+
+        condition = self._resolve_condition(node.condition)
+        main_circuit = self._circuit
+
+        # Visit if block into a separate circuit
+        true_body = QuantumCircuit(main_circuit.num_qubits, main_circuit.num_clbits)
+        self._circuit = true_body
+        for statement in node.if_block:
+            self._visitor(statement)
+
+        # Visit else block if present
+        false_body = None
+        if node.else_block:
+            false_body = QuantumCircuit(main_circuit.num_qubits, main_circuit.num_clbits)
+            self._circuit = false_body
+            for statement in node.else_block:
+                self._visitor(statement)
+
+        self._circuit = main_circuit
+
+        if_else_op = IfElseOp(condition, true_body, false_body)
+        qubits = list(range(main_circuit.num_qubits))
+        clbits = list(range(main_circuit.num_clbits))
+        self._circuit.append(if_else_op, qubits, clbits)
+
+    def handle_for_loop(self, node: ForInLoop) -> None:
+        index = self._visitor(node.set_declaration)
+        if isinstance(index, RangeDefinition):
+            index_values = [IntegerLiteral(x) for x in convert_range_def_to_range(index)]
+        else:
+            index_values = index.values
+        for i in index_values:
+            with self.enter_scope():
+                self.declare_variable(node.identifier.name, node.type, i)
+                try:
+                    self._visitor(deepcopy(node.block))
+                except _BreakSignal:
+                    break
+                except _ContinueSignal:
+                    continue
+
+    def handle_while_loop(self, node: WhileLoop) -> None:
+        while cast_to(BooleanLiteral, self._visitor(node.while_condition)).value:
+            try:
+                self._visitor(deepcopy(node.block))
+            except _BreakSignal:
+                break
+            except _ContinueSignal:
+                continue
+
+    def _resolve_condition(
+        self, condition: BinaryExpression
+    ) -> tuple[Clbit, int]:
+        """Convert an OpenQASM condition AST node to a Qiskit (Clbit, int) condition."""
+        if isinstance(condition.lhs, (Identifier, IndexedIdentifier, IndexExpression)):
+            clbit_index = self._resolve_clbit_index(condition.lhs)
+            value = condition.rhs.value
+        else:
+            clbit_index = self._resolve_clbit_index(condition.rhs)
+            value = condition.lhs.value
+        return (self._circuit.clbits[clbit_index], int(value))
+
+    def _resolve_clbit_index(self, node: Identifier | IndexExpression) -> int:
+        """Resolve an identifier or indexed identifier to a classical bit index."""
+        if isinstance(node, IndexExpression):
+            name = node.collection.name
+            index = node.index[0].value
+        elif isinstance(node, Identifier):
+            name = node.name
+            index = 0
+        else:
+            raise TypeError(f"Unsupported condition operand type: {type(node)}")
+
+        return self._clbit_offset[name] + index
 
 
 def native_gate_connectivity(properties: DeviceCapabilities) -> list[list[int]] | None:

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -359,6 +359,7 @@ class _QiskitProgramContext(AbstractProgramContext):
         self._verbatim_circuit: QuantumCircuit | None = None
         self._verbatim_box_name = verbatim_box_name
         self._clbit_offset: dict[str, int] = {}
+        self._measured_bits: set[str] = set()
 
     @property
     def _active_circuit(self) -> QuantumCircuit:
@@ -408,7 +409,7 @@ class _QiskitProgramContext(AbstractProgramContext):
             else:
                 size = 1
             
-            # this is used deal with Qiskit circuit storing all classical bits in a flat list
+            # this is used to deal with Qiskit's QuantumCircuit storing all classical bits in a flat list
             self._clbit_offset[name] = self._active_circuit.num_clbits
             self._active_circuit.add_bits([Clbit() for _ in range(size)])
 
@@ -454,7 +455,16 @@ class _QiskitProgramContext(AbstractProgramContext):
     def handle_parameter_value(self, value: Number | Expr) -> Number | Parameter:
         return _sympy_to_qiskit(value, self._param_map) if isinstance(value, Expr) else value
 
-    def add_measure(self, target: tuple[int], classical_targets: Iterable[int] | None = None, **kwargs):
+    def add_measure(
+        self,
+        target: tuple[int],
+        classical_targets: Iterable[int] | None = None,
+        *,
+        classical_destination: Identifier | IndexedIdentifier | None = None,
+    ) -> None:
+        if classical_destination is not None:
+            name = classical_destination.name if isinstance(classical_destination, IndexedIdentifier) else classical_destination
+            self._measured_bits.add(name.name)
         active = self._active_circuit
         # this is to cover the edge case where a user measures a qubit without assigning it to a classical register
         if active.num_clbits < len(target):
@@ -511,6 +521,18 @@ class _QiskitProgramContext(AbstractProgramContext):
     def supports_midcircuit_measurement(self) -> bool:
         return True
 
+    def _references_measurement(self, condition) -> bool:
+        """Check if condition references a variable that was measured into."""
+        match condition:
+            case Identifier(name=name):
+                return name in self._measured_bits
+            case IndexExpression(collection=Identifier(name=name)):
+                return name in self._measured_bits
+            case BinaryExpression(lhs=lhs, rhs=rhs):
+                return self._references_measurement(lhs) or self._references_measurement(rhs)
+            case _:
+                return False
+
     def evaluate_condition(self, condition):
         """Evaluate a branching condition using a circuit stack.
 
@@ -521,15 +543,13 @@ class _QiskitProgramContext(AbstractProgramContext):
         For static conditions (no measurement dependency), evaluates directly
         and yields only the taken branch.
         """
-        # Try static evaluation first
-        try:
-            result = cast_to(BooleanLiteral, self._evaluate_expression(condition))
-        except (TypeError, ValueError, AttributeError):
-            # TypeError: unsupported node type (e.g., FunctionCall) in _evaluate_expression
-            # ValueError: binary expression with None operand (unresolved measurement)
-            # AttributeError: cast_to on None.value (bare bit with pending measurement)
-            pass
-        else:
+        if not self._references_measurement(condition):
+            try:
+                result = cast_to(BooleanLiteral, self._evaluate_expression(condition))
+            except (TypeError, ValueError, AttributeError) as e:
+                raise TypeError(
+                    "Unsupported condition in branching statement"
+                ) from e
             yield result.value
             return
 
@@ -540,19 +560,12 @@ class _QiskitProgramContext(AbstractProgramContext):
             resolved_condition = self._resolve_condition_from_identifier(condition)
         elif isinstance(condition, BinaryExpression):
             if condition.op != BinaryOperator["=="]:
-                raise TypeError(
+                raise NotImplementedError(
                     f"Unsupported operator '{condition.op.name}' in branching condition. "
                     f"Only '==' is supported for mid-circuit measurement branching."
                 )
             resolved_condition = self._resolve_condition(condition)
-        else:
-            raise TypeError(
-                f"Unsupported condition type for mid-circuit measurement branching: "
-                f"{type(condition).__name__}. Only binary comparisons on classical bits "
-                f"(e.g., 'c[0] == 1') or bare bit checks (e.g., 'c[0]') are supported."
-            )
 
-        # Push circuit for if-block
         true_body = QuantumCircuit(main.num_qubits, main.num_clbits)
         self._circuit_stack.append(true_body)
         yield True
@@ -565,12 +578,19 @@ class _QiskitProgramContext(AbstractProgramContext):
         yield False
         self._circuit_stack.pop()
 
-        # Only include false_body if it has instructions
         actual_false = false_body if false_body.data else None
 
+        # Sync main circuit dimensions if branch bodies grew
+        max_qubits = max(true_body.num_qubits, false_body.num_qubits)
+        max_clbits = max(true_body.num_clbits, false_body.num_clbits)
+        if max_qubits > main.num_qubits:
+            main.add_bits([Qubit() for _ in range(max_qubits - main.num_qubits)])
+        if max_clbits > main.num_clbits:
+            main.add_bits([Clbit() for _ in range(max_clbits - main.num_clbits)])
+
         if_else_op = IfElseOp(resolved_condition, true_body, actual_false)
-        qubits = list(range(main.num_qubits))
-        clbits = list(range(main.num_clbits))
+        qubits = list(range(max_qubits))
+        clbits = list(range(max_clbits))
         main.append(if_else_op, qubits, clbits)
 
     def evaluate_for_range(self, set_declaration, loop_var: str, loop_type):
@@ -624,7 +644,7 @@ class _QiskitProgramContext(AbstractProgramContext):
         self, condition: BinaryExpression
     ) -> tuple[Clbit, int]:
         """Convert an OpenQASM condition AST node to a Qiskit (Clbit, int) condition."""
-        if isinstance(condition.lhs, (Identifier, IndexedIdentifier, IndexExpression)):
+        if isinstance(condition.lhs, (Identifier, IndexExpression)):
             clbit_index = self._resolve_clbit_index(condition.lhs)
             value = condition.rhs.value
         else:
@@ -646,6 +666,14 @@ class _QiskitProgramContext(AbstractProgramContext):
             index = node.index[0].value
         elif isinstance(node, Identifier):
             name = node.name
+            var_type = self.get_type(name)
+            if isinstance(var_type, BitType) and var_type.size is not None:
+                size = var_type.size.value if isinstance(var_type.size, IntegerLiteral) else None
+                if size is not None and size > 1:
+                    raise TypeError(
+                        f"Multi-bit register '{name}' (bit[{size}]) cannot be used as a "
+                        f"single-bit condition. Use an indexed reference like '{name}[0]'."
+                    )
             index = 0
         else:
             raise TypeError(f"Unsupported condition operand type: {type(node)}")

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -9,7 +9,6 @@ sequences that should not be optimized.
 import warnings
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Mapping, Sequence
-from copy import deepcopy
 from dataclasses import dataclass
 from math import inf, pi, prod
 from numbers import Number
@@ -56,25 +55,31 @@ from braket.circuits import noises as braket_noises
 from braket.circuits import observables as braket_observables
 from braket.default_simulator.openqasm._helpers.arrays import convert_range_def_to_range
 from braket.default_simulator.openqasm._helpers.casting import cast_to
+from braket.default_simulator.openqasm._helpers.functions import (
+    evaluate_binary_expression,
+    evaluate_unary_expression,
+)
 from braket.default_simulator.openqasm.interpreter import Interpreter, VerbatimBoxDelimiter
 from braket.default_simulator.openqasm.parser.openqasm_ast import (
+    ArrayLiteral,
     BinaryExpression,
+    BinaryOperator,
     BitType,
     BooleanLiteral,
-    BranchingStatement,
+    Cast,
     ClassicalType,
-    ForInLoop,
+    DiscreteSet,
+    FloatLiteral,
     Identifier,
     IndexedIdentifier,
     IndexExpression,
     IntegerLiteral,
     RangeDefinition,
-    WhileLoop,
+    SymbolLiteral,
+    UnaryExpression,
 )
 from braket.default_simulator.openqasm.program_context import (
     AbstractProgramContext,
-    _BreakSignal,
-    _ContinueSignal,
 )
 from braket.device_schema import (
     DeviceActionType,
@@ -349,12 +354,17 @@ class _QiskitProgramContext(AbstractProgramContext):
         """
         super().__init__()
         self._circuit = QuantumCircuit()
+        self._circuit_stack: list[QuantumCircuit] = []
         self._param_map = {}
         self._in_verbatim_box = False
         self._verbatim_circuit: QuantumCircuit | None = None
         self._verbatim_box_name = verbatim_box_name
-        self._visitor: Callable | None = None
         self._clbit_offset: dict[str, int] = {}
+
+    @property
+    def _active_circuit(self) -> QuantumCircuit:
+        """The circuit that instructions should be added to (top of stack or main)."""
+        return self._circuit_stack[-1] if self._circuit_stack else self._circuit
 
     @property
     def circuit(self):
@@ -367,7 +377,7 @@ class _QiskitProgramContext(AbstractProgramContext):
 
     def add_qubits(self, name: str, num_qubits: int | None = 1) -> None:
         super().add_qubits(name, num_qubits)
-        self._circuit.add_register(num_qubits)
+        self._active_circuit.add_register(num_qubits)
 
     def declare_variable(
         self,
@@ -400,14 +410,14 @@ class _QiskitProgramContext(AbstractProgramContext):
                 size = 1
             
             # this is used deal with Qiskit circuit storing all classical bits in a flat list
-            self._clbit_offset[name] = self._circuit.num_clbits
-            self._circuit.add_bits([Clbit() for _ in range(size)])
+            self._clbit_offset[name] = self._active_circuit.num_clbits
+            self._active_circuit.add_bits([Clbit() for _ in range(size)])
 
     def is_builtin_gate(self, name: str) -> bool:
         return name in _BRAKET_GATE_NAME_TO_QISKIT_GATE
 
     def add_phase_instruction(self, target, phase_value):
-        self._circuit.global_phase += phase_value
+        self._active_circuit.global_phase += phase_value
 
     def add_gate_instruction(
         self, gate_name: str, target: tuple[int, ...], params, ctrl_modifiers: list[int], power: int
@@ -426,12 +436,13 @@ class _QiskitProgramContext(AbstractProgramContext):
                 len(ctrl_modifiers), ctrl_state=str("".join([str(i) for i in ctrl_modifiers]))
             )
 
+        active = self._active_circuit
         # Ensure circuit has enough qubits for the target indices by adding missing qubits
         # This is needed when using physical qubits ($0, $1, etc.) where no qubit register is declared
         max_qubits = (max(target) + 1) if target else -1
-        num_missing_qubits = max_qubits - self._circuit.num_qubits
-        self._circuit.add_bits([Qubit() for _ in range(num_missing_qubits)])
-        self.num_qubits = self._circuit.num_qubits        
+        num_missing_qubits = max_qubits - active.num_qubits
+        active.add_bits([Qubit() for _ in range(num_missing_qubits)])
+        self.num_qubits = max(self.num_qubits, active.num_qubits)
 
         if self._in_verbatim_box:
             # Ensure verbatim circuit also has enough qubits by adding missing qubits
@@ -439,19 +450,20 @@ class _QiskitProgramContext(AbstractProgramContext):
             self._verbatim_circuit.add_bits([Qubit() for _ in range(num_missing_qubits)])
             self._verbatim_circuit.append(CircuitInstruction(gate, target))
         else:
-            self._circuit.append(CircuitInstruction(gate, target))
+            active.append(CircuitInstruction(gate, target))
 
     def handle_parameter_value(self, value: Number | Expr) -> Number | Parameter:
         return _sympy_to_qiskit(value, self._param_map) if isinstance(value, Expr) else value
 
-    def add_measure(self, target: tuple[int], classical_targets: Iterable[int] | None = None):
+    def add_measure(self, target: tuple[int], classical_targets: Iterable[int] | None = None, **kwargs):
+        active = self._active_circuit
         # this is to cover the edge case where a user measures a qubit without assigning it to a classical register
-        if self._circuit.num_clbits < len(target):
-            num_missing_clbits = len(target) - self._circuit.num_clbits
-            self._circuit.add_bits([Clbit() for _ in range(num_missing_clbits)])
+        if active.num_clbits < len(target):
+            num_missing_clbits = len(target) - active.num_clbits
+            active.add_bits([Clbit() for _ in range(num_missing_clbits)])
         for iter, qubit in enumerate(target):
             index = classical_targets[iter] if classical_targets else iter
-            self._circuit.measure(qubit, index)
+            active.measure(qubit, index)
 
     def add_verbatim_marker(self, marker: VerbatimBoxDelimiter) -> None:
         """Handle verbatim box start/end markers.
@@ -485,10 +497,10 @@ class _QiskitProgramContext(AbstractProgramContext):
 
             box_op = BoxOp(self._verbatim_circuit, label=self._verbatim_box_name)
 
-            # Append BoxOp to main circuit with all qubits (convert indices to Qubit objects)
-            # We need to pass the actual Qubit objects from the main circuit, not just indices
-            qubit_objects = [self._circuit.qubits[i] for i in range(self._verbatim_circuit.num_qubits)]
-            self._circuit.append(box_op, qubit_objects)
+            active = self._active_circuit
+            # Append BoxOp to active circuit with all qubits (convert indices to Qubit objects)
+            qubit_objects = [active.qubits[i] for i in range(self._verbatim_circuit.num_qubits)]
+            active.append(box_op, qubit_objects)
 
             self._in_verbatim_box = False
             self._verbatim_circuit = None
@@ -500,73 +512,110 @@ class _QiskitProgramContext(AbstractProgramContext):
     def supports_midcircuit_measurement(self) -> bool:
         return True
 
-    def set_visitor(self, visitor: Callable) -> None:
-        self._visitor = visitor
+    def evaluate_condition(self, condition):
+        """Evaluate a branching condition using a circuit stack.
 
-    def handle_branching_statement(self, node: BranchingStatement) -> None:
-        # Try static evaluation first; fall back to MCM if the condition
-        # can't be resolved (e.g. it depends on a measurement result) due to
-        # NameError (uninitialized variable, i.e. measurement result) or
-        # TypeError (can't cast to boolean)
+        Yields True (visit if-block) then False (visit else-block).
+        Each yield pushes a new circuit onto the stack; after the interpreter
+        visits the block, the circuit is popped and used to build an IfElseOp.
+
+        For static conditions (no measurement dependency), evaluates directly
+        and yields only the taken branch.
+        """
+        # Try static evaluation first
         try:
-            condition = cast_to(BooleanLiteral, self._visitor(node.condition))
-        except (NameError, TypeError):
+            result = cast_to(BooleanLiteral, self._evaluate_expression(condition))
+        except (NameError, TypeError, ValueError, AttributeError):
             pass
         else:
-            if condition.value:
-                self._visitor(node.if_block)
-            elif node.else_block:
-                self._visitor(node.else_block)
+            yield result.value
             return
 
-        condition = self._resolve_condition(node.condition)
-        main_circuit = self._circuit
+        # MCM path: resolve condition to (Clbit, value)
+        main = self._active_circuit
+        if isinstance(condition, (Identifier, IndexExpression)):
+            # Bare identifier like `if (c)` or `if (c[0])` — equivalent to `== 1`
+            resolved_condition = self._resolve_condition_from_identifier(condition)
+        elif isinstance(condition, BinaryExpression):
+            if condition.op != BinaryOperator["=="]:
+                raise TypeError(
+                    f"Unsupported operator '{condition.op.name}' in branching condition. "
+                    f"Only '==' is supported for mid-circuit measurement branching."
+                )
+            resolved_condition = self._resolve_condition(condition)
+        else:
+            raise TypeError(
+                f"Unsupported condition type for mid-circuit measurement branching: "
+                f"{type(condition).__name__}. Only binary comparisons on classical bits "
+                f"(e.g., 'c[0] == 1') or bare bit checks (e.g., 'c[0]') are supported."
+            )
 
-        # Visit if block into a separate circuit
-        true_body = QuantumCircuit(main_circuit.num_qubits, main_circuit.num_clbits)
-        self._circuit = true_body
-        for statement in node.if_block:
-            self._visitor(statement)
+        # Push circuit for if-block
+        true_body = QuantumCircuit(main.num_qubits, main.num_clbits)
+        self._circuit_stack.append(true_body)
+        yield True
+        self._circuit_stack.pop()
 
-        # Visit else block if present
-        false_body = None
-        if node.else_block:
-            false_body = QuantumCircuit(main_circuit.num_qubits, main_circuit.num_clbits)
-            self._circuit = false_body
-            for statement in node.else_block:
-                self._visitor(statement)
+        # Push circuit for else-block
+        false_body = QuantumCircuit(main.num_qubits, main.num_clbits)
+        self._circuit_stack.append(false_body)
+        yield False
+        self._circuit_stack.pop()
 
-        self._circuit = main_circuit
+        # Only include false_body if it has instructions
+        actual_false = false_body if false_body.data else None
 
-        if_else_op = IfElseOp(condition, true_body, false_body)
-        qubits = list(range(main_circuit.num_qubits))
-        clbits = list(range(main_circuit.num_clbits))
-        self._circuit.append(if_else_op, qubits, clbits)
+        if_else_op = IfElseOp(resolved_condition, true_body, actual_false)
+        qubits = list(range(main.num_qubits))
+        clbits = list(range(main.num_clbits))
+        main.append(if_else_op, qubits, clbits)
 
-    def handle_for_loop(self, node: ForInLoop) -> None:
-        index = self._visitor(node.set_declaration)
+    def evaluate_for_range(self, set_declaration, loop_var: str, loop_type):
+        """Set up each for-loop iteration, yielding once per iteration."""
+        index = self._evaluate_expression(set_declaration)
         if isinstance(index, RangeDefinition):
             index_values = [IntegerLiteral(x) for x in convert_range_def_to_range(index)]
         else:
             index_values = index.values
         for i in index_values:
             with self.enter_scope():
-                self.declare_variable(node.identifier.name, node.type, i)
-                try:
-                    self._visitor(deepcopy(node.block))
-                except _BreakSignal:
-                    break
-                except _ContinueSignal:
-                    continue
+                self.declare_variable(loop_var, loop_type, i)
+                yield
 
-    def handle_while_loop(self, node: WhileLoop) -> None:
-        while cast_to(BooleanLiteral, self._visitor(node.while_condition)).value:
-            try:
-                self._visitor(deepcopy(node.block))
-            except _BreakSignal:
-                break
-            except _ContinueSignal:
-                continue
+    def evaluate_while_condition(self, condition):
+        """Evaluate a while-loop condition, yielding True per iteration."""
+        while cast_to(BooleanLiteral, self._evaluate_expression(condition)).value:
+            yield True
+
+    def _evaluate_expression(self, expression):
+        """Lightweight expression evaluator for loop conditions and ranges."""
+        match expression:
+            case BooleanLiteral() | IntegerLiteral() | FloatLiteral() | ArrayLiteral() | SymbolLiteral():
+                return expression
+            case Identifier():
+                return self.get_value_by_identifier(expression)
+            case BinaryExpression(lhs=lhs, rhs=rhs, op=op):
+                return evaluate_binary_expression(
+                    self._evaluate_expression(lhs),
+                    self._evaluate_expression(rhs),
+                    op,
+                )
+            case UnaryExpression(expression=inner, op=op):
+                return evaluate_unary_expression(self._evaluate_expression(inner), op)
+            case Cast(type=cast_type, argument=argument):
+                return cast_to(cast_type, self._evaluate_expression(argument))
+            case RangeDefinition(start=start, end=end, step=step):
+                return RangeDefinition(
+                    self._evaluate_expression(start) if start else None,
+                    self._evaluate_expression(end),
+                    self._evaluate_expression(step) if step else None,
+                )
+            case DiscreteSet(values=values):
+                return DiscreteSet(values=[self._evaluate_expression(v) for v in values])
+            case list():
+                return [self._evaluate_expression(item) for item in expression]
+            case _:
+                raise TypeError(f"Cannot evaluate expression of type {type(expression).__name__}")
 
     def _resolve_condition(
         self, condition: BinaryExpression
@@ -579,6 +628,13 @@ class _QiskitProgramContext(AbstractProgramContext):
             clbit_index = self._resolve_clbit_index(condition.rhs)
             value = condition.lhs.value
         return (self._circuit.clbits[clbit_index], int(value))
+
+    def _resolve_condition_from_identifier(
+        self, condition: Identifier | IndexExpression
+    ) -> tuple[Clbit, int]:
+        """Convert a bare identifier condition (e.g., `c` or `c[0]`) to (Clbit, 1)."""
+        clbit_index = self._resolve_clbit_index(condition)
+        return (self._circuit.clbits[clbit_index], 1)
 
     def _resolve_clbit_index(self, node: Identifier | IndexExpression) -> int:
         """Resolve an identifier or indexed identifier to a classical bit index."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ certifi>=2021.5.30
 qiskit>=0.34.2
 qiskit-ionq>=0.5.2
 amazon-braket-sdk>=1.99.0
+amazon-braket-default-simulator>=1.37.0
 
 setuptools>=40.1.0
 numpy>=1.3

--- a/tests/providers/test_adapter.py
+++ b/tests/providers/test_adapter.py
@@ -1,6 +1,7 @@
 """Tests for Qiskit to Braket adapter."""
 
 import copy
+import unittest
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
@@ -1188,7 +1189,7 @@ class TestAdapter(TestCase):
         qasm_program = Program(source=qasm_string, inputs={"theta": 1.0})
         self.assertTrue(check_to_braket_openqasm_unitary_correct(qasm_program))
 
-    @pytest.mark.skip(reason="Requires interpreter pre-evaluation of FunctionCall conditions (amazon-braket-default-simulator-python#feature/pre-evaluate-branching-condition)")
+    @unittest.skip("Requires interpreter pre-evaluation of FunctionCall conditions")
     def test_roundtrip_openqasm_program(self):
         qasm_string = """
         const int[8] n = 4;

--- a/tests/providers/test_adapter.py
+++ b/tests/providers/test_adapter.py
@@ -1,5 +1,6 @@
 """Tests for Qiskit to Braket adapter."""
 
+import copy
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
@@ -1187,6 +1188,7 @@ class TestAdapter(TestCase):
         qasm_program = Program(source=qasm_string, inputs={"theta": 1.0})
         self.assertTrue(check_to_braket_openqasm_unitary_correct(qasm_program))
 
+    @pytest.mark.skip(reason="Requires interpreter pre-evaluation of FunctionCall conditions (amazon-braket-default-simulator-python#feature/pre-evaluate-branching-condition)")
     def test_roundtrip_openqasm_program(self):
         qasm_string = """
         const int[8] n = 4;
@@ -1637,8 +1639,6 @@ class TestThereAndBackAgain(TestCase):
 
     def test_missing_qubit_in_properties_handled_gracefully(self):
         """Tests that missing qubits in topology are handled gracefully with warnings."""
-        import copy
-        from unittest.mock import Mock
 
         # Create a mock device with properties containing qubits not in topology
         mock_device = Mock()

--- a/tests/providers/test_adapter_branching.py
+++ b/tests/providers/test_adapter_branching.py
@@ -5,18 +5,14 @@ from qiskit.circuit import Clbit, IfElseOp
 from qiskit.circuit.library import CXGate, HGate, Measure, XGate, YGate, ZGate
 from qiskit.transpiler import Target
 
+from braket.default_simulator.openqasm.parser.openqasm_ast import IntegerLiteral
 from qiskit_braket_provider import to_qiskit
-from qiskit_braket_provider.providers.adapter import _compile
+from qiskit_braket_provider.providers.adapter import _compile, _QiskitProgramContext
 
 
 def _get_if_else_ops(circuit):
     """Extract all IfElseOp instructions from a circuit."""
     return [instr for instr in circuit.data if isinstance(instr.operation, IfElseOp)]
-
-
-def _get_gate_names(circuit):
-    """Get gate names from a circuit, excluding measurements."""
-    return [instr.operation.name for instr in circuit.data if instr.operation.name != "measure"]
 
 
 def _get_ops_with_qubits(circuit):
@@ -439,7 +435,6 @@ if (c[0] == 1) {
     assert 1 in qubit_indices
 
 
-
 def test_static_true_condition_takes_if_branch():
     """A static true condition should execute only the if block."""
     qasm = """
@@ -602,9 +597,6 @@ c[0] = measure q[0];
 
 
 def test_resolve_clbit_index_unsupported_type():
-    from braket.default_simulator.openqasm.parser.openqasm_ast import IntegerLiteral
-    from qiskit_braket_provider.providers.adapter import _QiskitProgramContext
-
     ctx = _QiskitProgramContext()
     with pytest.raises(TypeError, match="Unsupported condition operand type"):
         ctx._resolve_clbit_index(IntegerLiteral(value=0))

--- a/tests/providers/test_adapter_branching.py
+++ b/tests/providers/test_adapter_branching.py
@@ -671,15 +671,15 @@ if (c[0] != 1) {
     h q[1];
 }
 """
-    with pytest.raises(TypeError, match="Unsupported operator.*Only '==' is supported"):
+    with pytest.raises(NotImplementedError, match="Unsupported operator.*Only '==' is supported"):
         to_qiskit(qasm)
 
 
 def test_unsupported_condition_type():
-    """A condition type that is not Identifier, IndexExpression, or BinaryExpression should raise."""
+    """A non-boolean-castable static condition should raise an unsupported condition error."""
     ctx = _QiskitProgramContext()
     gen = ctx.evaluate_condition(ArrayLiteral(values=[BooleanLiteral(value=True)]))
-    with pytest.raises(TypeError, match="Unsupported condition type"):
+    with pytest.raises(TypeError, match="Unsupported condition in branching statement"):
         next(gen)
 
 
@@ -711,3 +711,104 @@ def test_evaluate_expression_list():
     assert len(result) == 2
     assert result[0].value == 1
     assert result[1].value == 2
+
+
+def test_multi_bit_register_condition_raises():
+    """Using a multi-bit register as a bare condition should raise TypeError."""
+    qasm = """
+OPENQASM 3.0;
+qubit[3] q;
+bit[3] c;
+c[0] = measure q[0];
+c[1] = measure q[1];
+c[2] = measure q[2];
+if (c == 3) {
+    h q[0];
+}
+"""
+    with pytest.raises(TypeError, match="Multi-bit register.*cannot be used as a single-bit condition"):
+        to_qiskit(qasm)
+
+
+def test_nested_if_else():
+    """Nested if/else should produce an IfElseOp inside the outer IfElseOp's true body."""
+    qasm = """
+OPENQASM 3.0;
+qubit[3] q;
+bit[2] c;
+c[0] = measure q[0];
+c[1] = measure q[1];
+if (c[0] == 1) {
+    if (c[1] == 1) {
+        h q[2];
+    } else {
+        x q[2];
+    }
+}
+"""
+    qc = to_qiskit(qasm)
+    outer_ops = _get_if_else_ops(qc)
+    assert len(outer_ops) == 1
+
+    outer = outer_ops[0].operation
+    true_body, false_body = outer.params
+    assert false_body is None
+
+    # The outer true body should contain a nested IfElseOp
+    inner_ops = _get_if_else_ops(true_body)
+    assert len(inner_ops) == 1
+
+    inner = inner_ops[0].operation
+    inner_true, inner_false = inner.params
+    assert _get_ops_with_qubits(inner_true) == [("h", [2])]
+    assert _get_ops_with_qubits(inner_false) == [("x", [2])]
+
+
+def test_physical_qubit_inside_branch_expands_circuit():
+    """A physical qubit reference inside a branch should expand the main circuit."""
+    qasm = """
+OPENQASM 3.0;
+qubit[2] q;
+bit[1] c;
+c[0] = measure q[0];
+if (c[0] == 1) {
+    h $4;
+}
+"""
+    qc = to_qiskit(qasm)
+    assert qc.num_qubits == 5
+    op = _get_if_else_ops(qc)[0].operation
+    true_body = op.params[0]
+    assert _get_ops_with_qubits(true_body) == [("h", [4])]
+
+
+def test_mcm_while_loop_not_supported():
+    """A while loop conditioned on a measurement result is not yet supported."""
+    qasm = """
+OPENQASM 3.0;
+qubit[2] q;
+bit c;
+c = measure q[0];
+while (c == 0) {
+    x q[1];
+    c = measure q[0];
+}
+"""
+    with pytest.raises(ValueError):
+        to_qiskit(qasm)
+
+
+def test_classical_bit_declared_inside_branch_expands_circuit():
+    """A classical bit declared inside a branch should expand the main circuit."""
+    qasm = """
+OPENQASM 3.0;
+qubit[2] q;
+bit c;
+c = measure q[0];
+if (c == 1) {
+    bit d;
+    d = measure q[1];
+}
+"""
+    qc = to_qiskit(qasm)
+    assert qc.num_clbits == 2

--- a/tests/providers/test_adapter_branching.py
+++ b/tests/providers/test_adapter_branching.py
@@ -1,0 +1,630 @@
+"""Tests for branching statement (if/else) support in the Qiskit adapter."""
+
+import pytest
+from qiskit.circuit import Clbit, IfElseOp
+from qiskit.circuit.library import CXGate, HGate, Measure, XGate, YGate, ZGate
+from qiskit.transpiler import Target
+
+from qiskit_braket_provider import to_qiskit
+from qiskit_braket_provider.providers.adapter import _compile
+
+
+def _get_if_else_ops(circuit):
+    """Extract all IfElseOp instructions from a circuit."""
+    return [instr for instr in circuit.data if isinstance(instr.operation, IfElseOp)]
+
+
+def _get_gate_names(circuit):
+    """Get gate names from a circuit, excluding measurements."""
+    return [instr.operation.name for instr in circuit.data if instr.operation.name != "measure"]
+
+
+def _get_ops_with_qubits(circuit):
+    """Get (gate_name, qubit_indices) tuples for all non-measure ops in a circuit."""
+    return [
+        (instr.operation.name, [circuit.find_bit(q).index for q in instr.qubits])
+        for instr in circuit.data
+        if instr.operation.name != "measure"
+    ]
+
+
+@pytest.mark.parametrize(
+    "qasm, expected_true_ops, expected_false_ops",
+    [
+        pytest.param(
+            """
+OPENQASM 3.0;
+qubit[2] q;
+bit[1] c;
+c[0] = measure q[0];
+if (c[0] == 1) {
+    h q[1];
+} else {
+    x q[1];
+}
+""",
+            [("h", [1])],
+            [("x", [1])],
+            id="if_else_with_single_gates",
+        ),
+        pytest.param(
+            """
+OPENQASM 3.0;
+qubit[2] q;
+bit[1] c;
+c[0] = measure q[0];
+if (c[0] == 1) {
+    h q[1];
+    x q[0];
+} else {
+    y q[0];
+    z q[1];
+}
+""",
+            [("h", [1]), ("x", [0])],
+            [("y", [0]), ("z", [1])],
+            id="if_else_with_multiple_gates_different_qubits",
+        ),
+        pytest.param(
+            """
+OPENQASM 3.0;
+qubit[3] q;
+bit[1] c;
+c[0] = measure q[0];
+if (c[0] == 0) {
+    h q[1];
+    x q[2];
+} else {
+    y q[0];
+}
+""",
+            [("h", [1]), ("x", [2])],
+            [("y", [0])],
+            id="asymmetric_branches_different_qubits",
+        ),
+    ],
+)
+def test_if_else_branch_bodies(qasm, expected_true_ops, expected_false_ops):
+    qc = to_qiskit(qasm)
+    if_else_ops = _get_if_else_ops(qc)
+    assert len(if_else_ops) == 1
+
+    op = if_else_ops[0].operation
+    true_body, false_body = op.params
+
+    assert _get_ops_with_qubits(true_body) == expected_true_ops
+    assert _get_ops_with_qubits(false_body) == expected_false_ops
+
+
+def test_if_only_no_else():
+    qasm = """
+OPENQASM 3.0;
+qubit[2] q;
+bit[1] c;
+c[0] = measure q[0];
+if (c[0] == 1) {
+    h q[1];
+}
+"""
+    qc = to_qiskit(qasm)
+    if_else_ops = _get_if_else_ops(qc)
+    assert len(if_else_ops) == 1
+
+    op = if_else_ops[0].operation
+    true_body, false_body = op.params
+
+    assert _get_ops_with_qubits(true_body) == [("h", [1])]
+    assert false_body is None
+
+
+@pytest.mark.parametrize(
+    "condition_value, expected_value",
+    [
+        ("1", 1),
+        ("0", 0),
+    ],
+    ids=["condition_1", "condition_0"],
+)
+def test_condition_value(condition_value, expected_value):
+    qasm = f"""
+OPENQASM 3.0;
+qubit[2] q;
+bit[1] c;
+c[0] = measure q[0];
+if (c[0] == {condition_value}) {{
+    h q[1];
+}}
+"""
+    qc = to_qiskit(qasm)
+    op = _get_if_else_ops(qc)[0].operation
+    clbit, value = op.condition
+    assert isinstance(clbit, Clbit)
+    assert qc.clbits.index(clbit) == 0
+    assert value == expected_value
+
+
+def test_condition_references_correct_clbit():
+    """When multiple bit variables are declared, the condition should reference the right clbit."""
+    qasm = """
+OPENQASM 3.0;
+qubit[3] q;
+bit[2] a;
+bit[2] b;
+a[0] = measure q[0];
+b[1] = measure q[1];
+if (b[1] == 1) {
+    h q[2];
+}
+"""
+    qc = to_qiskit(qasm)
+    instr = _get_if_else_ops(qc)[0]
+    op = instr.operation
+    clbit, value = op.condition
+
+    # b starts at offset 2 (after a's 2 bits), b[1] is clbit index 3
+    assert qc.clbits.index(clbit) == 3
+    assert value == 1
+
+    # IfElseOp should span all qubits and clbits
+    assert [qc.find_bit(q).index for q in instr.qubits] == [0, 1, 2]
+    assert [qc.find_bit(c).index for c in instr.clbits] == [0, 1, 2, 3]
+
+    # Branch body gate targets correct qubit
+    true_body = op.params[0]
+    assert _get_ops_with_qubits(true_body) == [("h", [2])]
+
+
+def test_if_else_circuit_dimensions():
+    """Branch body circuits should have the same qubit/clbit counts as the main circuit."""
+    qasm = """
+OPENQASM 3.0;
+qubit[3] q;
+bit[2] c;
+c[0] = measure q[0];
+if (c[0] == 1) {
+    h q[1];
+} else {
+    x q[2];
+}
+"""
+    qc = to_qiskit(qasm)
+    instr = _get_if_else_ops(qc)[0]
+    op = instr.operation
+    true_body, false_body = op.params
+
+    assert true_body.num_qubits == qc.num_qubits
+    assert true_body.num_clbits == qc.num_clbits
+    assert false_body.num_qubits == qc.num_qubits
+    assert false_body.num_clbits == qc.num_clbits
+
+    assert _get_ops_with_qubits(true_body) == [("h", [1])]
+    assert _get_ops_with_qubits(false_body) == [("x", [2])]
+
+    # IfElseOp spans all qubits/clbits on the main circuit
+    assert [qc.find_bit(q).index for q in instr.qubits] == [0, 1, 2]
+    assert [qc.find_bit(c).index for c in instr.clbits] == [0, 1]
+
+
+def test_gates_before_and_after_branch():
+    """Gates outside the branch should appear on the main circuit, not inside the branch."""
+    qasm = """
+OPENQASM 3.0;
+qubit[2] q;
+bit[1] c;
+x q[0];
+c[0] = measure q[0];
+if (c[0] == 1) {
+    h q[1];
+}
+y q[1];
+"""
+    qc = to_qiskit(qasm)
+
+    main_ops = [(instr.operation.name, [qc.find_bit(q).index for q in instr.qubits]) for instr in qc.data]
+    assert main_ops[0] == ("x", [0])
+    assert main_ops[1] == ("measure", [0])
+    assert main_ops[2][0] == "if_else"
+    assert main_ops[2][1] == [0, 1]
+    assert main_ops[3] == ("y", [1])
+
+
+def test_multiple_branches():
+    """Multiple sequential if/else blocks should each produce their own IfElseOp."""
+    qasm = """
+OPENQASM 3.0;
+qubit[2] q;
+bit[2] c;
+c[0] = measure q[0];
+if (c[0] == 1) {
+    h q[1];
+}
+c[1] = measure q[1];
+if (c[1] == 1) {
+    x q[0];
+}
+"""
+    qc = to_qiskit(qasm)
+    if_else_ops = _get_if_else_ops(qc)
+    assert len(if_else_ops) == 2
+
+    # First branch: condition on c[0], h on q[1]
+    op0 = if_else_ops[0].operation
+    assert qc.clbits.index(op0.condition[0]) == 0
+    assert _get_ops_with_qubits(op0.params[0]) == [("h", [1])]
+
+    # Second branch: condition on c[1], x on q[0]
+    op1 = if_else_ops[1].operation
+    assert qc.clbits.index(op1.condition[0]) == 1
+    assert _get_ops_with_qubits(op1.params[0]) == [("x", [0])]
+
+
+def test_for_loop_before_measurement_works():
+    """For loops that appear before any measurement should work normally."""
+    qasm = """
+OPENQASM 3.0;
+qubit[2] q;
+bit[1] c;
+for int[8] i in [0:1] {
+    h q[0];
+}
+c[0] = measure q[0];
+"""
+    qc = to_qiskit(qasm)
+    main_ops = [(instr.operation.name, [qc.find_bit(q).index for q in instr.qubits]) for instr in qc.data]
+    assert main_ops[0] == ("h", [0])
+    assert main_ops[1] == ("h", [0])
+    assert main_ops[2] == ("measure", [0])
+
+
+def test_for_loop_after_unrelated_measurement_works():
+    """A for loop after a measurement on a different qubit should work."""
+    qasm = """
+OPENQASM 3.0;
+qubit[2] q;
+bit[1] c;
+c[0] = measure q[0];
+for int[8] i in [0:1] {
+    h q[1];
+}
+"""
+    qc = to_qiskit(qasm)
+    main_ops = [(instr.operation.name, [qc.find_bit(q).index for q in instr.qubits]) for instr in qc.data]
+    assert main_ops[0] == ("measure", [0])
+    assert main_ops[1] == ("h", [1])
+    assert main_ops[2] == ("h", [1])
+
+
+def test_mcm_branch_inside_for_loop():
+    """An MCM branching statement inside a for loop should produce IfElseOps."""
+    qasm = """
+OPENQASM 3.0;
+qubit[2] q;
+bit[1] c;
+c[0] = measure q[0];
+for int[8] i in [0:1] {
+    if (c[0] == 1) {
+        h q[1];
+    } else {
+        x q[1];
+    }
+}
+"""
+    qc = to_qiskit(qasm)
+    if_else_ops = _get_if_else_ops(qc)
+    assert len(if_else_ops) == 2
+
+    for op_instr in if_else_ops:
+        true_body, false_body = op_instr.operation.params
+        assert _get_ops_with_qubits(true_body) == [("h", [1])]
+        assert _get_ops_with_qubits(false_body) == [("x", [1])]
+        assert qc.clbits.index(op_instr.operation.condition[0]) == 0
+
+
+@pytest.fixture
+def mcm_target():
+    t = Target(num_qubits=3)
+    t.add_instruction(HGate())
+    t.add_instruction(XGate())
+    t.add_instruction(YGate())
+    t.add_instruction(ZGate())
+    t.add_instruction(CXGate())
+    t.add_instruction(Measure())
+    t.add_instruction(IfElseOp, name="if_else")
+    return t
+
+
+@pytest.mark.parametrize(
+    "qasm, expected_if_else_count",
+    [
+        pytest.param(
+            """
+OPENQASM 3.0;
+qubit[2] q;
+bit[1] c;
+c[0] = measure q[0];
+if (c[0] == 1) {
+    h q[1];
+} else {
+    x q[1];
+}
+""",
+            1,
+            id="single_if_else",
+        ),
+        pytest.param(
+            """
+OPENQASM 3.0;
+qubit[2] q;
+bit[2] c;
+c[0] = measure q[0];
+if (c[0] == 1) {
+    h q[1];
+}
+c[1] = measure q[1];
+if (c[1] == 1) {
+    x q[0];
+}
+""",
+            2,
+            id="multiple_if_else",
+        ),
+        pytest.param(
+            """
+OPENQASM 3.0;
+qubit[2] q;
+bit[1] c;
+c[0] = measure q[0];
+if (c[0] == 1) {
+    h q[1];
+}
+""",
+            1,
+            id="if_only_no_else",
+        ),
+    ],
+)
+def test_compile_preserves_if_else_ops(qasm, expected_if_else_count, mcm_target):
+    """IfElseOps should survive compilation through _compile."""
+    result = _compile(qasm, target=mcm_target)
+    compiled_circuit = result.circuits[0]
+    if_else_ops = [instr for instr in compiled_circuit.data if isinstance(instr.operation, IfElseOp)]
+    assert len(if_else_ops) == expected_if_else_count
+
+
+def test_compile_if_else_branch_bodies_intact(mcm_target):
+    """Branch body gate content and qubit targets should be preserved after compilation."""
+    qasm = """
+OPENQASM 3.0;
+qubit[2] q;
+bit[1] c;
+c[0] = measure q[0];
+if (c[0] == 1) {
+    h q[1];
+} else {
+    x q[1];
+}
+"""
+    result = _compile(qasm, target=mcm_target)
+    compiled_circuit = result.circuits[0]
+    op = next(instr for instr in compiled_circuit.data if isinstance(instr.operation, IfElseOp)).operation
+    true_body, false_body = op.params
+
+    assert _get_ops_with_qubits(true_body) == [("h", [1])]
+    assert _get_ops_with_qubits(false_body) == [("x", [1])]
+
+
+def test_compile_if_else_condition_preserved(mcm_target):
+    """The condition clbit and value should be preserved after compilation."""
+    qasm = """
+OPENQASM 3.0;
+qubit[2] q;
+bit[1] c;
+c[0] = measure q[0];
+if (c[0] == 1) {
+    h q[1];
+}
+"""
+    result = _compile(qasm, target=mcm_target)
+    compiled_circuit = result.circuits[0]
+    instr = next(i for i in compiled_circuit.data if isinstance(i.operation, IfElseOp))
+    op = instr.operation
+    clbit, value = op.condition
+    assert isinstance(clbit, Clbit)
+    assert compiled_circuit.clbits.index(clbit) == 0
+    assert value == 1
+
+    # Verify the IfElseOp spans the right qubits on the compiled circuit
+    qubit_indices = [compiled_circuit.find_bit(q).index for q in instr.qubits]
+    assert 0 in qubit_indices
+    assert 1 in qubit_indices
+
+
+# --- Coverage: static branching ---
+
+
+def test_static_true_condition_takes_if_branch():
+    """A static true condition should execute only the if block."""
+    qasm = """
+OPENQASM 3.0;
+qubit[1] q;
+bit[1] c;
+if (1 == 1) {
+    h q[0];
+} else {
+    x q[0];
+}
+c[0] = measure q[0];
+"""
+    qc = to_qiskit(qasm)
+    ops = _get_ops_with_qubits(qc)
+    assert ("h", [0]) in ops
+    assert ("x", [0]) not in ops
+
+
+def test_static_false_condition_takes_else_branch():
+    """A static false condition should execute only the else block."""
+    qasm = """
+OPENQASM 3.0;
+qubit[1] q;
+bit[1] c;
+if (0 == 1) {
+    h q[0];
+} else {
+    x q[0];
+}
+c[0] = measure q[0];
+"""
+    qc = to_qiskit(qasm)
+    ops = _get_ops_with_qubits(qc)
+    assert ("x", [0]) in ops
+    assert ("h", [0]) not in ops
+
+
+# --- Coverage: while loop ---
+
+
+def test_while_loop_before_measurement():
+    """A while loop with a static condition should execute normally."""
+    qasm = """
+OPENQASM 3.0;
+qubit[1] q;
+bit[1] c;
+int[8] i = 0;
+while (i < 2) {
+    h q[0];
+    i += 1;
+}
+c[0] = measure q[0];
+"""
+    qc = to_qiskit(qasm)
+    h_count = sum(1 for name, _ in _get_ops_with_qubits(qc) if name == "h")
+    assert h_count == 2
+
+
+# --- Coverage: for loop with break/continue and DiscreteSet ---
+
+
+def test_for_loop_with_break():
+    qasm = """
+OPENQASM 3.0;
+qubit[1] q;
+bit[1] c;
+for int[8] i in {0, 1, 2} {
+    h q[0];
+    break;
+}
+c[0] = measure q[0];
+"""
+    qc = to_qiskit(qasm)
+    h_count = sum(1 for name, _ in _get_ops_with_qubits(qc) if name == "h")
+    assert h_count == 1
+
+
+def test_for_loop_with_continue():
+    qasm = """
+OPENQASM 3.0;
+qubit[1] q;
+bit[1] c;
+for int[8] i in {0, 1} {
+    continue;
+    h q[0];
+}
+c[0] = measure q[0];
+"""
+    qc = to_qiskit(qasm)
+    h_count = sum(1 for name, _ in _get_ops_with_qubits(qc) if name == "h")
+    assert h_count == 0
+
+
+# --- Coverage: _resolve_condition with literal on LHS ---
+
+
+def test_condition_literal_on_lhs():
+    """Condition with literal on the left side: if (1 == c[0])."""
+    qasm = """
+OPENQASM 3.0;
+qubit[2] q;
+bit[1] c;
+c[0] = measure q[0];
+if (1 == c[0]) {
+    h q[1];
+}
+"""
+    qc = to_qiskit(qasm)
+    op = _get_if_else_ops(qc)[0].operation
+    clbit, value = op.condition
+    assert qc.clbits.index(clbit) == 0
+    assert value == 1
+
+
+# --- Coverage: _resolve_clbit_index for bare Identifier ---
+
+
+def test_condition_bare_identifier():
+    """Condition on a single-bit variable without indexing: if (c == 1)."""
+    qasm = """
+OPENQASM 3.0;
+qubit[2] q;
+bit c;
+c = measure q[0];
+if (c == 1) {
+    h q[1];
+}
+"""
+    qc = to_qiskit(qasm)
+    op = _get_if_else_ops(qc)[0].operation
+    clbit, value = op.condition
+    assert qc.clbits.index(clbit) == 0
+    assert value == 1
+    assert _get_ops_with_qubits(op.params[0]) == [("h", [1])]
+
+
+# --- Coverage: while loop break/continue ---
+
+
+def test_while_loop_with_break():
+    qasm = """
+OPENQASM 3.0;
+qubit[1] q;
+bit[1] c;
+int[8] i = 0;
+while (i < 5) {
+    h q[0];
+    i += 1;
+    break;
+}
+c[0] = measure q[0];
+"""
+    qc = to_qiskit(qasm)
+    h_count = sum(1 for name, _ in _get_ops_with_qubits(qc) if name == "h")
+    assert h_count == 1
+
+
+def test_while_loop_with_continue():
+    qasm = """
+OPENQASM 3.0;
+qubit[1] q;
+bit[1] c;
+int[8] i = 0;
+while (i < 2) {
+    i += 1;
+    continue;
+    h q[0];
+}
+c[0] = measure q[0];
+"""
+    qc = to_qiskit(qasm)
+    h_count = sum(1 for name, _ in _get_ops_with_qubits(qc) if name == "h")
+    assert h_count == 0
+
+
+# --- Coverage: _resolve_clbit_index unsupported type ---
+
+
+def test_resolve_clbit_index_unsupported_type():
+    from braket.default_simulator.openqasm.parser.openqasm_ast import IntegerLiteral
+    from qiskit_braket_provider.providers.adapter import _QiskitProgramContext
+
+    ctx = _QiskitProgramContext()
+    with pytest.raises(TypeError, match="Unsupported condition operand type"):
+        ctx._resolve_clbit_index(IntegerLiteral(value=0))

--- a/tests/providers/test_adapter_branching.py
+++ b/tests/providers/test_adapter_branching.py
@@ -5,7 +5,16 @@ from qiskit.circuit import Clbit, IfElseOp
 from qiskit.circuit.library import CXGate, HGate, Measure, XGate, YGate, ZGate
 from qiskit.transpiler import Target
 
-from braket.default_simulator.openqasm.parser.openqasm_ast import IntegerLiteral
+from braket.default_simulator.openqasm.parser.openqasm_ast import (
+    ArrayLiteral,
+    BooleanLiteral,
+    BoolType,
+    Cast,
+    FunctionCall,
+    IntegerLiteral,
+    UnaryExpression,
+    UnaryOperator,
+)
 from qiskit_braket_provider import to_qiskit
 from qiskit_braket_provider.providers.adapter import _compile, _QiskitProgramContext
 
@@ -664,3 +673,32 @@ if (c[0] != 1) {
 """
     with pytest.raises(TypeError, match="Unsupported operator.*Only '==' is supported"):
         to_qiskit(qasm)
+
+
+def test_unsupported_condition_type():
+    """A condition type that is not Identifier, IndexExpression, or BinaryExpression should raise."""
+    ctx = _QiskitProgramContext()
+    gen = ctx.evaluate_condition(ArrayLiteral(values=[BooleanLiteral(value=True)]))
+    with pytest.raises(TypeError, match="Unsupported condition type"):
+        next(gen)
+
+
+def test_evaluate_expression_unary():
+    """UnaryExpression should be handled by _evaluate_expression."""
+    ctx = _QiskitProgramContext()
+    result = ctx._evaluate_expression(UnaryExpression(op=UnaryOperator["!"], expression=BooleanLiteral(value=True)))
+    assert result.value is False
+
+
+def test_evaluate_expression_cast():
+    """Cast should be handled by _evaluate_expression."""
+    ctx = _QiskitProgramContext()
+    result = ctx._evaluate_expression(Cast(type=BoolType(), argument=IntegerLiteral(value=1)))
+    assert result.value is True
+
+
+def test_evaluate_expression_unsupported_type():
+    """An unsupported expression type should raise TypeError."""
+    ctx = _QiskitProgramContext()
+    with pytest.raises(TypeError, match="Cannot evaluate expression of type"):
+        ctx._evaluate_expression(FunctionCall(name=None, arguments=[]))

--- a/tests/providers/test_adapter_branching.py
+++ b/tests/providers/test_adapter_branching.py
@@ -608,3 +608,67 @@ def test_resolve_clbit_index_unsupported_type():
     ctx = _QiskitProgramContext()
     with pytest.raises(TypeError, match="Unsupported condition operand type"):
         ctx._resolve_clbit_index(IntegerLiteral(value=0))
+
+
+def test_bare_indexed_identifier_condition():
+    """Condition `if (c[0])` should be treated as `if (c[0] == 1)`."""
+    qasm = """
+OPENQASM 3.0;
+qubit[2] q;
+bit[1] c;
+c[0] = measure q[0];
+if (c[0]) {
+    h q[1];
+} else {
+    x q[1];
+}
+"""
+    qc = to_qiskit(qasm)
+    if_else_ops = _get_if_else_ops(qc)
+    assert len(if_else_ops) == 1
+
+    op = if_else_ops[0].operation
+    clbit, value = op.condition
+    assert qc.clbits.index(clbit) == 0
+    assert value == 1
+
+    true_body, false_body = op.params
+    assert _get_ops_with_qubits(true_body) == [("h", [1])]
+    assert _get_ops_with_qubits(false_body) == [("x", [1])]
+
+
+def test_bare_identifier_condition_mcm():
+    """Condition `if (c)` on a single-bit variable should be treated as `if (c == 1)`."""
+    qasm = """
+OPENQASM 3.0;
+qubit[2] q;
+bit c;
+c = measure q[0];
+if (c) {
+    h q[1];
+}
+"""
+    qc = to_qiskit(qasm)
+    if_else_ops = _get_if_else_ops(qc)
+    assert len(if_else_ops) == 1
+
+    op = if_else_ops[0].operation
+    clbit, value = op.condition
+    assert qc.clbits.index(clbit) == 0
+    assert value == 1
+    assert _get_ops_with_qubits(op.params[0]) == [("h", [1])]
+
+
+def test_unsupported_operator_in_condition():
+    """Operators other than == should raise TypeError."""
+    qasm = """
+OPENQASM 3.0;
+qubit[2] q;
+bit[1] c;
+c[0] = measure q[0];
+if (c[0] != 1) {
+    h q[1];
+}
+"""
+    with pytest.raises(TypeError, match="Unsupported operator.*Only '==' is supported"):
+        to_qiskit(qasm)

--- a/tests/providers/test_adapter_branching.py
+++ b/tests/providers/test_adapter_branching.py
@@ -439,8 +439,6 @@ if (c[0] == 1) {
     assert 1 in qubit_indices
 
 
-# --- Coverage: static branching ---
-
 
 def test_static_true_condition_takes_if_branch():
     """A static true condition should execute only the if block."""
@@ -480,9 +478,6 @@ c[0] = measure q[0];
     assert ("h", [0]) not in ops
 
 
-# --- Coverage: while loop ---
-
-
 def test_while_loop_before_measurement():
     """A while loop with a static condition should execute normally."""
     qasm = """
@@ -499,9 +494,6 @@ c[0] = measure q[0];
     qc = to_qiskit(qasm)
     h_count = sum(1 for name, _ in _get_ops_with_qubits(qc) if name == "h")
     assert h_count == 2
-
-
-# --- Coverage: for loop with break/continue and DiscreteSet ---
 
 
 def test_for_loop_with_break():
@@ -536,9 +528,6 @@ c[0] = measure q[0];
     assert h_count == 0
 
 
-# --- Coverage: _resolve_condition with literal on LHS ---
-
-
 def test_condition_literal_on_lhs():
     """Condition with literal on the left side: if (1 == c[0])."""
     qasm = """
@@ -555,9 +544,6 @@ if (1 == c[0]) {
     clbit, value = op.condition
     assert qc.clbits.index(clbit) == 0
     assert value == 1
-
-
-# --- Coverage: _resolve_clbit_index for bare Identifier ---
 
 
 def test_condition_bare_identifier():
@@ -577,9 +563,6 @@ if (c == 1) {
     assert qc.clbits.index(clbit) == 0
     assert value == 1
     assert _get_ops_with_qubits(op.params[0]) == [("h", [1])]
-
-
-# --- Coverage: while loop break/continue ---
 
 
 def test_while_loop_with_break():
@@ -616,9 +599,6 @@ c[0] = measure q[0];
     qc = to_qiskit(qasm)
     h_count = sum(1 for name, _ in _get_ops_with_qubits(qc) if name == "h")
     assert h_count == 0
-
-
-# --- Coverage: _resolve_clbit_index unsupported type ---
 
 
 def test_resolve_clbit_index_unsupported_type():

--- a/tests/providers/test_adapter_branching.py
+++ b/tests/providers/test_adapter_branching.py
@@ -702,3 +702,12 @@ def test_evaluate_expression_unsupported_type():
     ctx = _QiskitProgramContext()
     with pytest.raises(TypeError, match="Cannot evaluate expression of type"):
         ctx._evaluate_expression(FunctionCall(name=None, arguments=[]))
+
+
+def test_evaluate_expression_list():
+    """A list input should evaluate each element."""
+    ctx = _QiskitProgramContext()
+    result = ctx._evaluate_expression([IntegerLiteral(value=1), IntegerLiteral(value=2)])
+    assert len(result) == 2
+    assert result[0].value == 1
+    assert result[1].value == 2

--- a/tests/providers/test_adapter_to_qiskit_verbatim.py
+++ b/tests/providers/test_adapter_to_qiskit_verbatim.py
@@ -5,6 +5,7 @@ from qiskit.circuit import BoxOp
 
 from braket.circuits import Circuit
 from braket.default_simulator.openqasm.interpreter import VerbatimBoxDelimiter
+from braket.default_simulator.openqasm.parser.openqasm_ast import BitType, Identifier
 from braket.ir.openqasm import Program
 from qiskit_braket_provider import to_qiskit
 from qiskit_braket_provider.providers.adapter import _QiskitProgramContext
@@ -332,8 +333,6 @@ box {
 
 
 def test_bit_declaration_with_identifier_size_in_verbatim():
-    from braket.default_simulator.openqasm.parser.openqasm_ast import BitType, Identifier
-
     ctx = _QiskitProgramContext()
     ctx.declare_variable("c", BitType(size=Identifier(name="n")))
-    assert ctx._circuit.num_clbits == 0
+    assert ctx.circuit.num_clbits == 0


### PR DESCRIPTION
## Refactor branching to use generator-based interface from `AbstractProgramContext`

### Summary

Replaces the old visitor-based `handle_branching_statement/handle_for_loop/handle_while_loop` methods with the new generator-based `evaluate_condition/
evaluate_for_range/evaluate_while_condition` interface from `AbstractProgramContext` in `amazon-braket-default-simulator-python`.

### What changed

`_QiskitProgramContext` in `adapter.py`:
- Uses a circuit stack (`_circuit_stack`) instead of mutating `self._circuit`. The root circuit is `_circuit_stack[0]`, and `_active_circuit` always points  to the top of the stack. All instruction-adding methods (`add_gate_instruction`, `add_measure`, `add_qubits`, etc.) operate on `_active_circuit`.
- `evaluate_condition` pushes sub-circuits onto the stack for `if/else` blocks, yields control back to the interpreter, then pops them off and constructs an `IfElseOp`.
- `evaluate_for_range` and `evaluate_while_condition` use a lightweight `_evaluate_expression` to evaluate loop ranges and conditions.
- Supports bare identifier conditions (if `(c)`, if `(c[0])`) treated as `== 1`.
- Validates that MCM conditions use `==` operator; raises `TypeError` for unsupported operators.
- Static conditions (e.g., if `(1 == 1)`) are evaluated directly without creating an `IfElseOp`.

Tests:
- New `test_adapter_branching.py` with 31 tests covering: `if/else` bodies, `if-only`, condition values, `clbit` resolution, circuit dimensions, gates  before/after branches, multiple branches, for/while loops with break/continue, static conditions, bare identifiers, unsupported operators, and compilation preservation.

Note:
- Loops are out of scope for this PR. The implementation here is just to ensure non-MCM loops are handled.

### Dependencies

- Companion PR in `amazon-braket-default-simulator-python`: [feature/pre-evaluate-branching-condition](https://github.com/amazon-braket/amazon-braket-
default-simulator-python/pull/new/feature/pre-evaluate-branching-condition) — adds interpreter pre-evaluation of complex conditions (e.g., 
FunctionCall, SizeOf) before delegating to the context. Without this change, `test_roundtrip_openqasm_program` is skipped.