### PR TITLE
Switch default test runner from unittest to pytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps = -rrequirements.txt
        -rrequirements-dev.txt
 commands =
   pip check
-  python -m unittest -v
+  python -m pytest -v
 
 [testenv:linters]
 basepython = python3


### PR DESCRIPTION
## Summary

Replaces python -m unittest with python -m pytest in the default tox environment.

## Motivation

The test suite mixes unittest.TestCase and pytest-style tests. pytest runs both, while unittest only runs its own. This caused inconsistent results where one runner could pass while the other failed. The coverage environment already used pytest, so this aligns all environments on a single runner.