### PR TITLE
Enforce ruff format in CI

### DIFF
--- a/docs/tutorials/3_tutorial_minimum_eigen_optimizer.ipynb
+++ b/docs/tutorials/3_tutorial_minimum_eigen_optimizer.ipynb
@@ -102,7 +102,6 @@
     }
    ],
    "source": [
-    "\n",
     "import numpy as np\n",
     "from qiskit.visualization import plot_histogram\n",
     "from qiskit_optimization import QuadraticProgram\n",

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -336,18 +336,19 @@ class _SubstituteGates(TransformationPass):
 
 class _QiskitProgramContext(AbstractProgramContext):
     """Program context for converting OpenQASM 3 programs to Qiskit circuits.
-    
+
     This context extends AbstractProgramContext to build Qiskit QuantumCircuits from
     OpenQASM 3 programs. It supports Braket verbatim pragmas, which are converted to
     Qiskit BoxOp operations to preserve gate sequences that should not be optimized.
-    
+
     Verbatim boxes are represented using Qiskit's native BoxOp construct, which treats
     a block of operations atomically. All verbatim boxes in a circuit use the same
     configurable label name.
     """
+
     def __init__(self, verbatim_box_name: str = _BRAKET_VERBATIM_BOX_NAME):
         """Initialize the Qiskit program context.
-        
+
         Args:
             verbatim_box_name: Name to use for BoxOp labels when converting verbatim boxes.
                 Default: "verbatim"
@@ -387,16 +388,16 @@ class _QiskitProgramContext(AbstractProgramContext):
         const: bool = False,
     ) -> None:
         """Override to add classical bits to the Qiskit circuit when declared.
-        
+
         When a classical bit array is declared (e.g., bit[2] c;), we need to add
         the corresponding classical bits to the Qiskit circuit.
-        
+
         Note: This only adds classical bits when the size is known at declaration time.
         For function parameters with variable sizes (e.g., bit[n] where n is a parameter),
         the classical bits are not added since the size is not yet determined.
         """
         super().declare_variable(name, symbol_type, value, const)
-        
+
         # If this is a bit type declaration, add classical bits to the circuit
         if isinstance(symbol_type, BitType):
             if symbol_type.size is not None:
@@ -408,7 +409,7 @@ class _QiskitProgramContext(AbstractProgramContext):
                     return
             else:
                 size = 1
-            
+
             # this is used to deal with Qiskit's QuantumCircuit storing all classical bits in a flat list
             self._clbit_offset[name] = self._active_circuit.num_clbits
             self._active_circuit.add_bits([Clbit() for _ in range(size)])
@@ -463,7 +464,11 @@ class _QiskitProgramContext(AbstractProgramContext):
         classical_destination: Identifier | IndexedIdentifier | None = None,
     ) -> None:
         if classical_destination is not None:
-            name = classical_destination.name if isinstance(classical_destination, IndexedIdentifier) else classical_destination
+            name = (
+                classical_destination.name
+                if isinstance(classical_destination, IndexedIdentifier)
+                else classical_destination
+            )
             self._measured_bits.add(name.name)
         active = self._active_circuit
         # this is to cover the edge case where a user measures a qubit without assigning it to a classical register
@@ -513,7 +518,7 @@ class _QiskitProgramContext(AbstractProgramContext):
 
             self._in_verbatim_box = False
             self._verbatim_circuit = None
-        
+
         else:
             raise ValueError("Verbatim box created using invalid marker")
 
@@ -547,9 +552,7 @@ class _QiskitProgramContext(AbstractProgramContext):
             try:
                 result = cast_to(BooleanLiteral, self._evaluate_expression(condition))
             except (TypeError, ValueError, AttributeError) as e:
-                raise TypeError(
-                    "Unsupported condition in branching statement"
-                ) from e
+                raise TypeError("Unsupported condition in branching statement") from e
             yield result.value
             return
 
@@ -613,7 +616,13 @@ class _QiskitProgramContext(AbstractProgramContext):
     def _evaluate_expression(self, expression):
         """Lightweight expression evaluator for loop conditions and ranges."""
         match expression:
-            case BooleanLiteral() | IntegerLiteral() | FloatLiteral() | ArrayLiteral() | SymbolLiteral():
+            case (
+                BooleanLiteral()
+                | IntegerLiteral()
+                | FloatLiteral()
+                | ArrayLiteral()
+                | SymbolLiteral()
+            ):
                 return expression
             case Identifier():
                 return self.get_value_by_identifier(expression)
@@ -640,9 +649,7 @@ class _QiskitProgramContext(AbstractProgramContext):
             case _:
                 raise TypeError(f"Cannot evaluate expression of type {type(expression).__name__}")
 
-    def _resolve_condition(
-        self, condition: BinaryExpression
-    ) -> tuple[Clbit, int]:
+    def _resolve_condition(self, condition: BinaryExpression) -> tuple[Clbit, int]:
         """Convert an OpenQASM condition AST node to a Qiskit (Clbit, int) condition."""
         if isinstance(condition.lhs, (Identifier, IndexExpression)):
             clbit_index = self._resolve_clbit_index(condition.lhs)
@@ -1142,7 +1149,9 @@ def _restore_verbatim_boxes(
         ValueError: If barrier count doesn't match verbatim box count
         ValueError: If qubit mapping fails
     """
-    reconstructed_circuit = QuantumCircuit(transpiled_circuit.num_qubits, transpiled_circuit.num_clbits)
+    reconstructed_circuit = QuantumCircuit(
+        transpiled_circuit.num_qubits, transpiled_circuit.num_clbits
+    )
     reconstructed_circuit.global_phase = transpiled_circuit.global_phase
 
     verbatim_box_iter = iter(verbatim_boxes)
@@ -1151,7 +1160,10 @@ def _restore_verbatim_boxes(
     for instruction in transpiled_circuit.data:
         operation = instruction.operation
 
-        if isinstance(operation, Barrier) and getattr(operation, "label", None) == verbatim_box_name:
+        if (
+            isinstance(operation, Barrier)
+            and getattr(operation, "label", None) == verbatim_box_name
+        ):
             barrier_count += 1
 
             try:
@@ -1251,16 +1263,18 @@ def _compile(
                 # Check if any circuits have verbatim boxes and extract them before transpilation
                 elif isinstance(instr.operation, BoxOp):
                     has_verbatim_boxes = True
-    
+
     if has_barriers_named_verbatim:
-        raise ValueError("Cannot have a Barrier labeled with the same label used for verbatim boxes")
-    
+        raise ValueError(
+            "Cannot have a Barrier labeled with the same label used for verbatim boxes"
+        )
+
     if pass_manager and has_verbatim_boxes:
         raise ValueError(
             "Custom pass_manager is not supported with verbatim boxes. "
             "Verbatim boxes require controlled transpilation to preserve gate ordering."
         )
-    
+
     all_verbatim_boxes = []
     if has_verbatim_boxes:
         extracted_circuits = []
@@ -1288,16 +1302,19 @@ def _compile(
         circuits = pass_manager.run(circuits, callback=callback, num_processes=num_processes)
     elif not verbatim:
         target = target if basis_gates or target else _default_target(circuits)
-        
+
         if has_verbatim_boxes:
-            warnings.warn("Overriding layout method to 'trivial' "
-            "and routing method to 'none' as the circuit has verbatim blocks", stacklevel=1)
-            effective_layout_method = 'trivial'
-            effective_routing_method = 'none'
+            warnings.warn(
+                "Overriding layout method to 'trivial' "
+                "and routing method to 'none' as the circuit has verbatim blocks",
+                stacklevel=1,
+            )
+            effective_layout_method = "trivial"
+            effective_routing_method = "none"
         else:
             effective_layout_method = layout_method
             effective_routing_method = routing_method
-        
+
         if (
             target
             or coupling_map
@@ -1325,7 +1342,9 @@ def _compile(
 
     if has_verbatim_boxes:
         circuits = [
-            _restore_verbatim_boxes(circ, verbatim_boxes, verbatim_box_name) if len(verbatim_boxes) > 0 else circ
+            _restore_verbatim_boxes(circ, verbatim_boxes, verbatim_box_name)
+            if len(verbatim_boxes) > 0
+            else circ
             for circ, verbatim_boxes in zip(circuits, all_verbatim_boxes)
         ]
 
@@ -1424,7 +1443,7 @@ def to_braket(
         routing_method (str | None): The routing method to use during transpilation. If ``None``
             and the circuit contains verbatim boxes, defaults to ``'none'`` to disable routing
             and preserve physical qubit structure. Otherwise uses Qiskit's default. Default: ``None``.
-        seed_transpiler (int | None): This specifies a seed used for the stochastic parts 
+        seed_transpiler (int | None): This specifies a seed used for the stochastic parts
             of the transpiler. Default: ``None``.
 
     Raises:
@@ -1436,20 +1455,36 @@ def to_braket(
         Circuit | list[Circuit]: Braket circuit or circuits
     """
     result = _compile(
-        circuits, *args,
-        qubit_labels=qubit_labels, target=target, verbatim=verbatim,
-        basis_gates=basis_gates, coupling_map=coupling_map,
-        angle_restrictions=angle_restrictions, optimization_level=optimization_level,
-        callback=callback, num_processes=num_processes, pass_manager=pass_manager,
-        braket_device=braket_device, add_measurements=add_measurements,
-        circuit=circuit, connectivity=connectivity, verbatim_box_name=verbatim_box_name,
-        layout_method=layout_method, routing_method=routing_method,
+        circuits,
+        *args,
+        qubit_labels=qubit_labels,
+        target=target,
+        verbatim=verbatim,
+        basis_gates=basis_gates,
+        coupling_map=coupling_map,
+        angle_restrictions=angle_restrictions,
+        optimization_level=optimization_level,
+        callback=callback,
+        num_processes=num_processes,
+        pass_manager=pass_manager,
+        braket_device=braket_device,
+        add_measurements=add_measurements,
+        circuit=circuit,
+        connectivity=connectivity,
+        verbatim_box_name=verbatim_box_name,
+        layout_method=layout_method,
+        routing_method=routing_method,
         seed_transpiler=seed_transpiler,
     )
     translated = [
         _translate_to_braket(
-            circ, result.target, result.qubit_labels, result.verbatim,
-            result.basis_gates, result.angle_restrictions, result.pass_manager,
+            circ,
+            result.target,
+            result.qubit_labels,
+            result.verbatim,
+            result.basis_gates,
+            result.angle_restrictions,
+            result.pass_manager,
         )
         for circ in result.circuits
     ]
@@ -1788,10 +1823,10 @@ def to_qiskit(
 
     Returns:
         QuantumCircuit: Qiskit quantum circuit
-    
+
     Examples:
         Convert an OpenQASM 3 program with a verbatim box:
-        
+
         >>> openqasm_program = '''
         ... OPENQASM 3.0;
         ... #pragma braket verbatim
@@ -1806,9 +1841,9 @@ def to_qiskit(
         >>> for instruction in qiskit_circuit.data:
         ...     if hasattr(instruction.operation, 'label') and instruction.operation.label == 'verbatim':
         ...         print(f"Found verbatim box: {instruction.operation}")
-        
+
         Use a custom name for verbatim boxes:
-        
+
         >>> qiskit_circuit = to_qiskit(openqasm_program, verbatim_box_name="my_verbatim")
         >>> # All verbatim boxes will have the label "my_verbatim"
     """

--- a/tests/providers/mocks.py
+++ b/tests/providers/mocks.py
@@ -319,37 +319,39 @@ MOCK_PROGRAM_RESULT = {
 MOCK_PROGRAM_SET_RESULT = ProgramSetQuantumTaskResult.from_object(
     ProgramSetTaskResult(
         braketSchemaHeader={
-                "name": "braket.task_result.program_set_task_result",
+            "name": "braket.task_result.program_set_task_result",
+            "version": "1",
+        },
+        programResults=[MOCK_PROGRAM_RESULT] * 2,
+        taskMetadata={
+            "braketSchemaHeader": {
+                "name": "braket.task_result.program_set_task_metadata",
                 "version": "1",
-            }, programResults=[MOCK_PROGRAM_RESULT] * 2, taskMetadata={
+            },
+            "id": "TaskID",
+            "deviceId": "arn:aws:braket:::device/quantum-simulator/amazon/sv1",
+            "requestedShots": 120,
+            "successfulShots": 100,
+            "programMetadata": [{"executables": [{}]}],
+            "deviceParameters": {
                 "braketSchemaHeader": {
-                    "name": "braket.task_result.program_set_task_metadata",
+                    "name": "braket.device_schema.simulators.gate_model_simulator_device_parameters",
                     "version": "1",
                 },
-                "id": "TaskID",
-                "deviceId": "arn:aws:braket:::device/quantum-simulator/amazon/sv1",
-                "requestedShots": 120,
-                "successfulShots": 100,
-                "programMetadata": [{"executables": [{}]}],
-                "deviceParameters": {
+                "paradigmParameters": {
                     "braketSchemaHeader": {
-                        "name": "braket.device_schema.simulators.gate_model_simulator_device_parameters",
+                        "name": "braket.device_schema.gate_model_parameters",
                         "version": "1",
                     },
-                    "paradigmParameters": {
-                        "braketSchemaHeader": {
-                            "name": "braket.device_schema.gate_model_parameters",
-                            "version": "1",
-                        },
-                        "qubitCount": 5,
-                        "disableQubitRewiring": False,
-                    },
+                    "qubitCount": 5,
+                    "disableQubitRewiring": False,
                 },
-                "createdAt": "2024-10-15T19:06:58.986Z",
-                "endedAt": "2024-10-15T19:07:00.382Z",
-                "status": "COMPLETED",
-                "totalFailedExecutables": 1,
-            }
+            },
+            "createdAt": "2024-10-15T19:06:58.986Z",
+            "endedAt": "2024-10-15T19:07:00.382Z",
+            "status": "COMPLETED",
+            "totalFailedExecutables": 1,
+        },
     )
 )
 MOCK_PROGRAM_SET_QUANTUM_TASK = LocalQuantumTask(MOCK_PROGRAM_SET_RESULT)

--- a/tests/providers/test_adapter.py
+++ b/tests/providers/test_adapter.py
@@ -338,9 +338,7 @@ class TestAdapter(TestCase):
     def test_parameterized_global_phase_supported(self):
         """Tests that parameterized global phase is converted to gphase when supported."""
         braket_input = Circuit().phaseshift(0, FreeParameter("theta"))
-        result = to_braket(
-            braket_input, basis_gates=["rx", "rz", "cz", "global_phase"]
-        )
+        result = to_braket(braket_input, basis_gates=["rx", "rz", "cz", "global_phase"])
         self.assertIn("0.5*theta", str(result.global_phase))
 
     def test_exponential_gate_decomp(self):
@@ -465,15 +463,21 @@ class TestAdapter(TestCase):
         circuit.h(0)
         with pytest.raises(TypeError, match="Multiple values for basis_gates"):
             to_braket(circuit, {"h, cx"}, basis_gates={"h", "cx"})
-        with pytest.raises(TypeError, match="Multiple values for verbatim"), pytest.warns(
-            DeprecationWarning,
-            match="Passing basis_gates as a positional argument is deprecated.",
+        with (
+            pytest.raises(TypeError, match="Multiple values for verbatim"),
+            pytest.warns(
+                DeprecationWarning,
+                match="Passing basis_gates as a positional argument is deprecated.",
+            ),
         ):
             to_braket(circuit, {"h, cx"}, True, verbatim=True)
-        with pytest.raises(TypeError, match="Multiple values for connectivity"), pytest.warns(
+        with (
+            pytest.raises(TypeError, match="Multiple values for connectivity"),
+            pytest.warns(
                 DeprecationWarning, match="Passing verbatim as a positional argument is deprecated."
-            ):
-                to_braket(circuit, {"h, cx"}, True, [[0, 1]], connectivity=[[0, 1]])
+            ),
+        ):
+            to_braket(circuit, {"h, cx"}, True, [[0, 1]], connectivity=[[0, 1]])
         with pytest.raises(TypeError, match="Multiple values for angle_restrictions"):
             res = {"rx": {0: {np.pi}}}
             with pytest.warns(
@@ -1498,9 +1502,12 @@ class TestFromBraket(TestCase):
         instr = Instruction(op, range(2))
         circuit = Circuit().add_instruction(instr)
 
-        with self.assertRaises(TypeError), patch.dict(
-            "qiskit_braket_provider.providers.adapter._BRAKET_GATE_NAME_TO_QISKIT_GATE",
-            {"cnot": None},
+        with (
+            self.assertRaises(TypeError),
+            patch.dict(
+                "qiskit_braket_provider.providers.adapter._BRAKET_GATE_NAME_TO_QISKIT_GATE",
+                {"cnot": None},
+            ),
         ):
             to_qiskit(circuit)
 

--- a/tests/providers/test_adapter_branching.py
+++ b/tests/providers/test_adapter_branching.py
@@ -225,7 +225,9 @@ y q[1];
 """
     qc = to_qiskit(qasm)
 
-    main_ops = [(instr.operation.name, [qc.find_bit(q).index for q in instr.qubits]) for instr in qc.data]
+    main_ops = [
+        (instr.operation.name, [qc.find_bit(q).index for q in instr.qubits]) for instr in qc.data
+    ]
     assert main_ops[0] == ("x", [0])
     assert main_ops[1] == ("measure", [0])
     assert main_ops[2][0] == "if_else"
@@ -275,7 +277,9 @@ for int[8] i in [0:1] {
 c[0] = measure q[0];
 """
     qc = to_qiskit(qasm)
-    main_ops = [(instr.operation.name, [qc.find_bit(q).index for q in instr.qubits]) for instr in qc.data]
+    main_ops = [
+        (instr.operation.name, [qc.find_bit(q).index for q in instr.qubits]) for instr in qc.data
+    ]
     assert main_ops[0] == ("h", [0])
     assert main_ops[1] == ("h", [0])
     assert main_ops[2] == ("measure", [0])
@@ -293,7 +297,9 @@ for int[8] i in [0:1] {
 }
 """
     qc = to_qiskit(qasm)
-    main_ops = [(instr.operation.name, [qc.find_bit(q).index for q in instr.qubits]) for instr in qc.data]
+    main_ops = [
+        (instr.operation.name, [qc.find_bit(q).index for q in instr.qubits]) for instr in qc.data
+    ]
     assert main_ops[0] == ("measure", [0])
     assert main_ops[1] == ("h", [1])
     assert main_ops[2] == ("h", [1])
@@ -392,7 +398,9 @@ def test_compile_preserves_if_else_ops(qasm, expected_if_else_count, mcm_target)
     """IfElseOps should survive compilation through _compile."""
     result = _compile(qasm, target=mcm_target)
     compiled_circuit = result.circuits[0]
-    if_else_ops = [instr for instr in compiled_circuit.data if isinstance(instr.operation, IfElseOp)]
+    if_else_ops = [
+        instr for instr in compiled_circuit.data if isinstance(instr.operation, IfElseOp)
+    ]
     assert len(if_else_ops) == expected_if_else_count
 
 
@@ -411,7 +419,9 @@ if (c[0] == 1) {
 """
     result = _compile(qasm, target=mcm_target)
     compiled_circuit = result.circuits[0]
-    op = next(instr for instr in compiled_circuit.data if isinstance(instr.operation, IfElseOp)).operation
+    op = next(
+        instr for instr in compiled_circuit.data if isinstance(instr.operation, IfElseOp)
+    ).operation
     true_body, false_body = op.params
 
     assert _get_ops_with_qubits(true_body) == [("h", [1])]
@@ -686,7 +696,9 @@ def test_unsupported_condition_type():
 def test_evaluate_expression_unary():
     """UnaryExpression should be handled by _evaluate_expression."""
     ctx = _QiskitProgramContext()
-    result = ctx._evaluate_expression(UnaryExpression(op=UnaryOperator["!"], expression=BooleanLiteral(value=True)))
+    result = ctx._evaluate_expression(
+        UnaryExpression(op=UnaryOperator["!"], expression=BooleanLiteral(value=True))
+    )
     assert result.value is False
 
 
@@ -726,7 +738,9 @@ if (c == 3) {
     h q[0];
 }
 """
-    with pytest.raises(TypeError, match="Multi-bit register.*cannot be used as a single-bit condition"):
+    with pytest.raises(
+        TypeError, match="Multi-bit register.*cannot be used as a single-bit condition"
+    ):
         to_qiskit(qasm)
 
 

--- a/tests/providers/test_adapter_to_braket_verbatim.py
+++ b/tests/providers/test_adapter_to_braket_verbatim.py
@@ -231,8 +231,9 @@ def test_to_braket_with_single_verbatim_box(h_cx_circuit):
     for expected in ("X", "H", "CNot", "Y"):
         assert expected in names
 
-    indices = {n: next(i for i, (nm, _) in enumerate(info) if nm == n)
-               for n in ("X", "H", "CNot", "Y")}
+    indices = {
+        n: next(i for i, (nm, _) in enumerate(info) if nm == n) for n in ("X", "H", "CNot", "Y")
+    }
     assert indices["X"] < indices["H"] < indices["CNot"] < indices["Y"]
     assert info[indices["X"]][1] == [0]
     assert info[indices["H"]][1] == [0]
@@ -250,8 +251,7 @@ def test_to_braket_with_multiple_verbatim_boxes(h_circuit, cx_circuit):
     info = _gate_info(bc)
 
     assert bc.qubit_count == NUM_QUBITS
-    indices = {n: next(i for i, (nm, _) in enumerate(info) if nm == n)
-               for n in ("H", "X", "CNot")}
+    indices = {n: next(i for i, (nm, _) in enumerate(info) if nm == n) for n in ("H", "X", "CNot")}
     assert indices["H"] < indices["X"] < indices["CNot"]
     assert info[indices["H"]][1] == [0]
     assert info[indices["X"]][1] == [1]
@@ -326,7 +326,9 @@ def test_to_braket_raises_on_pass_manager_with_verbatim_boxes(h_circuit):
     qc = QuantumCircuit(NUM_QUBITS)
     qc.append(BoxOp(h_circuit, label=VERBATIM_LABEL), QUBIT_PAIR)
 
-    with pytest.raises(ValueError, match="Custom pass_manager is not supported with verbatim boxes"):
+    with pytest.raises(
+        ValueError, match="Custom pass_manager is not supported with verbatim boxes"
+    ):
         to_braket(qc, verbatim=False, pass_manager=PassManager([Optimize1qGates()]))
 
 
@@ -336,7 +338,10 @@ def test_to_braket_raises_on_barrier_labeled_as_verbatim_box():
     qc.append(Barrier(NUM_QUBITS, label=VERBATIM_LABEL), QUBIT_PAIR)
     qc.y(1)
 
-    with pytest.raises(ValueError, match="Cannot have a Barrier labeled with the same label used for verbatim boxes"):
+    with pytest.raises(
+        ValueError,
+        match="Cannot have a Barrier labeled with the same label used for verbatim boxes",
+    ):
         to_braket(qc, verbatim=False)
 
 
@@ -365,8 +370,9 @@ def test_to_braket_with_multiple_circuits_with_verbatim_boxes(h_cx_circuit):
 def test_round_trip_single_verbatim_box(use_program, single_box_qasm):
     qc = to_qiskit(_to_qiskit_input(single_box_qasm, use_program))
 
-    box_ops = [i for i in qc.data
-               if hasattr(i.operation, "label") and i.operation.label == VERBATIM_LABEL]
+    box_ops = [
+        i for i in qc.data if hasattr(i.operation, "label") and i.operation.label == VERBATIM_LABEL
+    ]
     assert len(box_ops) == 1
 
     bc = to_braket(qc, verbatim=False)
@@ -377,8 +383,7 @@ def test_round_trip_single_verbatim_box(use_program, single_box_qasm):
     for expected in ("H", "CNot", "X"):
         assert expected in names
 
-    indices = {n: next(i for i, (nm, _) in enumerate(info) if nm == n)
-               for n in ("H", "CNot", "X")}
+    indices = {n: next(i for i, (nm, _) in enumerate(info) if nm == n) for n in ("H", "CNot", "X")}
     assert indices["H"] < indices["X"]
     assert indices["CNot"] < indices["X"]
     assert info[indices["H"]][1] == [0]
@@ -390,16 +395,16 @@ def test_round_trip_single_verbatim_box(use_program, single_box_qasm):
 def test_round_trip_multiple_verbatim_boxes(use_program, multi_box_qasm):
     qc = to_qiskit(_to_qiskit_input(multi_box_qasm, use_program))
 
-    box_ops = [i for i in qc.data
-               if hasattr(i.operation, "label") and i.operation.label == VERBATIM_LABEL]
+    box_ops = [
+        i for i in qc.data if hasattr(i.operation, "label") and i.operation.label == VERBATIM_LABEL
+    ]
     assert len(box_ops) == 2
 
     bc = to_braket(qc, verbatim=False)
     info = _gate_info(bc)
 
     assert bc.qubit_count == NUM_QUBITS
-    indices = {n: next(i for i, (nm, _) in enumerate(info) if nm == n)
-               for n in ("H", "X", "CNot")}
+    indices = {n: next(i for i, (nm, _) in enumerate(info) if nm == n) for n in ("H", "X", "CNot")}
     assert indices["H"] < indices["X"] < indices["CNot"]
     assert info[indices["H"]][1] == [0]
     assert info[indices["X"]][1] == [1]
@@ -419,8 +424,7 @@ box {
     label = "custom_verbatim" if use_program else "my_custom_verbatim"
     qc = to_qiskit(_to_qiskit_input(qasm, use_program), verbatim_box_name=label)
 
-    box_ops = [i for i in qc.data
-               if hasattr(i.operation, "label") and i.operation.label == label]
+    box_ops = [i for i in qc.data if hasattr(i.operation, "label") and i.operation.label == label]
     assert len(box_ops) == 1
 
     bc = to_braket(qc, verbatim=False, verbatim_box_name=label)
@@ -471,8 +475,9 @@ box {
 }
 """
     qc = to_qiskit(qasm)
-    box_ops = [i for i in qc.data
-               if hasattr(i.operation, "label") and i.operation.label == VERBATIM_LABEL]
+    box_ops = [
+        i for i in qc.data if hasattr(i.operation, "label") and i.operation.label == VERBATIM_LABEL
+    ]
     assert len(box_ops) == 2
 
     bc = to_braket(qc, verbatim=False)

--- a/tests/providers/test_adapter_to_qiskit_verbatim.py
+++ b/tests/providers/test_adapter_to_qiskit_verbatim.py
@@ -31,7 +31,9 @@ box {
     cnot $0, $1;
 }
 """,
-            2, "verbatim", ["h", "cx"],
+            2,
+            "verbatim",
+            ["h", "cx"],
         ),
         (
             """
@@ -40,7 +42,9 @@ OPENQASM 3.0;
 box {
 }
 """,
-            0, "verbatim", [],
+            0,
+            "verbatim",
+            [],
         ),
         (
             """
@@ -50,7 +54,9 @@ box {
     h $0;
 }
 """,
-            1, "custom_verbatim", ["h"],
+            1,
+            "custom_verbatim",
+            ["h"],
         ),
     ],
     ids=["single_box_with_gates", "empty_box", "custom_label"],
@@ -229,11 +235,13 @@ cnot $0, $1;
             {"add_measurements": False},
         ),
         (
-            Program(source="""
+            Program(
+                source="""
 OPENQASM 3.0;
 h $0;
 cnot $0, $1;
-"""),
+"""
+            ),
             {},
         ),
     ],

--- a/tests/providers/test_braket_backend.py
+++ b/tests/providers/test_braket_backend.py
@@ -311,7 +311,6 @@ class TestBraketAwsBackend(TestCase):
             class SubclassAWSBraketBackend(AWSBraketBackend):  # pylint: disable=unused-variable
                 """A subclass of AWSBraketBackend for testing purposes"""
 
-
     def test_run_multiple_circuits(self):
         """Tests run with multiple circuits"""
         device = Mock()

--- a/tests/providers/test_braket_provider.py
+++ b/tests/providers/test_braket_provider.py
@@ -87,7 +87,6 @@ class TestBraketProvider(TestCase):
             class SubclassAWSBraketProvider(AWSBraketProvider):  # pylint: disable=unused-variable
                 """This is a subclass of AWSBraketProvider for testing purposes."""
 
-
     def test_provider_backends_kwargs_local(self):
         """Tests getting local backends using kwargs"""
         provider = BraketProvider()

--- a/tests/providers/test_openqasm_roundtrip.py
+++ b/tests/providers/test_openqasm_roundtrip.py
@@ -26,7 +26,13 @@ def _make_target(num_qubits):
     if num_qubits >= 3:
         target.add_instruction(
             qiskit_gates.CCXGate(),
-            {(i, j, k): None for i in range(num_qubits) for j in range(num_qubits) for k in range(num_qubits) if len({i, j, k}) == 3},
+            {
+                (i, j, k): None
+                for i in range(num_qubits)
+                for j in range(num_qubits)
+                for k in range(num_qubits)
+                if len({i, j, k}) == 3
+            },
         )
     return target
 
@@ -77,9 +83,7 @@ def test_single_h_with_target():
 
 
 def test_bell_state_with_target():
-    _assert_verbatim_roundtrip(
-        "OPENQASM 3.0;\nh $0;\ncnot $0, $1;\n", target=_make_target(2)
-    )
+    _assert_verbatim_roundtrip("OPENQASM 3.0;\nh $0;\ncnot $0, $1;\n", target=_make_target(2))
 
 
 def test_three_qubit_toffoli_with_target():
@@ -96,9 +100,7 @@ def test_rotation_gates_with_target():
 
 
 def test_swap_gate_with_target():
-    _assert_verbatim_roundtrip(
-        "OPENQASM 3.0;\nswap $0, $1;\n", target=_make_target(2)
-    )
+    _assert_verbatim_roundtrip("OPENQASM 3.0;\nswap $0, $1;\n", target=_make_target(2))
 
 
 def test_multi_gate_sequence_with_target():

--- a/tox.ini
+++ b/tox.ini
@@ -33,8 +33,10 @@ commands =
 basepython = python3
 skip_install = true
 deps =
+    {[testenv:ruff-format-check]deps}
     {[testenv:ruff-check]deps}
 commands =
+    {[testenv:ruff-format-check]commands}
     {[testenv:ruff-check]commands}
 
 [testenv:ruff-check]
@@ -52,6 +54,14 @@ deps =
     ruff
 commands =
     ruff format . {posargs}
+
+[testenv:ruff-format-check]
+basepython = python3
+skip_install = true
+deps =
+    ruff
+commands =
+    ruff format --check . {posargs}
 
 [testenv:min-versions]
 basepython = python3.11


### PR DESCRIPTION
ruff format was defined in the linters tox env but never enforced in CI, which only ran linters_check (ruff check only). This meant formatting drift could be merged undetected.

Changes:
- Add ruff-format-check tox env that runs ruff format --check
- Update linters_check to also run ruff-format-check
- Apply ruff format to fix existing formatting drift in test_adapter.py