### PR TITLE
infra: add pytest-xdist to dev dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ coverage>=7.6.1
 nbqa>=1.1.1
 treon>=0.1.3
 pytest>=7.0.0
-pytest-xdist
+pytest-xdist>=3.0.0
 tox==3.24.5
 jupyter-sphinx>=0.3.2
 nbsphinx>=0.8.8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ coverage>=7.6.1
 nbqa>=1.1.1
 treon>=0.1.3
 pytest>=7.0.0
+pytest-xdist
 tox==3.24.5
 jupyter-sphinx>=0.3.2
 nbsphinx>=0.8.8


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add pytest-xdist as required by some downstream dependency tests that run against amazon-braket-default-simulator-python, whose pytest config uses '-n logical' (which requires pytest-xdist).

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md#pr-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/README.md) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
