### PR TITLE
fix: missing layout bug

### DIFF
--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -1275,6 +1275,7 @@ def _restore_verbatim_boxes(
         transpiled_circuit.num_qubits, transpiled_circuit.num_clbits
     )
     reconstructed_circuit.global_phase = transpiled_circuit.global_phase
+    reconstructed_circuit._layout = transpiled_circuit._layout
 
     verbatim_box_iter = iter(verbatim_boxes)
     barrier_count = 0

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -1271,11 +1271,7 @@ def _restore_verbatim_boxes(
         ValueError: If barrier count doesn't match verbatim box count
         ValueError: If qubit mapping fails
     """
-    reconstructed_circuit = QuantumCircuit(
-        transpiled_circuit.num_qubits, transpiled_circuit.num_clbits
-    )
-    reconstructed_circuit.global_phase = transpiled_circuit.global_phase
-    reconstructed_circuit._layout = transpiled_circuit._layout
+    reconstructed_circuit = transpiled_circuit.copy_empty_like()
 
     verbatim_box_iter = iter(verbatim_boxes)
     barrier_count = 0

--- a/test/unit_tests/test_adapter.py
+++ b/test/unit_tests/test_adapter.py
@@ -9,10 +9,10 @@ import pytest
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister, generate_preset_pass_manager
 from qiskit.circuit import Instruction as QiskitInstruction
 from qiskit.circuit import Measure, Parameter, ParameterVector
-from qiskit.circuit.library import GlobalPhaseGate, PauliEvolutionGate
+from qiskit.circuit.library import CXGate, GlobalPhaseGate, HGate, PauliEvolutionGate
 from qiskit.circuit.library import standard_gates as qiskit_gates
 from qiskit.quantum_info import Kraus, Operator, SparsePauliOp
-from qiskit.transpiler import PassManager, Target
+from qiskit.transpiler import InstructionProperties, PassManager, Target
 from qiskit_ionq import ionq_gates
 
 from braket.aws import AwsDevice
@@ -36,6 +36,7 @@ from qiskit_braket_provider.providers.adapter import (
     _BRAKET_GATE_NAME_TO_QISKIT_GATE,
     _BRAKET_SUPPORTED_NOISES,
     _QISKIT_GATE_NAME_TO_BRAKET_GATE,
+    _compile,
     _get_controlled_gateset,
     _validate_angle_restrictions,
     aws_device_to_target,
@@ -1764,11 +1765,6 @@ class TestThereAndBackAgain(TestCase):
 
     def test_compile_preserves_layout_with_verbatim_boxes(self):
         """Layout from transpilation should be preserved after restoring verbatim boxes."""
-        from qiskit.circuit.library import CXGate, HGate
-        from qiskit.transpiler import InstructionProperties, Target
-
-        from qiskit_braket_provider.providers.adapter import _compile
-
         t = Target(num_qubits=2)
         t.add_instruction(HGate(), {(0,): InstructionProperties(), (1,): InstructionProperties()})
         t.add_instruction(

--- a/test/unit_tests/test_adapter.py
+++ b/test/unit_tests/test_adapter.py
@@ -1761,3 +1761,25 @@ class TestThereAndBackAgain(TestCase):
         with self.assertRaises(ValueError) as context:
             to_braket(circuit)
         self.assertIn("Cannot add global barrier to empty circuit", str(context.exception))
+
+    def test_compile_preserves_layout_with_verbatim_boxes(self):
+        """Layout from transpilation should be preserved after restoring verbatim boxes."""
+        from qiskit.circuit.library import CXGate, HGate
+        from qiskit.transpiler import InstructionProperties, Target
+
+        from qiskit_braket_provider.providers.adapter import _compile
+
+        t = Target(num_qubits=2)
+        t.add_instruction(HGate(), {(0,): InstructionProperties(), (1,): InstructionProperties()})
+        t.add_instruction(
+            CXGate(), {(0, 1): InstructionProperties(), (1, 0): InstructionProperties()}
+        )
+
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.h(1)
+
+        result = _compile(qc, target=t)
+        compiled = result.circuits[0]
+        assert compiled.layout is not None


### PR DESCRIPTION
Fix a bug where the circuit layout was being lost during `_restore_verbatim_boxes()`
