### PR TITLE
fix: unify MCM-dependency check in _QiskitProgramContext

### DIFF
--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -529,15 +529,17 @@ class _QiskitProgramContext(AbstractProgramContext):
     def supports_midcircuit_measurement(self) -> bool:
         return True
 
-    def _references_measurement(self, condition) -> bool:
-        """Check if condition references a variable that was measured into."""
-        match condition:
+    def is_mcm_dependent(self, expression) -> bool:
+        """Check if expression references a variable that was measured into."""
+        match expression:
             case Identifier(name=name):
                 return name in self._measured_bits
             case IndexExpression(collection=Identifier(name=name)):
                 return name in self._measured_bits
             case BinaryExpression(lhs=lhs, rhs=rhs):
-                return self._references_measurement(lhs) or self._references_measurement(rhs)
+                return self.is_mcm_dependent(lhs) or self.is_mcm_dependent(rhs)
+            case RangeDefinition() | DiscreteSet():
+                return True
             case _:
                 return False
 
@@ -551,7 +553,7 @@ class _QiskitProgramContext(AbstractProgramContext):
         For static conditions (no measurement dependency), evaluates directly
         and yields only the taken branch.
         """
-        if not self._references_measurement(condition):
+        if not self.is_mcm_dependent(condition):
             try:
                 result = cast_to(BooleanLiteral, self._evaluate_expression(condition))
             except (TypeError, ValueError, AttributeError) as e:
@@ -689,7 +691,7 @@ class _QiskitProgramContext(AbstractProgramContext):
         For static conditions (no measurement dependency), evaluates directly.
         For MCM-dependent conditions, captures the body into a WhileLoopOp.
         """
-        if not self._references_measurement(condition):
+        if not self.is_mcm_dependent(condition):
             try:
                 while cast_to(BooleanLiteral, self._evaluate_expression(condition)).value:
                     yield True

--- a/test/unit_tests/test_adapter_dynamic_circuits.py
+++ b/test/unit_tests/test_adapter_dynamic_circuits.py
@@ -10,8 +10,10 @@ from braket.default_simulator.openqasm.parser.openqasm_ast import (
     BooleanLiteral,
     BoolType,
     Cast,
+    DiscreteSet,
     FunctionCall,
     IntegerLiteral,
+    RangeDefinition,
     UnaryExpression,
     UnaryOperator,
 )
@@ -786,6 +788,28 @@ def test_unsupported_condition_type():
         next(gen)
 
 
+def test_evaluate_condition_static_yields_value_directly():
+    """A static condition yields its boolean value and terminates."""
+    ctx = _QiskitProgramContext()
+    gen = ctx.evaluate_condition(BooleanLiteral(value=True))
+    assert next(gen) is True
+    with pytest.raises(StopIteration):
+        next(gen)
+
+
+def test_is_mcm_dependent_for_loop_set_declarations():
+    """For-loop set_declaration nodes (``RangeDefinition`` / ``DiscreteSet``)
+    are always treated as MCM-dependent so the interpreter routes them
+    through ``evaluate_for_range`` (to produce a ``ForLoopOp``) even when
+    the range is static.
+    """
+    ctx = _QiskitProgramContext()
+    assert ctx.is_mcm_dependent(
+        RangeDefinition(start=IntegerLiteral(0), end=IntegerLiteral(1), step=None)
+    )
+    assert ctx.is_mcm_dependent(DiscreteSet(values=[IntegerLiteral(0), IntegerLiteral(1)]))
+
+
 def test_evaluate_expression_unary():
     """UnaryExpression should be handled by _evaluate_expression."""
     ctx = _QiskitProgramContext()
@@ -1056,6 +1080,22 @@ def test_while_loop_unsupported_condition_type():
     gen = ctx.evaluate_while_condition(ArrayLiteral(values=[BooleanLiteral(value=True)]))
     with pytest.raises(TypeError, match="Unsupported condition in while loop"):
         next(gen)
+
+
+def test_evaluate_while_condition_static_terminates_on_false():
+    """A static false while condition yields nothing and terminates."""
+    ctx = _QiskitProgramContext()
+    gen = ctx.evaluate_while_condition(BooleanLiteral(value=False))
+    with pytest.raises(StopIteration):
+        next(gen)
+
+
+def test_evaluate_while_condition_static_true_yields_true():
+    """A static true while condition yields True on each iteration."""
+    ctx = _QiskitProgramContext()
+    gen = ctx.evaluate_while_condition(BooleanLiteral(value=True))
+    assert next(gen) is True
+    gen.close()
 
 
 def test_for_loop_body_expands_circuit():


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Consolidates the private `_references_measurement` helper into a single `is_mcm_dependent` override on `_QiskitProgramContext`.

*Testing done:*

- All existing unit tests pass against both the released
  `amazon-braket-default-simulator` and the branch at https://github.com/amazon-braket/amazon-braket-default-simulator-python/pull/367.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md#pr-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/README.md) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
