### PR TITLE
fix: use new default simulator interface

### DIFF
--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -533,14 +533,6 @@ class _QiskitProgramContext(AbstractProgramContext):
             return True
         return super().is_mcm_dependent(expression)
 
-    def mark_mcm_dependent(self, name: str) -> None:
-        """Mark a variable as MCM-dependent in its declaration scope."""
-        super().mark_mcm_dependent(name)
-
-    def track_mcm_dependency(self, lvalue_name: str, rvalue) -> None:
-        """Propagate MCM-dependency through classical assignments."""
-        super().track_mcm_dependency(lvalue_name, rvalue)
-
     def iter_classical_scopes(self, expression):
         """Yield once since Qiskit circuit building doesn't do per-path branching."""
         yield

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -483,7 +483,7 @@ class _QiskitProgramContext(AbstractProgramContext):
         target: tuple[int],
         classical_targets: Sequence[int] | None = None,
         *,
-        classical_destination: Identifier | IndexedIdentifier | None = None,
+        classical_destination: Identifier | IndexedIdentifier | None = None,  # noqa: ARG002
     ) -> None:
         active = self._active_circuit
         # this is to cover the edge case where a user measures a qubit without assigning it to a classical register
@@ -553,7 +553,7 @@ class _QiskitProgramContext(AbstractProgramContext):
             return True
         return super().is_mcm_dependent(expression)
 
-    def iter_classical_scopes(self, expression):
+    def iter_classical_scopes(self, expression: Expression):  # noqa: ARG002
         """Yield once since Qiskit circuit building doesn't do per-path branching."""
         yield
 

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -551,18 +551,7 @@ class _QiskitProgramContext(AbstractProgramContext):
         Yields True (visit if-block) then False (visit else-block).
         Each yield pushes a new circuit onto the stack; after the interpreter
         visits the block, the circuit is popped and used to build an IfElseOp.
-
-        For static conditions (no measurement dependency), evaluates directly
-        and yields only the taken branch.
         """
-        if not self.is_mcm_dependent(condition):
-            try:
-                result = cast_to(BooleanLiteral, self._evaluate_expression(condition))
-            except (TypeError, ValueError, AttributeError) as e:
-                raise TypeError("Unsupported condition in branching statement") from e
-            yield result.value
-            return
-
         # MCM path: resolve condition to (Clbit, value)
         main = self._active_circuit
         if isinstance(condition, (Identifier, IndexExpression)):
@@ -575,6 +564,11 @@ class _QiskitProgramContext(AbstractProgramContext):
                     f"Only '==' is supported for mid-circuit measurement branching."
                 )
             resolved_condition = self._resolve_condition(condition)
+        else:
+            raise NotImplementedError(
+                f"Unsupported condition type '{type(condition).__name__}' in branching condition. "
+                f"Only Identifier, IndexExpression, and BinaryExpression (==) are supported."
+            )
 
         true_body = QuantumCircuit(main.num_qubits, main.num_clbits)
         self._circuit_stack.append(true_body)
@@ -688,31 +682,23 @@ class _QiskitProgramContext(AbstractProgramContext):
         raise NotImplementedError("continue statements are not supported in loops.")
 
     def evaluate_while_condition(self, condition: Expression):
-        """Evaluate a while-loop condition, yielding True per iteration.
-
-        For static conditions (no measurement dependency), evaluates directly.
-        For MCM-dependent conditions, captures the body into a WhileLoopOp.
-        """
-        if not self.is_mcm_dependent(condition):
-            try:
-                while cast_to(BooleanLiteral, self._evaluate_expression(condition)).value:
-                    yield True
-            except (TypeError, ValueError, AttributeError) as e:
-                raise TypeError("Unsupported condition in while loop") from e
-            else:
-                return
-
+        """Evaluate a while-loop condition, capturing the body into a WhileLoopOp."""
         # MCM path: resolve condition and capture body into WhileLoopOp
         main = self._active_circuit
         if isinstance(condition, (Identifier, IndexExpression)):
             resolved_condition = self._resolve_condition_from_identifier(condition)
-        else:
+        elif isinstance(condition, BinaryExpression):
             if condition.op != BinaryOperator["=="]:
                 raise NotImplementedError(
                     f"Unsupported operator '{condition.op.name}' in while-loop condition. "
                     f"Only '==' is supported for mid-circuit measurement while loops."
                 )
             resolved_condition = self._resolve_condition(condition)
+        else:
+            raise NotImplementedError(
+                f"Unsupported condition type '{type(condition).__name__}' in while-loop condition. "
+                f"Only Identifier, IndexExpression, and BinaryExpression (==) are supported."
+            )
 
         body = QuantumCircuit(main.num_qubits, main.num_clbits)
         self._circuit_stack.append(body)

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -363,7 +363,6 @@ class _QiskitProgramContext(AbstractProgramContext):
         self._verbatim_circuit: QuantumCircuit | None = None
         self._verbatim_box_name = verbatim_box_name
         self._clbit_offset: dict[str, int] = {}
-        self._measured_bits: set[str] = set()
 
     @property
     def _active_circuit(self) -> QuantumCircuit:
@@ -466,13 +465,6 @@ class _QiskitProgramContext(AbstractProgramContext):
         *,
         classical_destination: Identifier | IndexedIdentifier | None = None,
     ) -> None:
-        if classical_destination is not None:
-            name = (
-                classical_destination.name
-                if isinstance(classical_destination, IndexedIdentifier)
-                else classical_destination
-            )
-            self._measured_bits.add(name.name)
         active = self._active_circuit
         # this is to cover the edge case where a user measures a qubit without assigning it to a classical register
         if active.num_clbits < len(target):
@@ -530,18 +522,28 @@ class _QiskitProgramContext(AbstractProgramContext):
         return True
 
     def is_mcm_dependent(self, expression) -> bool:
-        """Check if expression references a variable that was measured into."""
-        match expression:
-            case Identifier(name=name):
-                return name in self._measured_bits
-            case IndexExpression(collection=Identifier(name=name)):
-                return name in self._measured_bits
-            case BinaryExpression(lhs=lhs, rhs=rhs):
-                return self.is_mcm_dependent(lhs) or self.is_mcm_dependent(rhs)
-            case RangeDefinition() | DiscreteSet():
-                return True
-            case _:
-                return False
+        """Check if expression depends on a mid-circuit measurement result.
+
+        Delegates to the base class for identifier-based checks using
+        _mcm_dependent_scopes, but always returns True for RangeDefinition
+        and DiscreteSet to force for-loops through evaluate_for_range
+        (producing ForLoopOp).
+        """
+        if isinstance(expression, (RangeDefinition, DiscreteSet)):
+            return True
+        return super().is_mcm_dependent(expression)
+
+    def mark_mcm_dependent(self, name: str) -> None:
+        """Mark a variable as MCM-dependent in its declaration scope."""
+        super().mark_mcm_dependent(name)
+
+    def track_mcm_dependency(self, lvalue_name: str, rvalue) -> None:
+        """Propagate MCM-dependency through classical assignments."""
+        super().track_mcm_dependency(lvalue_name, rvalue)
+
+    def iter_classical_scopes(self, expression):
+        """Yield once since Qiskit circuit building doesn't do per-path branching."""
+        yield
 
     def evaluate_condition(self, condition):
         """Evaluate a branching condition using a circuit stack.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ certifi>=2021.5.30
 qiskit>=2.0.0
 qiskit-ionq>=1.0.0
 amazon-braket-sdk>=1.111.1
-amazon-braket-default-simulator>=1.38.0
+amazon-braket-default-simulator>=1.39.3
 
 setuptools>=40.1.0
 numpy>=1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ amazon-braket-sdk>=1.111.1
 amazon-braket-default-simulator>=1.39.3
 
 setuptools>=40.1.0
-numpy>=1.3
+numpy>=1.23

--- a/test/unit_tests/test_adapter_dynamic_circuits.py
+++ b/test/unit_tests/test_adapter_dynamic_circuits.py
@@ -781,23 +781,6 @@ if (c[0] != 1) {
         to_qiskit(qasm)
 
 
-def test_unsupported_condition_type():
-    """A non-boolean-castable static condition should raise an unsupported condition error."""
-    ctx = _QiskitProgramContext()
-    gen = ctx.evaluate_condition(ArrayLiteral(values=[BooleanLiteral(value=True)]))
-    with pytest.raises(TypeError, match="Unsupported condition in branching statement"):
-        next(gen)
-
-
-def test_evaluate_condition_static_yields_value_directly():
-    """A static condition yields its boolean value and terminates."""
-    ctx = _QiskitProgramContext()
-    gen = ctx.evaluate_condition(BooleanLiteral(value=True))
-    assert next(gen) is True
-    with pytest.raises(StopIteration):
-        next(gen)
-
-
 def test_is_mcm_dependent_for_loop_set_declarations():
     """For-loop set_declaration nodes (``RangeDefinition`` / ``DiscreteSet``)
     are always treated as MCM-dependent so the interpreter routes them
@@ -1075,30 +1058,6 @@ while (c != 0) {
         to_qiskit(qasm)
 
 
-def test_while_loop_unsupported_condition_type():
-    """A non-boolean-castable static while condition should raise an unsupported condition error."""
-    ctx = _QiskitProgramContext()
-    gen = ctx.evaluate_while_condition(ArrayLiteral(values=[BooleanLiteral(value=True)]))
-    with pytest.raises(TypeError, match="Unsupported condition in while loop"):
-        next(gen)
-
-
-def test_evaluate_while_condition_static_terminates_on_false():
-    """A static false while condition yields nothing and terminates."""
-    ctx = _QiskitProgramContext()
-    gen = ctx.evaluate_while_condition(BooleanLiteral(value=False))
-    with pytest.raises(StopIteration):
-        next(gen)
-
-
-def test_evaluate_while_condition_static_true_yields_true():
-    """A static true while condition yields True on each iteration."""
-    ctx = _QiskitProgramContext()
-    gen = ctx.evaluate_while_condition(BooleanLiteral(value=True))
-    assert next(gen) is True
-    gen.close()
-
-
 def test_for_loop_body_expands_circuit():
     """A physical qubit reference inside a for-loop body expands the main circuit."""
     qasm = """
@@ -1249,3 +1208,36 @@ if (c[0] == 1) {
         context.mark_mcm_dependent("c")
         context.track_mcm_dependency("d", Identifier("c"))
         assert context.is_mcm_dependent(Identifier("d"))
+
+
+def test_negated_condition_raises_not_implemented():
+    """A negated MCM condition like !c should raise NotImplementedError."""
+    qasm = """
+OPENQASM 3.0;
+qubit[2] q;
+bit c;
+c = measure q[0];
+if (!c) {
+    x q[1];
+}
+"""
+    with pytest.raises(NotImplementedError, match="Unsupported condition type"):
+        to_qiskit(qasm)
+
+
+def test_mcm_propagation_through_classical_assignment():
+    """MCM dependency should propagate through intermediate classical assignments."""
+    qasm = """
+OPENQASM 3.0;
+qubit[3] __qubits__;
+bit[1] mcm;
+bit __bit_1__;
+__bit_1__ = measure __qubits__[1];
+mcm[0] = __bit_1__;
+if (mcm[0] == 1) {
+    x __qubits__[2];
+}
+"""
+    qc = to_qiskit(qasm)
+    if_else_ops = _get_if_else_ops(qc)
+    assert len(if_else_ops) == 1

--- a/test/unit_tests/test_adapter_dynamic_circuits.py
+++ b/test/unit_tests/test_adapter_dynamic_circuits.py
@@ -12,6 +12,7 @@ from braket.default_simulator.openqasm.parser.openqasm_ast import (
     Cast,
     DiscreteSet,
     FunctionCall,
+    Identifier,
     IntegerLiteral,
     RangeDefinition,
     UnaryExpression,
@@ -1151,3 +1152,100 @@ if (c == 1) {
 """
     qc = to_qiskit(qasm)
     assert qc.num_clbits == 2
+
+
+# ---- Tests for new base-class interface methods ----
+
+
+class TestMarkMcmDependent:
+    """Tests for mark_mcm_dependent using base class _mcm_dependent_scopes."""
+
+    def test_mark_makes_variable_mcm_dependent(self):
+        context = _QiskitProgramContext()
+        context.add_qubits("q", 2)
+        context.declare_variable("c", BoolType())
+        context.mark_mcm_dependent("c")
+        assert context.is_mcm_dependent(Identifier("c"))
+
+    def test_unmarked_variable_is_not_mcm_dependent(self):
+        context = _QiskitProgramContext()
+        context.add_qubits("q", 1)
+        context.declare_variable("c", BoolType())
+        assert not context.is_mcm_dependent(Identifier("c"))
+
+
+class TestTrackMcmDependency:
+    """Tests for track_mcm_dependency propagating MCM status through assignments."""
+
+    def test_propagates_dependency_from_mcm_variable(self):
+        context = _QiskitProgramContext()
+        context.add_qubits("q", 1)
+        context.declare_variable("c", BoolType())
+        context.declare_variable("d", BoolType())
+        context.mark_mcm_dependent("c")
+        # d = c should make d MCM-dependent
+        context.track_mcm_dependency("d", Identifier("c"))
+        assert context.is_mcm_dependent(Identifier("d"))
+
+    def test_clears_dependency_when_rvalue_not_mcm(self):
+        context = _QiskitProgramContext()
+        context.add_qubits("q", 1)
+        context.declare_variable("c", BoolType())
+        context.declare_variable("d", BoolType())
+        context.mark_mcm_dependent("d")
+        assert context.is_mcm_dependent(Identifier("d"))
+        # d = c where c is NOT mcm-dependent should clear d
+        context.track_mcm_dependency("d", Identifier("c"))
+        assert not context.is_mcm_dependent(Identifier("d"))
+
+
+class TestIterClassicalScopes:
+    """Tests for iter_classical_scopes yielding exactly once."""
+
+    def test_yields_once(self):
+        context = _QiskitProgramContext()
+        count = sum(1 for _ in context.iter_classical_scopes(IntegerLiteral(0)))
+        assert count == 1
+
+
+class TestIsMcmDependentBaseClass:
+    """Tests for is_mcm_dependent using base class _mcm_dependent_scopes."""
+
+    def test_range_definition_always_mcm_dependent(self):
+        context = _QiskitProgramContext()
+        assert context.is_mcm_dependent(RangeDefinition(IntegerLiteral(0), IntegerLiteral(3), None))
+
+    def test_discrete_set_always_mcm_dependent(self):
+        context = _QiskitProgramContext()
+        assert context.is_mcm_dependent(DiscreteSet([IntegerLiteral(1), IntegerLiteral(2)]))
+
+    def test_literal_not_mcm_dependent(self):
+        context = _QiskitProgramContext()
+        assert not context.is_mcm_dependent(IntegerLiteral(42))
+
+    def test_mcm_dependency_through_full_program(self):
+        """End-to-end: measure marks variable, which is then detected as MCM-dependent."""
+        qasm = """
+OPENQASM 3.0;
+qubit[2] q;
+bit[1] c;
+c[0] = measure q[0];
+if (c[0] == 1) {
+    x q[1];
+}
+"""
+        qc = to_qiskit(qasm)
+        if_else_ops = _get_if_else_ops(qc)
+        assert len(if_else_ops) == 1
+
+    def test_classical_assignment_propagates_mcm(self):
+        """Variable assigned from MCM result should be detected as MCM-dependent
+        when using the context directly (not through the interpreter, which
+        requires runtime values)."""
+        context = _QiskitProgramContext()
+        context.add_qubits("q", 2)
+        context.declare_variable("c", BoolType())
+        context.declare_variable("d", BoolType())
+        context.mark_mcm_dependent("c")
+        context.track_mcm_dependency("d", Identifier("c"))
+        assert context.is_mcm_dependent(Identifier("d"))

--- a/test/unit_tests/test_adapter_dynamic_circuits.py
+++ b/test/unit_tests/test_adapter_dynamic_circuits.py
@@ -1113,78 +1113,66 @@ if (c == 1) {
     assert qc.num_clbits == 2
 
 
-# ---- Tests for new base-class interface methods ----
+def test_mark_mcm_dependent_makes_variable_mcm_dependent():
+    context = _QiskitProgramContext()
+    context.add_qubits("q", 2)
+    context.declare_variable("c", BoolType())
+    context.mark_mcm_dependent("c")
+    assert context.is_mcm_dependent(Identifier("c"))
 
 
-class TestMarkMcmDependent:
-    """Tests for mark_mcm_dependent using base class _mcm_dependent_scopes."""
-
-    def test_mark_makes_variable_mcm_dependent(self):
-        context = _QiskitProgramContext()
-        context.add_qubits("q", 2)
-        context.declare_variable("c", BoolType())
-        context.mark_mcm_dependent("c")
-        assert context.is_mcm_dependent(Identifier("c"))
-
-    def test_unmarked_variable_is_not_mcm_dependent(self):
-        context = _QiskitProgramContext()
-        context.add_qubits("q", 1)
-        context.declare_variable("c", BoolType())
-        assert not context.is_mcm_dependent(Identifier("c"))
+def test_unmarked_variable_is_not_mcm_dependent():
+    context = _QiskitProgramContext()
+    context.add_qubits("q", 1)
+    context.declare_variable("c", BoolType())
+    assert not context.is_mcm_dependent(Identifier("c"))
 
 
-class TestTrackMcmDependency:
-    """Tests for track_mcm_dependency propagating MCM status through assignments."""
-
-    def test_propagates_dependency_from_mcm_variable(self):
-        context = _QiskitProgramContext()
-        context.add_qubits("q", 1)
-        context.declare_variable("c", BoolType())
-        context.declare_variable("d", BoolType())
-        context.mark_mcm_dependent("c")
-        # d = c should make d MCM-dependent
-        context.track_mcm_dependency("d", Identifier("c"))
-        assert context.is_mcm_dependent(Identifier("d"))
-
-    def test_clears_dependency_when_rvalue_not_mcm(self):
-        context = _QiskitProgramContext()
-        context.add_qubits("q", 1)
-        context.declare_variable("c", BoolType())
-        context.declare_variable("d", BoolType())
-        context.mark_mcm_dependent("d")
-        assert context.is_mcm_dependent(Identifier("d"))
-        # d = c where c is NOT mcm-dependent should clear d
-        context.track_mcm_dependency("d", Identifier("c"))
-        assert not context.is_mcm_dependent(Identifier("d"))
+def test_track_mcm_dependency_propagates_from_mcm_variable():
+    context = _QiskitProgramContext()
+    context.add_qubits("q", 1)
+    context.declare_variable("c", BoolType())
+    context.declare_variable("d", BoolType())
+    context.mark_mcm_dependent("c")
+    context.track_mcm_dependency("d", Identifier("c"))
+    assert context.is_mcm_dependent(Identifier("d"))
 
 
-class TestIterClassicalScopes:
-    """Tests for iter_classical_scopes yielding exactly once."""
+def test_track_mcm_dependency_clears_when_rvalue_not_mcm():
+    context = _QiskitProgramContext()
+    context.add_qubits("q", 1)
+    context.declare_variable("c", BoolType())
+    context.declare_variable("d", BoolType())
+    context.mark_mcm_dependent("d")
+    assert context.is_mcm_dependent(Identifier("d"))
+    context.track_mcm_dependency("d", Identifier("c"))
+    assert not context.is_mcm_dependent(Identifier("d"))
 
-    def test_yields_once(self):
-        context = _QiskitProgramContext()
-        count = sum(1 for _ in context.iter_classical_scopes(IntegerLiteral(0)))
-        assert count == 1
+
+def test_iter_classical_scopes_yields_once():
+    context = _QiskitProgramContext()
+    count = sum(1 for _ in context.iter_classical_scopes(IntegerLiteral(0)))
+    assert count == 1
 
 
-class TestIsMcmDependentBaseClass:
-    """Tests for is_mcm_dependent using base class _mcm_dependent_scopes."""
+def test_is_mcm_dependent_range_definition():
+    context = _QiskitProgramContext()
+    assert context.is_mcm_dependent(RangeDefinition(IntegerLiteral(0), IntegerLiteral(3), None))
 
-    def test_range_definition_always_mcm_dependent(self):
-        context = _QiskitProgramContext()
-        assert context.is_mcm_dependent(RangeDefinition(IntegerLiteral(0), IntegerLiteral(3), None))
 
-    def test_discrete_set_always_mcm_dependent(self):
-        context = _QiskitProgramContext()
-        assert context.is_mcm_dependent(DiscreteSet([IntegerLiteral(1), IntegerLiteral(2)]))
+def test_is_mcm_dependent_discrete_set():
+    context = _QiskitProgramContext()
+    assert context.is_mcm_dependent(DiscreteSet([IntegerLiteral(1), IntegerLiteral(2)]))
 
-    def test_literal_not_mcm_dependent(self):
-        context = _QiskitProgramContext()
-        assert not context.is_mcm_dependent(IntegerLiteral(42))
 
-    def test_mcm_dependency_through_full_program(self):
-        """End-to-end: measure marks variable, which is then detected as MCM-dependent."""
-        qasm = """
+def test_is_mcm_dependent_literal_not_dependent():
+    context = _QiskitProgramContext()
+    assert not context.is_mcm_dependent(IntegerLiteral(42))
+
+
+def test_is_mcm_dependent_through_full_program():
+    """End-to-end: measure marks variable, which is then detected as MCM-dependent."""
+    qasm = """
 OPENQASM 3.0;
 qubit[2] q;
 bit[1] c;
@@ -1193,21 +1181,20 @@ if (c[0] == 1) {
     x q[1];
 }
 """
-        qc = to_qiskit(qasm)
-        if_else_ops = _get_if_else_ops(qc)
-        assert len(if_else_ops) == 1
+    qc = to_qiskit(qasm)
+    if_else_ops = _get_if_else_ops(qc)
+    assert len(if_else_ops) == 1
 
-    def test_classical_assignment_propagates_mcm(self):
-        """Variable assigned from MCM result should be detected as MCM-dependent
-        when using the context directly (not through the interpreter, which
-        requires runtime values)."""
-        context = _QiskitProgramContext()
-        context.add_qubits("q", 2)
-        context.declare_variable("c", BoolType())
-        context.declare_variable("d", BoolType())
-        context.mark_mcm_dependent("c")
-        context.track_mcm_dependency("d", Identifier("c"))
-        assert context.is_mcm_dependent(Identifier("d"))
+
+def test_classical_assignment_propagates_mcm():
+    """Variable assigned from MCM result should be detected as MCM-dependent."""
+    context = _QiskitProgramContext()
+    context.add_qubits("q", 2)
+    context.declare_variable("c", BoolType())
+    context.declare_variable("d", BoolType())
+    context.mark_mcm_dependent("c")
+    context.track_mcm_dependency("d", Identifier("c"))
+    assert context.is_mcm_dependent(Identifier("d"))
 
 
 def test_negated_condition_raises_not_implemented():

--- a/test/unit_tests/test_adapter_dynamic_circuits.py
+++ b/test/unit_tests/test_adapter_dynamic_circuits.py
@@ -13,7 +13,6 @@ from qiskit.circuit.library import CXGate, HGate, Measure, XGate, YGate, ZGate
 from qiskit.transpiler import Target
 
 from braket.default_simulator.openqasm.parser.openqasm_ast import (
-    ArrayLiteral,
     BooleanLiteral,
     BoolType,
     Cast,
@@ -1219,6 +1218,22 @@ bit c;
 c = measure q[0];
 if (!c) {
     x q[1];
+}
+"""
+    with pytest.raises(NotImplementedError, match="Unsupported condition type"):
+        to_qiskit(qasm)
+
+
+def test_negated_while_condition_raises_not_implemented():
+    """A negated MCM condition in a while loop should raise NotImplementedError."""
+    qasm = """
+OPENQASM 3.0;
+qubit[2] q;
+bit c;
+c = measure q[0];
+while (!c) {
+    x q[1];
+    c = measure q[0];
 }
 """
     with pytest.raises(NotImplementedError, match="Unsupported condition type"):


### PR DESCRIPTION
  The default simulator's AbstractProgramContext (v1.37+) now handles MCM dependency tracking internally via _mcm_dependent_scopes with proper lexical scoping, and the interpreter handles static condition evaluation itself.                                                                          

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md) doc
- [ ] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md#pr-title-format)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/README.md) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
