### PR TITLE
feat: Support AWS device emulators

### DIFF
--- a/qiskit_braket_provider/__init__.py
+++ b/qiskit_braket_provider/__init__.py
@@ -17,6 +17,9 @@ from .providers import (
     BraketAwsBackend as BraketAwsBackend,
 )
 from .providers import (
+    BraketAwsEmulatorBackend as BraketAwsEmulatorBackend,
+)
+from .providers import (
     BraketEstimator as BraketEstimator,
 )
 from .providers import (

--- a/qiskit_braket_provider/providers/__init__.py
+++ b/qiskit_braket_provider/providers/__init__.py
@@ -28,6 +28,7 @@ from .adapter import to_braket as to_braket
 from .adapter import to_qiskit as to_qiskit
 from .braket_backend import AWSBraketBackend as AWSBraketBackend
 from .braket_backend import BraketAwsBackend as BraketAwsBackend
+from .braket_backend import BraketAwsEmulatorBackend as BraketAwsEmulatorBackend
 from .braket_backend import BraketLocalBackend as BraketLocalBackend
 from .braket_estimator import BraketEstimator as BraketEstimator
 from .braket_job import AmazonBraketTask as AmazonBraketTask

--- a/qiskit_braket_provider/providers/braket_backend.py
+++ b/qiskit_braket_provider/providers/braket_backend.py
@@ -37,6 +37,8 @@ if TYPE_CHECKING:
     import datetime
     from collections.abc import Callable, Iterable
 
+    from braket.emulation.emulator import Emulator
+
     from .braket_provider import BraketProvider
 
 logger = logging.getLogger(__name__)
@@ -68,6 +70,10 @@ class BraketBackend(BackendV2, ABC, Generic[T]):
         """
         return None
 
+    @property
+    def _execution_device(self) -> Device:
+        return self._device
+
     def _validate_meas_level(self, meas_level: enum.Enum | int) -> None:
         if isinstance(meas_level, enum.Enum):
             meas_level = meas_level.value
@@ -98,7 +104,7 @@ class BraketBackend(BackendV2, ABC, Generic[T]):
         **options,
     ) -> BraketQuantumTask:
         program_set = ProgramSet(braket_circuits, shots_per_executable=shots)
-        task = self._device.run(program_set, **options)
+        task = self._execution_device.run(program_set, **options)
         return BraketQuantumTask(
             task_id=task.id, tasks=task, backend=self, shots=program_set.total_shots
         )
@@ -459,6 +465,47 @@ class BraketAwsBackend(BraketBackend[AwsDevice]):
             if key != "_device":
                 setattr(result, key, copy.deepcopy(value, memo))  # Pass memo along
         return result
+
+
+class BraketAwsEmulatorBackend(BraketAwsBackend):
+    """Runs quantum circuits on a local emulator for an Amazon Braket AWS device."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        """Initialize an emulator backend from an AWS device.
+
+        The backend keeps the original AWS device metadata for target construction and
+        transpilation, while submissions are sent to the device emulator.
+        """
+        super().__init__(*args, **kwargs)
+        self._emulator = self._device.emulator()
+        self._supports_program_sets = True
+
+    @property
+    def is_emulator(self) -> bool:
+        """bool: Whether this backend submits tasks to a local device emulator."""
+        return True
+
+    @property
+    def emulator(self) -> Emulator:
+        """Local emulator used to execute circuits for this AWS device."""
+        return self._emulator
+
+    @property
+    def _execution_device(self) -> Emulator:
+        return self._emulator
+
+    def _run_batch(
+        self,
+        braket_circuits: list[Circuit],
+        shots: int,
+        **options,
+    ) -> BraketQuantumTask:
+        tasks = [
+            self._emulator.run(task_specification=circuit, shots=shots, **options)
+            for circuit in braket_circuits
+        ]
+        task_id = _TASK_ID_DIVIDER.join(task.id for task in tasks)
+        return BraketQuantumTask(task_id=task_id, tasks=tasks, backend=self, shots=shots)
 
 
 class AWSBraketBackend(BraketAwsBackend):

--- a/qiskit_braket_provider/providers/braket_estimator.py
+++ b/qiskit_braket_provider/providers/braket_estimator.py
@@ -116,7 +116,7 @@ class BraketEstimator(BaseEstimatorV2):
         shots = int(np.ceil(1.0 / (pub_precision if pub_precision is not None else precision) ** 2))
         program_set = ProgramSet(all_bindings, shots_per_executable=shots)
         return BraketPrimitiveTask(
-            self._backend._device.run(program_set, **self._options),
+            self._backend._execution_device.run(program_set, **self._options),
             lambda result: BraketEstimator._translate_result(
                 result,
                 _JobMetadata(

--- a/qiskit_braket_provider/providers/braket_provider.py
+++ b/qiskit_braket_provider/providers/braket_provider.py
@@ -4,12 +4,12 @@ import warnings
 
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
 
-from braket.aws import AwsDevice
+from braket.aws import AwsDevice, AwsDeviceType
 from braket.device_schema.dwave import DwaveDeviceCapabilities
 from braket.device_schema.quera import QueraDeviceCapabilities
 from braket.device_schema.xanadu import XanaduDeviceCapabilities
 
-from .braket_backend import BraketAwsBackend, BraketLocalBackend
+from .braket_backend import BraketAwsBackend, BraketAwsEmulatorBackend, BraketLocalBackend
 
 
 class BraketProvider:
@@ -30,7 +30,9 @@ class BraketProvider:
          BraketBackend[dm1]]
     """
 
-    def get_backend(self, name: str | None = None, **kwargs) -> BraketAwsBackend:
+    def get_backend(
+        self, name: str | None = None, **kwargs
+    ) -> BraketAwsBackend | BraketAwsEmulatorBackend | BraketLocalBackend:
         """Return a single backend matching the specified filters.
 
         Args:
@@ -53,7 +55,7 @@ class BraketProvider:
         self,
         name: str | None = None,
         **kwargs,
-    ) -> list[BraketAwsBackend | BraketLocalBackend]:
+    ) -> list[BraketAwsBackend | BraketAwsEmulatorBackend | BraketLocalBackend]:
         """Return a list of backends matching the specified filters.
 
         Args:
@@ -67,6 +69,7 @@ class BraketProvider:
                 BraketLocalBackend(name="braket_sv"),
                 BraketLocalBackend(name="braket_dm"),
             ]
+        emulator = kwargs.pop("emulator", False)
         names = [name] if name else None
         devices = AwsDevice.get_devices(names=names, **kwargs)
         # filter by supported devices
@@ -83,16 +86,22 @@ class BraketProvider:
                 ),
             )
         ]
+        backend_cls = BraketAwsEmulatorBackend if emulator else BraketAwsBackend
         return [
-            BraketAwsBackend(
+            backend_cls(
                 device=device,
                 provider=self,
                 name=device.name,
-                description=f"AWS Device: {device.provider_name} {device.name}.",
+                description=(
+                    f"AWS Device Emulator: {device.provider_name} {device.name}."
+                    if emulator
+                    else f"AWS Device: {device.provider_name} {device.name}."
+                ),
                 online_date=device.properties.service.updatedAt,
                 backend_version="2",
             )
             for device in supported_devices
+            if not emulator or device.type != AwsDeviceType.SIMULATOR
         ]
 
 

--- a/qiskit_braket_provider/providers/braket_sampler.py
+++ b/qiskit_braket_provider/providers/braket_sampler.py
@@ -102,7 +102,7 @@ class BraketSampler(BaseSamplerV2):
         shots_per_executable = pub_shots if pub_shots is not None else shots
         program_set = ProgramSet(circuit_bindings, shots_per_executable=shots_per_executable)
         return BraketPrimitiveTask(
-            self._backend._device.run(program_set, **self._options),
+            self._backend._execution_device.run(program_set, **self._options),
             lambda result: BraketSampler._translate_result(
                 result,
                 _JobMetadata(

--- a/test/unit_tests/test_braket_backend.py
+++ b/test/unit_tests/test_braket_backend.py
@@ -26,6 +26,7 @@ from braket.tasks.local_quantum_task import LocalQuantumTask
 from qiskit_braket_provider import (
     AWSBraketBackend,
     BraketAwsBackend,
+    BraketAwsEmulatorBackend,
     BraketLocalBackend,
     BraketProvider,
     __version__,
@@ -599,3 +600,34 @@ class TestBraketAwsBackend(TestCase):
         self.assertEqual(deep_target.operations, target.operations)
         self.assertEqual(deep_target.operation_names, target.operation_names)
         self.assertNotEqual(deep, backend)
+
+
+class TestBraketAwsEmulatorBackend(TestCase):
+    """Tests class for BraketAwsEmulatorBackend."""
+
+    @patch("qiskit_braket_provider.providers.braket_backend.to_braket")
+    def test_emulator_backend_run(self, mock_to_braket: MagicMock):
+        """Tests that emulator backends submit circuits through AwsDevice.emulator()."""
+        device = Mock()
+        device.properties = MOCK_RIGETTI_GATE_MODEL_QPU_CAPABILITIES.copy(deep=True)
+        device.gate_calibrations = None
+        device.type = "QPU"
+        device.topology_graph = MOCK_RIGETTI_TOPOLOGY_GRAPH
+
+        emulator = Mock()
+        emulator_task = Mock(spec=LocalQuantumTask)
+        emulator_task.id = "emulator-task-0"
+        emulator.run.return_value = emulator_task
+        device.emulator.return_value = emulator
+
+        backend = BraketAwsEmulatorBackend(device=device)
+        braket_circuit = Circuit().h(1)
+        mock_to_braket.return_value = [braket_circuit]
+
+        task = backend.run(QuantumCircuit(1), shots=10)
+
+        self.assertTrue(backend.is_emulator)
+        self.assertIs(backend.emulator, emulator)
+        device.emulator.assert_called_once()
+        emulator.run.assert_called_once_with(task_specification=braket_circuit, shots=10)
+        self.assertEqual(task.task_id(), "emulator-task-0")

--- a/test/unit_tests/test_braket_estimator.py
+++ b/test/unit_tests/test_braket_estimator.py
@@ -14,9 +14,13 @@ from qiskit.primitives.containers.observables_array import ObservablesArray
 from qiskit.quantum_info import SparsePauliOp
 
 from braket.program_sets import ProgramSet
-from qiskit_braket_provider.providers import BraketLocalBackend
+from qiskit_braket_provider.providers import BraketAwsEmulatorBackend, BraketLocalBackend
 from qiskit_braket_provider.providers.braket_estimator import BraketEstimator
 from qiskit_braket_provider.providers.braket_primitive_task import BraketPrimitiveTask
+from test.unit_tests.mocks import (
+    MOCK_RIGETTI_M_3_QPU_CAPABILITIES,
+    MOCK_RIGETTI_TOPOLOGY_GRAPH,
+)
 
 
 class TestBraketEstimator(TestCase):
@@ -41,6 +45,33 @@ class TestBraketEstimator(TestCase):
         backend._supports_program_sets = False
         with self.assertRaises(ValueError):
             BraketEstimator(backend)
+
+    def test_emulator_backend_uses_emulator_for_program_sets(self):
+        """Tests that estimator primitives run ProgramSets on the device emulator."""
+        device = Mock()
+        device.properties = MOCK_RIGETTI_M_3_QPU_CAPABILITIES.copy(deep=True)
+        device.gate_calibrations = None
+        device.type = "QPU"
+        device.topology_graph = MOCK_RIGETTI_TOPOLOGY_GRAPH
+
+        emulator = Mock()
+        emulator_task = Mock()
+        emulator_task.id = "emulator-program-set"
+        emulator.run.return_value = emulator_task
+        device.emulator.return_value = emulator
+
+        backend = BraketAwsEmulatorBackend(device=device)
+        estimator = BraketEstimator(backend)
+        qc = QuantumCircuit(1)
+        qc.rx(0.1, 0)
+        pub = (qc, SparsePauliOp(["Z"]))
+
+        job = estimator.run([pub], precision=0.1)
+
+        self.assertTrue(backend._supports_program_sets)
+        emulator.run.assert_called_once()
+        self.assertIsInstance(emulator.run.call_args[0][0], ProgramSet)
+        self.assertEqual(job.job_id(), "emulator-program-set")
 
     def test_simple_pub(self):
         """Test a simple pub with no broadcasting."""

--- a/test/unit_tests/test_braket_provider.py
+++ b/test/unit_tests/test_braket_provider.py
@@ -17,6 +17,7 @@ from braket.circuits import Circuit
 from qiskit_braket_provider import (
     AWSBraketProvider,
     BraketAwsBackend,
+    BraketAwsEmulatorBackend,
     BraketLocalBackend,
     BraketProvider,
     to_braket,
@@ -28,6 +29,7 @@ from test.unit_tests.mocks import (
     MOCK_GATE_MODEL_SIMULATOR_TN,
     MOCK_RIGETTI_GATE_MODEL_M_3_QPU,
     MOCK_RIGETTI_M_3_QPU_CAPABILITIES,
+    MOCK_RIGETTI_TOPOLOGY_GRAPH,
     SIMULATOR_REGION,
 )
 
@@ -92,6 +94,44 @@ class TestBraketProvider(TestCase):
         provider = BraketProvider()
 
         self.assertIsInstance(provider.backends(name=None, local="sv1")[0], BraketLocalBackend)
+
+    @patch("qiskit_braket_provider.providers.braket_provider.AwsDevice.get_devices")
+    def test_provider_get_backend_emulator(self, mock_get_devices: MagicMock):
+        """Tests getting a local emulator backend for an AWS device."""
+        mock_device = Mock()
+        mock_device.name = "Aspen-M-3"
+        mock_device.provider_name = "Rigetti"
+        mock_device.properties = MOCK_RIGETTI_M_3_QPU_CAPABILITIES.copy(deep=True)
+        mock_device.properties.service = Mock()
+        mock_device.properties.service.updatedAt = "2026-06-03T00:00:00+00:00"
+        mock_device.type = AwsDeviceType.QPU
+        mock_device.topology_graph = MOCK_RIGETTI_TOPOLOGY_GRAPH
+        mock_device.gate_calibrations = None
+        mock_device.aws_session.add_braket_user_agent = Mock()
+        mock_device.emulator.return_value = Mock()
+        mock_get_devices.return_value = [mock_device]
+
+        backend = BraketProvider().get_backend("Aspen-M-3", emulator=True)
+
+        self.assertIsInstance(backend, BraketAwsEmulatorBackend)
+        self.assertTrue(backend.is_emulator)
+        self.assertEqual(backend.name, "Aspen-M-3")
+        self.assertIn("AWS Device Emulator", backend.description)
+        mock_get_devices.assert_called_once_with(names=["Aspen-M-3"])
+        mock_device.emulator.assert_called_once()
+
+    @patch("qiskit_braket_provider.providers.braket_provider.AwsDevice.get_devices")
+    def test_provider_emulator_excludes_managed_simulators(self, mock_get_devices: MagicMock):
+        """Tests that emulator=True does not request emulators for managed simulators."""
+        mock_device = Mock()
+        mock_device.name = "SV1"
+        mock_device.provider_name = "Amazon"
+        mock_device.properties = MOCK_GATE_MODEL_SIMULATOR_SV
+        mock_device.type = AwsDeviceType.SIMULATOR
+        mock_get_devices.return_value = [mock_device]
+
+        self.assertEqual(BraketProvider().backends("SV1", emulator=True), [])
+        mock_device.emulator.assert_not_called()
 
     def test_real_devices(self):
         """Tests real devices."""

--- a/test/unit_tests/test_braket_sampler.py
+++ b/test/unit_tests/test_braket_sampler.py
@@ -1,6 +1,7 @@
 """Tests for BraketSampler."""
 
 from unittest import TestCase
+from unittest.mock import Mock
 
 import numpy as np
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
@@ -10,9 +11,13 @@ from qiskit.primitives.containers import BitArray
 from qiskit.primitives.containers.sampler_pub import SamplerPub
 
 from braket.circuits import Circuit
-from braket.program_sets import CircuitBinding
-from qiskit_braket_provider.providers import BraketLocalBackend
+from braket.program_sets import CircuitBinding, ProgramSet
+from qiskit_braket_provider.providers import BraketAwsEmulatorBackend, BraketLocalBackend
 from qiskit_braket_provider.providers.braket_sampler import BraketSampler
+from test.unit_tests.mocks import (
+    MOCK_RIGETTI_M_3_QPU_CAPABILITIES,
+    MOCK_RIGETTI_TOPOLOGY_GRAPH,
+)
 
 
 class TestBraketSampler(TestCase):
@@ -55,6 +60,33 @@ class TestBraketSampler(TestCase):
             self.sampler.run([(qc, [0, 1, 2, 3], 100), (qc, [0, 1, 2, 3], 200)])
 
         self.assertIn("same shots", str(context.exception))
+
+    def test_emulator_backend_uses_emulator_for_program_sets(self):
+        """Tests that sampler primitives run ProgramSets on the device emulator."""
+        device = Mock()
+        device.properties = MOCK_RIGETTI_M_3_QPU_CAPABILITIES.copy(deep=True)
+        device.gate_calibrations = None
+        device.type = "QPU"
+        device.topology_graph = MOCK_RIGETTI_TOPOLOGY_GRAPH
+
+        emulator = Mock()
+        emulator_task = Mock()
+        emulator_task.id = "emulator-program-set"
+        emulator.run.return_value = emulator_task
+        device.emulator.return_value = emulator
+
+        backend = BraketAwsEmulatorBackend(device=device)
+        sampler = BraketSampler(backend)
+        qc = QuantumCircuit(1)
+        qc.rx(0.1, 0)
+        qc.measure_all()
+
+        job = sampler.run([(qc,)], shots=10)
+
+        self.assertTrue(backend._supports_program_sets)
+        emulator.run.assert_called_once()
+        self.assertIsInstance(emulator.run.call_args[0][0], ProgramSet)
+        self.assertEqual(job.job_id(), "emulator-program-set")
 
     def test_run_local_multiple_registers(self):
         """Tests that correct results are returned for circuits with multiple registers"""


### PR DESCRIPTION
Closes #325.

## Summary
- Add `BraketAwsEmulatorBackend` for AWS devices requested through `BraketProvider(...).get_backend(..., emulator=True)`.
- Keep AWS device metadata and target construction from the selected device, while routing circuit execution to `AwsDevice.emulator()`.
- Route `BraketSampler` and `BraketEstimator` ProgramSet execution through the backend execution device so emulator backends work with primitives.
- Export the new backend class and add regression coverage for provider selection, backend execution, sampler, and estimator paths.

## Validation
- `.\.venv\Scripts\python -m ruff check qiskit_braket_provider\providers\braket_backend.py qiskit_braket_provider\providers\braket_provider.py qiskit_braket_provider\providers\braket_sampler.py qiskit_braket_provider\providers\braket_estimator.py qiskit_braket_provider\providers\__init__.py qiskit_braket_provider\__init__.py test\unit_tests\test_braket_provider.py test\unit_tests\test_braket_backend.py test\unit_tests\test_braket_sampler.py test\unit_tests\test_braket_estimator.py`
- `.\.venv\Scripts\python -m ruff format --check qiskit_braket_provider\providers\braket_backend.py qiskit_braket_provider\providers\braket_provider.py qiskit_braket_provider\providers\braket_sampler.py qiskit_braket_provider\providers\braket_estimator.py qiskit_braket_provider\providers\__init__.py qiskit_braket_provider\__init__.py test\unit_tests\test_braket_provider.py test\unit_tests\test_braket_backend.py test\unit_tests\test_braket_sampler.py test\unit_tests\test_braket_estimator.py`
- `.\.venv\Scripts\python -m pytest -q test\unit_tests`