### PR TITLE
feat: add emulator execution routing for Braket AWS backends

### DIFF
--- a/qiskit_braket_provider/providers/braket_backend.py
+++ b/qiskit_braket_provider/providers/braket_backend.py
@@ -107,7 +107,14 @@ class BraketBackend(BackendV2, ABC, Generic[T]):
 class BraketLocalBackend(BraketBackend[LocalSimulator]):
     """Runs quantum circuits on the Braket local simulator."""
 
-    def __init__(self, name: str = "default", **fields) -> None:
+    def __init__(
+        self,
+        name: str = "default",
+        *,
+        target: Target | None = None,
+        gateset: set[str] | None = None,
+        **fields,
+    ) -> None:
         """Initialize the backend.
 
         Example:
@@ -123,8 +130,8 @@ class BraketLocalBackend(BraketBackend[LocalSimulator]):
         """
         simulator = LocalSimulator(backend=name)
         super().__init__(simulator, name or simulator.name, **fields)
-        self._target = local_simulator_to_target(self._device)
-        self._gateset = self.get_gateset()
+        self._target = target if target is not None else local_simulator_to_target(self._device)
+        self._gateset = gateset if gateset is not None else self.get_gateset()
         self.status = self._device.status
 
     @property
@@ -297,6 +304,10 @@ class BraketAwsBackend(BraketBackend[AwsDevice]):
     @classmethod
     def _default_options(cls) -> Options:
         return Options()
+
+    def emulator(self) -> BraketLocalBackend:
+        """Return a local simulator backend using this backend's target."""
+        return BraketLocalBackend(target=self.target, gateset=self._gateset)
 
     def qubit_properties(self, qubit: int | list[int]) -> QubitProperties | list[QubitProperties]:
         # TODO: fetch information from device.properties.provider

--- a/qiskit_braket_provider/providers/braket_backend.py
+++ b/qiskit_braket_provider/providers/braket_backend.py
@@ -111,8 +111,10 @@ class BraketLocalBackend(BraketBackend[LocalSimulator]):
         self,
         name: str = "default",
         *,
+        device: LocalSimulator | None = None,
         target: Target | None = None,
         gateset: set[str] | None = None,
+        qubit_labels: tuple[int, ...] | None = None,
         **fields,
     ) -> None:
         """Initialize the backend.
@@ -128,15 +130,20 @@ class BraketLocalBackend(BraketBackend[LocalSimulator]):
             name (str): Name of backend. Default: ``default``.
             **fields: Extra arguments.
         """
-        simulator = LocalSimulator(backend=name)
+        simulator = device or LocalSimulator(backend=name)
         super().__init__(simulator, name or simulator.name, **fields)
         self._target = target if target is not None else local_simulator_to_target(self._device)
         self._gateset = gateset if gateset is not None else self.get_gateset()
+        self._qubit_labels = qubit_labels
         self.status = self._device.status
 
     @property
     def target(self) -> Target:
         return self._target
+
+    @property
+    def qubit_labels(self) -> tuple[int, ...] | None:
+        return self._qubit_labels
 
     @property
     def max_circuits(self) -> None:
@@ -181,7 +188,12 @@ class BraketLocalBackend(BraketBackend[LocalSimulator]):
         convert_input = [run_input] if isinstance(run_input, QuantumCircuit) else list(run_input)
         verbatim = options.pop("verbatim", False)
         circuits: list[Circuit] = [
-            to_braket(circ, target=self._target if not verbatim else None, verbatim=verbatim)
+            to_braket(
+                circ,
+                qubit_labels=self.qubit_labels,
+                target=self._target if not verbatim else None,
+                verbatim=verbatim,
+            )
             for circ in convert_input
         ]
 
@@ -307,7 +319,12 @@ class BraketAwsBackend(BraketBackend[AwsDevice]):
 
     def emulator(self) -> BraketLocalBackend:
         """Return a local simulator backend using this backend's target."""
-        return BraketLocalBackend(target=self.target, gateset=self._gateset)
+        return BraketLocalBackend(
+            device=self._device.emulator(),
+            target=self.target,
+            gateset=self._gateset,
+            qubit_labels=self.qubit_labels,
+        )
 
     def qubit_properties(self, qubit: int | list[int]) -> QubitProperties | list[QubitProperties]:
         # TODO: fetch information from device.properties.provider

--- a/qiskit_braket_provider/providers/braket_backend.py
+++ b/qiskit_braket_provider/providers/braket_backend.py
@@ -115,6 +115,7 @@ class BraketLocalBackend(BraketBackend[LocalSimulator]):
         target: Target | None = None,
         gateset: set[str] | None = None,
         qubit_labels: tuple[int, ...] | None = None,
+        supports_program_sets: bool | None = None,
         **fields,
     ) -> None:
         """Initialize the backend.
@@ -128,6 +129,11 @@ class BraketLocalBackend(BraketBackend[LocalSimulator]):
 
         Args:
             name (str): Name of backend. Default: ``default``.
+            device (LocalSimulator | None): Local simulator device to use for execution.
+            target (Target | None): Qiskit target to use for transpilation and conversion.
+            gateset (set[str] | None): Braket gate set to use for conversion.
+            qubit_labels (tuple[int, ...] | None): Physical qubit labels for conversion.
+            supports_program_sets (bool | None): Program-set support override.
             **fields: Extra arguments.
         """
         simulator = device or LocalSimulator(backend=name)
@@ -135,6 +141,8 @@ class BraketLocalBackend(BraketBackend[LocalSimulator]):
         self._target = target if target is not None else local_simulator_to_target(self._device)
         self._gateset = gateset if gateset is not None else self.get_gateset()
         self._qubit_labels = qubit_labels
+        if supports_program_sets is not None:
+            self._supports_program_sets = supports_program_sets
         self.status = self._device.status
 
     @property
@@ -318,12 +326,17 @@ class BraketAwsBackend(BraketBackend[AwsDevice]):
         return Options()
 
     def emulator(self) -> BraketLocalBackend:
-        """Return a local simulator backend using this backend's target."""
+        """Return a local simulator backend configured from this AWS backend.
+
+        The returned backend uses the AWS device emulator for execution while preserving
+        target, gateset, qubit labels, and program-set support metadata from this backend.
+        """
         return BraketLocalBackend(
             device=self._device.emulator(),
             target=self.target,
             gateset=self._gateset,
             qubit_labels=self.qubit_labels,
+            supports_program_sets=self._supports_program_sets,
         )
 
     def qubit_properties(self, qubit: int | list[int]) -> QubitProperties | list[QubitProperties]:

--- a/test/unit_tests/test_braket_backend.py
+++ b/test/unit_tests/test_braket_backend.py
@@ -137,17 +137,20 @@ class TestBraketLocalBackend(TestCase):
         target = Target(num_qubits=2)
         gateset = {"h", "cx"}
         qubit_labels = (3, 5)
+        supports_program_sets = True
 
         backend = BraketLocalBackend(
             name="default",
             target=target,
             gateset=gateset,
             qubit_labels=qubit_labels,
+            supports_program_sets=supports_program_sets,
         )
 
         self.assertIs(backend.target, target)
         self.assertEqual(backend._gateset, gateset)
         self.assertEqual(backend.qubit_labels, qubit_labels)
+        self.assertEqual(backend._supports_program_sets, supports_program_sets)
 
     def test_local_backend_circuit(self):
         """Tests local backend with circuit."""
@@ -349,6 +352,7 @@ class TestBraketAwsBackend(TestCase):
         local_device.properties.action = {}
 
         backend = BraketAwsBackend(device=device)
+        backend._supports_program_sets = True
         emulator = backend.emulator()
 
         device.emulator.assert_called_once()
@@ -357,6 +361,7 @@ class TestBraketAwsBackend(TestCase):
         self.assertIs(emulator.target, backend.target)
         self.assertEqual(emulator._gateset, backend._gateset)
         self.assertEqual(emulator.qubit_labels, backend.qubit_labels)
+        self.assertEqual(emulator._supports_program_sets, backend._supports_program_sets)
 
     def test_emulator_run_uses_aws_target_qubit_labels(self):
         """Tests running a circuit through an AWS backend emulator."""

--- a/test/unit_tests/test_braket_backend.py
+++ b/test/unit_tests/test_braket_backend.py
@@ -31,7 +31,7 @@ from qiskit_braket_provider import (
     __version__,
     exception,
 )
-from qiskit_braket_provider.providers.adapter import native_gate_connectivity
+from qiskit_braket_provider.providers.adapter import native_gate_connectivity, to_braket
 from test.unit_tests.mocks import (
     MOCK_RIGETTI_GATE_MODEL_QPU_CAPABILITIES,
     MOCK_RIGETTI_M_3_QPU_CAPABILITIES,
@@ -103,15 +103,22 @@ class TestBraketLocalBackend(TestCase):
         first_backend = BraketLocalBackend(name="braket_dm")
         self.assertEqual(first_backend.name, "braket_dm")
 
-    def test_local_backend_target_and_gateset_override(self):
-        """Tests local backend target and gateset overrides."""
+    def test_local_backend_metadata_overrides(self):
+        """Tests local backend metadata overrides."""
         target = Target(num_qubits=2)
         gateset = {"h", "cx"}
+        qubit_labels = (3, 5)
 
-        backend = BraketLocalBackend(name="default", target=target, gateset=gateset)
+        backend = BraketLocalBackend(
+            name="default",
+            target=target,
+            gateset=gateset,
+            qubit_labels=qubit_labels,
+        )
 
         self.assertIs(backend.target, target)
         self.assertEqual(backend._gateset, gateset)
+        self.assertEqual(backend.qubit_labels, qubit_labels)
 
     def test_local_backend_circuit(self):
         """Tests local backend with circuit."""
@@ -302,20 +309,57 @@ class TestBraketAwsBackend(TestCase):
         with self.assertRaises(ValueError):
             BraketAwsBackend(arn="some_arn", device="some_device")
 
-    def test_emulator_returns_local_backend_with_aws_target(self):
+    def test_emulator_returns_local_backend_with_aws_metadata(self):
         """Tests creating a local emulator backend from an AWS backend."""
         device = Mock()
         device.properties = MOCK_RIGETTI_GATE_MODEL_QPU_CAPABILITIES
         device.gate_calibrations = None
         device.type = "QPU"
         device.topology_graph = MOCK_RIGETTI_TOPOLOGY_GRAPH
+        local_device = device.emulator.return_value
+        local_device.properties.action = {}
 
         backend = BraketAwsBackend(device=device)
         emulator = backend.emulator()
 
+        device.emulator.assert_called_once()
         self.assertIsInstance(emulator, BraketLocalBackend)
+        self.assertIs(emulator._device, local_device)
         self.assertIs(emulator.target, backend.target)
         self.assertEqual(emulator._gateset, backend._gateset)
+        self.assertEqual(emulator.qubit_labels, backend.qubit_labels)
+
+    def test_emulator_run_uses_aws_target_qubit_labels(self):
+        """Tests running a circuit through an AWS backend emulator."""
+        device = Mock()
+        device.properties = MOCK_RIGETTI_GATE_MODEL_QPU_CAPABILITIES
+        device.gate_calibrations = None
+        device.type = "QPU"
+        device.topology_graph = MOCK_RIGETTI_TOPOLOGY_GRAPH
+        local_device = device.emulator.return_value
+        local_device.properties.action = {}
+        local_task = Mock(spec=LocalQuantumTask)
+        local_task.id = "local-task"
+        local_device.run.return_value = local_task
+
+        backend = BraketAwsBackend(device=device)
+        emulator = backend.emulator()
+
+        circuit = QuantumCircuit(3)
+        circuit.h(0)
+        circuit.cx(0, 1)
+        circuit.cx(0, 2)
+
+        task = emulator.run(circuit, shots=10)
+
+        device.emulator.assert_called_once()
+        local_device.run.assert_called_once()
+        submitted_circuit = local_device.run.call_args.kwargs["task_specification"]
+        self.assertEqual(
+            submitted_circuit,
+            to_braket(circuit, qubit_labels=backend.qubit_labels, target=backend.target),
+        )
+        self.assertEqual(task.task_id(), "local-task")
 
     def test_deprecation_warning_on_init(self):
         """Test that a deprecation warning is raised when initializing AWSBraketBackend"""

--- a/test/unit_tests/test_braket_backend.py
+++ b/test/unit_tests/test_braket_backend.py
@@ -32,6 +32,7 @@ from qiskit_braket_provider import (
     exception,
 )
 from qiskit_braket_provider.providers.adapter import native_gate_connectivity, to_braket
+from qiskit_braket_provider.providers.braket_backend import BraketBackend
 from test.unit_tests.mocks import (
     MOCK_RIGETTI_GATE_MODEL_QPU_CAPABILITIES,
     MOCK_RIGETTI_M_3_QPU_CAPABILITIES,
@@ -72,6 +73,34 @@ class TestBraketBackend(TestCase):
         """Test the repr method of BraketBackend."""
         backend = BraketLocalBackend(name="default")
         self.assertEqual(repr(backend), "BraketBackend[default]")
+
+    def test_qubit_labels_default(self):
+        """Tests default qubit labels for generic backend."""
+
+        class ConcreteBraketBackend(BraketBackend):
+            @classmethod
+            def _default_options(cls) -> object:
+                from qiskit.providers import Options
+
+                return Options()
+
+            @property
+            def target(self) -> Target:
+                return Target(num_qubits=1)
+
+            @property
+            def max_circuits(self) -> None:
+                return None
+
+            def run(self, run_input: object, **options) -> object:
+                raise NotImplementedError
+
+        device = Mock()
+        device.properties.action = {}
+
+        backend = ConcreteBraketBackend(device, "test")
+
+        self.assertIsNone(backend.qubit_labels)
 
 
 class TestBraketLocalBackend(TestCase):

--- a/test/unit_tests/test_braket_backend.py
+++ b/test/unit_tests/test_braket_backend.py
@@ -103,6 +103,16 @@ class TestBraketLocalBackend(TestCase):
         first_backend = BraketLocalBackend(name="braket_dm")
         self.assertEqual(first_backend.name, "braket_dm")
 
+    def test_local_backend_target_and_gateset_override(self):
+        """Tests local backend target and gateset overrides."""
+        target = Target(num_qubits=2)
+        gateset = {"h", "cx"}
+
+        backend = BraketLocalBackend(name="default", target=target, gateset=gateset)
+
+        self.assertIs(backend.target, target)
+        self.assertEqual(backend._gateset, gateset)
+
     def test_local_backend_circuit(self):
         """Tests local backend with circuit."""
         backend = BraketLocalBackend(name="default")
@@ -291,6 +301,21 @@ class TestBraketAwsBackend(TestCase):
 
         with self.assertRaises(ValueError):
             BraketAwsBackend(arn="some_arn", device="some_device")
+
+    def test_emulator_returns_local_backend_with_aws_target(self):
+        """Tests creating a local emulator backend from an AWS backend."""
+        device = Mock()
+        device.properties = MOCK_RIGETTI_GATE_MODEL_QPU_CAPABILITIES
+        device.gate_calibrations = None
+        device.type = "QPU"
+        device.topology_graph = MOCK_RIGETTI_TOPOLOGY_GRAPH
+
+        backend = BraketAwsBackend(device=device)
+        emulator = backend.emulator()
+
+        self.assertIsInstance(emulator, BraketLocalBackend)
+        self.assertIs(emulator.target, backend.target)
+        self.assertEqual(emulator._gateset, backend._gateset)
 
     def test_deprecation_warning_on_init(self):
         """Test that a deprecation warning is raised when initializing AWSBraketBackend"""


### PR DESCRIPTION
Issue #, if available:

Fixes #325

Description of changes:

Adds a local emulator path for Braket AWS backends by allowing an AWS backend to create a local backend with AWS-derived target metadata.

This change follows the reviewer feedback to avoid separate execution-device routing on `BraketAwsBackend`. Instead, the AWS backend remains responsible for AWS device metadata, and `.emulator()` returns a `BraketLocalBackend` configured with the AWS backend’s target/gateset.

Main changes:

* Adds optional `target` and `gateset` overrides to `BraketLocalBackend`
* Adds `BraketAwsBackend.emulator()`
* `BraketAwsBackend.emulator()` returns a `BraketLocalBackend` using the AWS backend target/gateset
* Preserves the existing AWS backend execution path without adding `_run_device` routing
* Adds focused unit tests for local backend target/gateset override behavior and AWS-backend emulator creation

Testing done:

Local validation:

* `python -m pytest -q test/unit_tests/test_braket_backend.py`

  * `26 passed, 4 skipped, 4 warnings, 18 subtests passed`
* `python -m ruff check qiskit_braket_provider test`

  * passed
* `python -m ruff format --check qiskit_braket_provider test`

  * passed

The added tests use mocks and are not configured for a specific AWS region or account.

## Merge Checklist

#### General

* [x] I have read the [[CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md)](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/[CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md#pr-title-format).md) doc
* [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md#pr-title-format)
* [x] I have updated any necessary documentation, including [[READMEs](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/README.md)](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/README.md) (if appropriate)

#### Tests

* [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
* [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.