### PR TITLE
fix: Don't use qubit labels for virtual qubits

### DIFF
--- a/qiskit_braket_provider/providers/braket_backend.py
+++ b/qiskit_braket_provider/providers/braket_backend.py
@@ -402,7 +402,7 @@ class BraketAwsBackend(BraketBackend[AwsDevice]):
             del options["meas_level"]
 
         # Always use target for simulator
-        target, basis_gates, qubit_labels = self._to_braket_args(native, pass_manager)
+        target, basis_gates, qubit_labels = self._resolve_compilation_args(native, pass_manager)
         braket_circuits = (
             to_braket(circuits, qubit_labels=self._qubit_labels, verbatim=True)
             if verbatim
@@ -426,9 +426,12 @@ class BraketAwsBackend(BraketBackend[AwsDevice]):
             else self._run_batch(braket_circuits, shots, **options)
         )
 
-    def _to_braket_args(
+    def _resolve_compilation_args(
         self, native: bool, pass_manager: PassManager
-    ) -> tuple[Target | None, set[str] | None, tuple[int] | None]:
+    ) -> tuple[Target | None, set[str] | None, tuple[int, ...] | None]:
+        """
+        Determine multiple compilation args that all come from the same information
+        """
         if pass_manager:
             return None, None, self._qubit_labels
         if native or self._device.type == AwsDeviceType.SIMULATOR:

--- a/qiskit_braket_provider/providers/braket_backend.py
+++ b/qiskit_braket_provider/providers/braket_backend.py
@@ -402,13 +402,13 @@ class BraketAwsBackend(BraketBackend[AwsDevice]):
             del options["meas_level"]
 
         # Always use target for simulator
-        target, basis_gates = self._target_and_basis_gates(native, pass_manager)
+        target, basis_gates, qubit_labels = self._to_braket_args(native, pass_manager)
         braket_circuits = (
             to_braket(circuits, qubit_labels=self._qubit_labels, verbatim=True)
             if verbatim
             else to_braket(
                 circuits,
-                qubit_labels=self._qubit_labels,
+                qubit_labels=qubit_labels,
                 target=target,
                 basis_gates=basis_gates,
                 angle_restrictions=(
@@ -426,15 +426,15 @@ class BraketAwsBackend(BraketBackend[AwsDevice]):
             else self._run_batch(braket_circuits, shots, **options)
         )
 
-    def _target_and_basis_gates(
+    def _to_braket_args(
         self, native: bool, pass_manager: PassManager
-    ) -> tuple[Target | None, set[str] | None]:
+    ) -> tuple[Target | None, set[str] | None, tuple[int] | None]:
         if pass_manager:
-            return None, None
+            return None, None, self._qubit_labels
         if native or self._device.type == AwsDeviceType.SIMULATOR:
             # Always use target for simulator
-            return self._target, None
-        return None, self._gateset
+            return self._target, None, self._qubit_labels
+        return None, self._gateset, None
 
     def _run_batch(
         self,

--- a/test/unit_tests/test_braket_backend.py
+++ b/test/unit_tests/test_braket_backend.py
@@ -331,7 +331,7 @@ class TestBraketAwsBackend(TestCase):
         circuit.h(0)
 
         backend.run([circuit, circuit], shots=0, meas_level=2)
-        braket_circuit = Circuit().h(1)
+        braket_circuit = Circuit().h(0)
         device.run_batch.assert_called_once_with([braket_circuit, braket_circuit], shots=0)
 
         backend.run([circuit, circuit], shots=0, native=True, num_processes=2)
@@ -361,7 +361,7 @@ class TestBraketAwsBackend(TestCase):
         circuit.h(0)
 
         backend.run([circuit, circuit], shots=5, meas_level=2)
-        braket_circuit = Circuit().h(1)
+        braket_circuit = Circuit().h(0)
         device.run.assert_called_once_with(
             ProgramSet([braket_circuit, braket_circuit], shots_per_executable=5)
         )


### PR DESCRIPTION
Translating virtual qubits to device qubits with `qubit_labels` can result in OpenQASM programs allocating more qubits than necessary.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md#pr-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/README.md) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
