### PR TITLE
feat: #325 add requested minimal Braket device emulator backends

### DIFF
--- a/docs/quickstart_guide.rst
+++ b/docs/quickstart_guide.rst
@@ -49,6 +49,26 @@ list all available backends for your account (including simulators and QPUs) wit
 A list of available quantum devices and their features can be found in the `Amazon Braket Developer
 Guide <https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html>`_.
 
+Running a circuit on a device emulator
+======================================
+
+Amazon Braket device emulators are local backends derived from supported QPU devices. They are
+created with the Braket SDK ``AwsDevice.emulator()`` method and reuse the QPU target for Qiskit
+transpilation.
+
+.. code-block:: python
+
+    provider = BraketProvider()
+    backend = provider.get_backend("Aria 1", emulator=True)
+
+    print(backend.is_emulator)  # True
+    job = backend.run(circuit, shots=100)
+    result = job.result()
+    print(result.get_counts())
+
+AWS managed simulators, such as ``SV1``, ``TN1``, and ``DM1``, are not device emulators. Request an
+emulator for a supported QPU device instead.
+
 Running circuits on the local simulator
 =======================================
 

--- a/qiskit_braket_provider/providers/braket_backend.py
+++ b/qiskit_braket_provider/providers/braket_backend.py
@@ -49,15 +49,25 @@ T = TypeVar("T", bound=Device, covariant=True)  # noqa: PLC0105
 class BraketBackend(BackendV2, ABC, Generic[T]):
     """Base Qiskit backend for Amazon Braket devices."""
 
-    def __init__(self, device: T, name: str, **fields) -> None:
+    def __init__(
+        self, device: T, name: str, supports_program_sets: bool | None = None, **fields
+    ) -> None:
         super().__init__(name=name, **fields)
         self._device = device
+        actions = getattr(getattr(self._device, "properties", None), "action", None)
         self._supports_program_sets = (
-            DeviceActionType.OPENQASM_PROGRAM_SET in self._device.properties.action
+            supports_program_sets
+            if supports_program_sets is not None
+            else bool(actions and DeviceActionType.OPENQASM_PROGRAM_SET in actions)
         )
 
     def __repr__(self) -> str:
         return f"BraketBackend[{self.name}]"
+
+    @property
+    def is_emulator(self) -> bool:
+        """Whether this backend wraps an Amazon Braket SDK emulator."""
+        return bool(getattr(self, "_is_emulator", False))
 
     @property
     def qubit_labels(self) -> tuple[int, ...] | None:
@@ -86,9 +96,15 @@ class BraketBackend(BackendV2, ABC, Generic[T]):
         Returns:
             set[str] | None: The requested gate set.
         """
+        properties = getattr(self._device, "properties", None)
+        if properties is None:
+            return None
         if native:
-            return native_gate_set(self._device.properties)
-        action = self._device.properties.action.get(DeviceActionType.OPENQASM)
+            return native_gate_set(properties)
+        actions = getattr(properties, "action", None)
+        if not actions:
+            return None
+        action = actions.get(DeviceActionType.OPENQASM)
         return gateset_from_properties(action) if action else None
 
     def _run_program_set(
@@ -104,10 +120,20 @@ class BraketBackend(BackendV2, ABC, Generic[T]):
         )
 
 
-class BraketLocalBackend(BraketBackend[LocalSimulator]):
+class BraketLocalBackend(BraketBackend[Device]):
     """Runs quantum circuits on the Braket local simulator."""
 
-    def __init__(self, name: str = "default", **fields) -> None:
+    def __init__(
+        self,
+        name: str = "default",
+        *,
+        device: Device | None = None,
+        target: Target | None = None,
+        is_emulator: bool = False,
+        qubit_labels: tuple[int, ...] | None = None,
+        supports_program_sets: bool | None = None,
+        **fields,
+    ) -> None:
         """Initialize the backend.
 
         Example:
@@ -119,13 +145,35 @@ class BraketLocalBackend(BraketBackend[LocalSimulator]):
 
         Args:
             name (str): Name of backend. Default: ``default``.
+            device (Device | None): Braket local device instance. Default: ``None``.
+            target (Target | None): Qiskit target to use for the local device. Default: ``None``.
+            is_emulator (bool): Whether this backend wraps a device emulator. Default: ``False``.
+            qubit_labels (tuple[int, ...] | None): Underlying device qubit labels.
+                Default: ``None``.
+            supports_program_sets (bool | None): Whether this backend supports program sets.
+                Default: infer from the local device properties.
             **fields: Extra arguments.
         """
-        simulator = LocalSimulator(backend=name)
-        super().__init__(simulator, name or simulator.name, **fields)
-        self._target = local_simulator_to_target(self._device)
-        self._gateset = self.get_gateset()
+        simulator = device or LocalSimulator(backend=name)
+        if target is None:
+            if not isinstance(simulator, LocalSimulator):
+                raise ValueError("Must specify a target when creating a backend for a local device")
+            target = local_simulator_to_target(simulator)
+        super().__init__(
+            simulator,
+            name or simulator.name,
+            supports_program_sets=supports_program_sets,
+            **fields,
+        )
+        self._is_emulator = is_emulator
+        self._qubit_labels = qubit_labels
+        self._target = target
+        self._gateset = self.get_gateset() or set(self._target.operation_names)
         self.status = self._device.status
+
+    @property
+    def qubit_labels(self) -> tuple[int, ...] | None:
+        return self._qubit_labels
 
     @property
     def target(self) -> Target:
@@ -174,7 +222,12 @@ class BraketLocalBackend(BraketBackend[LocalSimulator]):
         convert_input = [run_input] if isinstance(run_input, QuantumCircuit) else list(run_input)
         verbatim = options.pop("verbatim", False)
         circuits: list[Circuit] = [
-            to_braket(circ, target=self._target if not verbatim else None, verbatim=verbatim)
+            to_braket(
+                circ,
+                qubit_labels=self._qubit_labels,
+                target=self._target if not verbatim else None,
+                verbatim=verbatim,
+            )
             for circ in convert_input
         ]
 
@@ -264,6 +317,26 @@ class BraketAwsBackend(BraketBackend[AwsDevice]):
             else None
         )
         self._gateset = self.get_gateset()
+
+    def emulator(self) -> BraketLocalBackend:
+        """Create a local backend backed by this AWS device's Braket SDK emulator.
+
+        The Braket emulator object does not expose device properties, so the local backend reuses
+        the target and program-set support inferred from the source AWS device.
+        """
+        description = getattr(self, "description", None) or self.name
+        return BraketLocalBackend(
+            device=self._device.emulator(),
+            name=self.name,
+            provider=getattr(self, "provider", None),
+            description=f"Emulator for {description}",
+            online_date=getattr(self, "online_date", None),
+            backend_version=getattr(self, "backend_version", None),
+            target=copy.deepcopy(self._target),
+            is_emulator=True,
+            qubit_labels=self._qubit_labels,
+            supports_program_sets=self._supports_program_sets,
+        )
 
     def retrieve_job(self, task_id: str) -> BraketQuantumTask:
         """Return a single job submitted to AWS backend.

--- a/qiskit_braket_provider/providers/braket_provider.py
+++ b/qiskit_braket_provider/providers/braket_provider.py
@@ -4,12 +4,27 @@ import warnings
 
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
 
-from braket.aws import AwsDevice
+from braket.aws import AwsDevice, AwsDeviceType
 from braket.device_schema.dwave import DwaveDeviceCapabilities
 from braket.device_schema.quera import QueraDeviceCapabilities
 from braket.device_schema.xanadu import XanaduDeviceCapabilities
 
 from .braket_backend import BraketAwsBackend, BraketLocalBackend
+
+
+def _is_aws_simulator(device: AwsDevice) -> bool:
+    return device.type in (AwsDeviceType.SIMULATOR, AwsDeviceType.SIMULATOR.value)
+
+
+def _is_supported_gate_model(device: AwsDevice) -> bool:
+    return not isinstance(
+        device.properties,
+        (
+            DwaveDeviceCapabilities,
+            XanaduDeviceCapabilities,
+            QueraDeviceCapabilities,
+        ),
+    )
 
 
 class BraketProvider:
@@ -30,14 +45,17 @@ class BraketProvider:
          BraketBackend[dm1]]
     """
 
-    def get_backend(self, name: str | None = None, **kwargs) -> BraketAwsBackend:
+    def get_backend(
+        self, name: str | None = None, **kwargs
+    ) -> BraketAwsBackend | BraketLocalBackend:
         """Return a single backend matching the specified filters.
 
         Args:
             name (str): name of the selected backend
-            **kwargs: dict with additional options for filtering and storing aws session
+            **kwargs: dict with additional options for filtering and storing aws session.
+                Set ``emulator=True`` to return a local emulator backend for an AWS device.
         Returns:
-            BraketAwsBackend: a backend matching the filters.
+            BraketAwsBackend | BraketLocalBackend: a backend matching the filters.
         Raises:
             QiskitBackendNotFoundError: if no backend could be found or
             more than one backend matches the filters.
@@ -58,10 +76,12 @@ class BraketProvider:
 
         Args:
             name (str): name of the selected backend
-            **kwargs: dict with additional options for filtering and storing aws session
+            **kwargs: dict with additional options for filtering and storing aws session.
+                Set ``emulator=True`` to return local emulator backends for AWS devices.
         Returns:
-            BraketAwsBackend: a list of backends matching the filters.
+            BraketAwsBackend | BraketLocalBackend: a list of backends matching the filters.
         """
+        emulator = kwargs.pop("emulator", False)
         if kwargs.get("local"):
             return [
                 BraketLocalBackend(name="braket_sv"),
@@ -71,19 +91,18 @@ class BraketProvider:
         devices = AwsDevice.get_devices(names=names, **kwargs)
         # filter by supported devices
         # gate models are only supported
+        supported_gate_model_devices = [d for d in devices if _is_supported_gate_model(d)]
         supported_devices = [
-            d
-            for d in devices
-            if not isinstance(
-                d.properties,
-                (
-                    DwaveDeviceCapabilities,
-                    XanaduDeviceCapabilities,
-                    QueraDeviceCapabilities,
-                ),
-            )
+            d for d in supported_gate_model_devices if not emulator or not _is_aws_simulator(d)
         ]
-        return [
+        if emulator and name and not supported_devices:
+            simulator_matches = [d for d in supported_gate_model_devices if _is_aws_simulator(d)]
+            if simulator_matches:
+                raise QiskitBackendNotFoundError(
+                    f"Backend {name} does not support device emulation; emulators are available "
+                    "only for supported QPU devices."
+                )
+        backends = [
             BraketAwsBackend(
                 device=device,
                 provider=self,
@@ -94,6 +113,7 @@ class BraketProvider:
             )
             for device in supported_devices
         ]
+        return [backend.emulator() for backend in backends] if emulator else backends
 
 
 class AWSBraketProvider(BraketProvider):

--- a/test/unit_tests/test_braket_backend.py
+++ b/test/unit_tests/test_braket_backend.py
@@ -33,6 +33,7 @@ from qiskit_braket_provider import (
     exception,
 )
 from qiskit_braket_provider.providers.adapter import native_gate_connectivity
+from qiskit_braket_provider.providers.braket_backend import BraketBackend
 from test.unit_tests.mocks import (
     MOCK_RIGETTI_GATE_MODEL_QPU_CAPABILITIES,
     MOCK_RIGETTI_M_3_QPU_CAPABILITIES,
@@ -73,6 +74,11 @@ class TestBraketBackend(TestCase):
         """Test the repr method of BraketBackend."""
         backend = BraketLocalBackend(name="default")
         self.assertEqual(repr(backend), "BraketBackend[default]")
+
+    def test_base_qubit_labels(self):
+        """Test the default base qubit labels fallback."""
+        backend = BraketLocalBackend(name="default")
+        self.assertIsNone(BraketBackend.qubit_labels.fget(backend))
 
 
 class TestBraketLocalBackend(TestCase):
@@ -125,6 +131,21 @@ class TestBraketLocalBackend(TestCase):
         self.assertTrue(backend.is_emulator)
         self.assertTrue(backend._supports_program_sets)
         self.assertEqual(backend.qubit_labels, (3,))
+        self.assertEqual(backend._gateset, set(target.operation_names))
+
+    def test_local_backend_without_device_actions(self):
+        """Tests fallback when device properties expose no action map."""
+        target = copy.deepcopy(BraketLocalBackend().target)
+        backend = BraketLocalBackend(
+            name="emulator",
+            device=SimpleNamespace(
+                status="AVAILABLE",
+                properties=SimpleNamespace(action={}),
+            ),
+            target=target,
+        )
+
+        self.assertIsNone(backend.get_gateset())
         self.assertEqual(backend._gateset, set(target.operation_names))
 
     def test_local_backend_circuit(self):

--- a/test/unit_tests/test_braket_backend.py
+++ b/test/unit_tests/test_braket_backend.py
@@ -2,6 +2,7 @@
 
 import copy
 import unittest
+from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock, patch
 
@@ -10,7 +11,7 @@ from botocore import errorfactory
 from networkx import DiGraph, complete_graph
 from qiskit import QuantumCircuit, generate_preset_pass_manager, transpile
 from qiskit.circuit import Instruction as QiskitInstruction
-from qiskit.circuit.library import n_local
+from qiskit.circuit.library import XGate, n_local
 from qiskit.circuit.random import random_circuit
 from qiskit.primitives import BackendEstimatorV2
 from qiskit.quantum_info import SparsePauliOp, Statevector
@@ -81,6 +82,7 @@ class TestBraketLocalBackend(TestCase):
         """Tests local backend."""
         backend = BraketLocalBackend(name="default")
         self.assertTrue(backend)
+        self.assertFalse(backend.is_emulator)
         self.assertIsInstance(backend.target, Target)
         self.assertIsNone(backend.max_circuits)
         with self.assertRaises(NotImplementedError):
@@ -102,6 +104,28 @@ class TestBraketLocalBackend(TestCase):
         """Test local backend output"""
         first_backend = BraketLocalBackend(name="braket_dm")
         self.assertEqual(first_backend.name, "braket_dm")
+
+    def test_local_backend_requires_target_for_injected_device(self):
+        """Tests injected non-simulator devices require a supplied target."""
+        with self.assertRaisesRegex(ValueError, "Must specify a target"):
+            BraketLocalBackend(device=SimpleNamespace(status="AVAILABLE"))
+
+    def test_local_backend_with_injected_device_without_properties(self):
+        """Tests injected devices without properties can use explicit metadata."""
+        target = copy.deepcopy(BraketLocalBackend().target)
+        backend = BraketLocalBackend(
+            name="emulator",
+            device=SimpleNamespace(status="AVAILABLE"),
+            target=target,
+            is_emulator=True,
+            qubit_labels=(3,),
+            supports_program_sets=True,
+        )
+
+        self.assertTrue(backend.is_emulator)
+        self.assertTrue(backend._supports_program_sets)
+        self.assertEqual(backend.qubit_labels, (3,))
+        self.assertEqual(backend._gateset, set(target.operation_names))
 
     def test_local_backend_circuit(self):
         """Tests local backend with circuit."""
@@ -283,6 +307,48 @@ class TestBraketAwsBackend(TestCase):
             backend.measure_channel(0)
         with self.assertRaises(NotImplementedError):
             backend.control_channel([0, 1])
+
+    def test_device_backend_emulator(self):
+        """Tests creating a local emulator backend from an AWS backend."""
+        device = Mock()
+        device.properties = MOCK_RIGETTI_GATE_MODEL_QPU_CAPABILITIES.copy(deep=True)
+        device.properties.action["braket.ir.openqasm.program_set"] = {
+            "actionType": "braket.ir.openqasm.program_set",
+            "version": ["1"],
+            "maximumExecutables": 500,
+            "maximumTotalShots": 1000000,
+        }
+        device.gate_calibrations = None
+        device.type = "QPU"
+        device.topology_graph = MOCK_RIGETTI_TOPOLOGY_GRAPH
+        task = Mock(spec=LocalQuantumTask)
+        task.id = "0"
+        emulator_device = SimpleNamespace(status="AVAILABLE", run=Mock(return_value=task))
+        device.emulator.return_value = emulator_device
+
+        backend = BraketAwsBackend(device=device, description="AWS Device: Rigetti Aspen-M-3.")
+        emulator = backend.emulator()
+        circuit = QuantumCircuit(1)
+        circuit.h(0)
+        emulator.run(circuit, shots=1)
+
+        self.assertIsInstance(emulator, BraketLocalBackend)
+        self.assertIs(emulator._device, emulator_device)
+        self.assertTrue(emulator.is_emulator)
+        self.assertEqual(emulator.name, backend.name)
+        self.assertEqual(emulator.target.instructions, backend.target.instructions)
+        self.assertIsNot(emulator.target, backend.target)
+        self.assertEqual(emulator._supports_program_sets, backend._supports_program_sets)
+        self.assertEqual(emulator.qubit_labels, backend.qubit_labels)
+        self.assertEqual(
+            emulator_device.run.call_args.kwargs["task_specification"].qubits,
+            {backend.qubit_labels[0]},
+        )
+        device.emulator.assert_called_once_with()
+
+        emulator.target.add_instruction(XGate(), {(0,): None})
+        self.assertIn("x", emulator.target.operation_names)
+        self.assertNotIn("x", backend.target.operation_names)
 
     def test_invalid_identifiers(self):
         """Test the invalid identifiers of BraketAwsBackend."""

--- a/test/unit_tests/test_braket_estimator.py
+++ b/test/unit_tests/test_braket_estimator.py
@@ -42,6 +42,36 @@ class TestBraketEstimator(TestCase):
         with self.assertRaises(ValueError):
             BraketEstimator(backend)
 
+    def test_run_emulator_backend_with_mocked_device(self):
+        """Tests estimator execution through an emulator-shaped local backend."""
+        mock_task = Mock()
+        mock_task.id = "test-task-id"
+        mock_device = Mock()
+        mock_device.status = "AVAILABLE"
+        mock_device.properties = None
+        mock_device.run.return_value = mock_task
+        backend = BraketLocalBackend(
+            name="emulator",
+            device=mock_device,
+            target=BraketLocalBackend().target,
+            is_emulator=True,
+            qubit_labels=(4,),
+            supports_program_sets=True,
+        )
+        estimator = BraketEstimator(backend)
+        circuit = QuantumCircuit(1)
+        circuit.h(0)
+        observable = SparsePauliOp(["Z"])
+
+        job = estimator.run([(circuit, observable)], precision=0.01)
+
+        mock_device.run.assert_called_once()
+        program_set = mock_device.run.call_args.args[0]
+        self.assertIsInstance(program_set, ProgramSet)
+        self.assertIs(job.program_set, program_set)
+        self.assertEqual(program_set[0].circuit.qubits, {4})
+        self.assertEqual(program_set.total_shots, 10000)
+
     def test_simple_pub(self):
         """Test a simple pub with no broadcasting."""
         qc = QuantumCircuit(2)

--- a/test/unit_tests/test_braket_provider.py
+++ b/test/unit_tests/test_braket_provider.py
@@ -1,6 +1,7 @@
 """Tests for Amazon Braket provider."""
 
 import uuid
+from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock, patch
 
@@ -24,10 +25,12 @@ from qiskit_braket_provider import (
 )
 from qiskit_braket_provider.providers.braket_backend import BraketBackend
 from test.unit_tests.mocks import (
+    MOCK_GATE_MODEL_SIMULATOR_CAPABILITIES,
     MOCK_GATE_MODEL_SIMULATOR_SV,
     MOCK_GATE_MODEL_SIMULATOR_TN,
     MOCK_RIGETTI_GATE_MODEL_M_3_QPU,
     MOCK_RIGETTI_M_3_QPU_CAPABILITIES,
+    MOCK_RIGETTI_TOPOLOGY_GRAPH,
     SIMULATOR_REGION,
 )
 
@@ -92,6 +95,82 @@ class TestBraketProvider(TestCase):
         provider = BraketProvider()
 
         self.assertIsInstance(provider.backends(name=None, local="sv1")[0], BraketLocalBackend)
+
+    @patch("qiskit_braket_provider.providers.braket_provider.AwsDevice.get_devices")
+    def test_provider_get_backend_emulator(self, mock_get_devices: MagicMock):
+        """Tests getting a local emulator backend for an AWS backend."""
+        emulator_device = SimpleNamespace(status="AVAILABLE")
+        mock_device = Mock()
+        mock_device.name = "Aspen-M-3"
+        mock_device.provider_name = "Rigetti"
+        mock_device.properties = MOCK_RIGETTI_M_3_QPU_CAPABILITIES.copy(deep=True)
+        mock_device.properties.service = Mock()
+        mock_device.properties.service.updatedAt = "2023-06-02T17:00:00+00:00"
+        mock_device.gate_calibrations = None
+        mock_device.type = AwsDeviceType.QPU
+        mock_device.topology_graph = MOCK_RIGETTI_TOPOLOGY_GRAPH
+        mock_device.emulator.return_value = emulator_device
+        mock_get_devices.return_value = [mock_device]
+
+        backend = BraketProvider().get_backend(
+            "Aspen-M-3", emulator=True, aws_session=self.mock_session
+        )
+
+        self.assertIsInstance(backend, BraketLocalBackend)
+        self.assertIs(backend._device, emulator_device)
+        self.assertTrue(backend.is_emulator)
+        self.assertEqual(backend.name, "Aspen-M-3")
+        mock_device.emulator.assert_called_once_with()
+        mock_get_devices.assert_called_once_with(names=["Aspen-M-3"], aws_session=self.mock_session)
+
+    @patch("qiskit_braket_provider.providers.braket_provider.AwsDevice.get_devices")
+    def test_provider_get_backend_emulator_rejects_managed_simulator(
+        self, mock_get_devices: MagicMock
+    ):
+        """Tests named managed simulators give a clear emulator error."""
+        mock_device = Mock()
+        mock_device.name = "SV1"
+        mock_device.properties = MOCK_GATE_MODEL_SIMULATOR_CAPABILITIES.copy(deep=True)
+        mock_device.type = AwsDeviceType.SIMULATOR
+        mock_get_devices.return_value = [mock_device]
+
+        with self.assertRaisesRegex(
+            QiskitBackendNotFoundError, "does not support device emulation"
+        ):
+            BraketProvider().get_backend("SV1", emulator=True, aws_session=self.mock_session)
+
+        mock_device.emulator.assert_not_called()
+        mock_get_devices.assert_called_once_with(names=["SV1"], aws_session=self.mock_session)
+
+    @patch("qiskit_braket_provider.providers.braket_provider.AwsDevice.get_devices")
+    def test_provider_backends_emulator_filters_managed_simulators(
+        self, mock_get_devices: MagicMock
+    ):
+        """Tests emulator discovery excludes AWS managed simulators."""
+        emulator_device = SimpleNamespace(status="AVAILABLE")
+        qpu_device = Mock()
+        qpu_device.name = "Aspen-M-3"
+        qpu_device.provider_name = "Rigetti"
+        qpu_device.properties = MOCK_RIGETTI_M_3_QPU_CAPABILITIES.copy(deep=True)
+        qpu_device.properties.service = Mock()
+        qpu_device.properties.service.updatedAt = "2023-06-02T17:00:00+00:00"
+        qpu_device.gate_calibrations = None
+        qpu_device.type = AwsDeviceType.QPU
+        qpu_device.topology_graph = MOCK_RIGETTI_TOPOLOGY_GRAPH
+        qpu_device.emulator.return_value = emulator_device
+        simulator_device = Mock()
+        simulator_device.name = "SV1"
+        simulator_device.properties = MOCK_GATE_MODEL_SIMULATOR_CAPABILITIES.copy(deep=True)
+        simulator_device.type = AwsDeviceType.SIMULATOR
+        mock_get_devices.return_value = [qpu_device, simulator_device]
+
+        backends = BraketProvider().backends(emulator=True, aws_session=self.mock_session)
+
+        self.assertEqual(len(backends), 1)
+        self.assertIsInstance(backends[0], BraketLocalBackend)
+        self.assertIs(backends[0]._device, emulator_device)
+        qpu_device.emulator.assert_called_once_with()
+        simulator_device.emulator.assert_not_called()
 
     def test_real_devices(self):
         """Tests real devices."""

--- a/test/unit_tests/test_braket_sampler.py
+++ b/test/unit_tests/test_braket_sampler.py
@@ -1,6 +1,7 @@
 """Tests for BraketSampler."""
 
 from unittest import TestCase
+from unittest.mock import Mock
 
 import numpy as np
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
@@ -10,7 +11,7 @@ from qiskit.primitives.containers import BitArray
 from qiskit.primitives.containers.sampler_pub import SamplerPub
 
 from braket.circuits import Circuit
-from braket.program_sets import CircuitBinding
+from braket.program_sets import CircuitBinding, ProgramSet
 from qiskit_braket_provider.providers import BraketLocalBackend
 from qiskit_braket_provider.providers.braket_sampler import BraketSampler
 
@@ -55,6 +56,36 @@ class TestBraketSampler(TestCase):
             self.sampler.run([(qc, [0, 1, 2, 3], 100), (qc, [0, 1, 2, 3], 200)])
 
         self.assertIn("same shots", str(context.exception))
+
+    def test_run_emulator_backend_with_mocked_device(self):
+        """Tests sampler execution through an emulator-shaped local backend."""
+        mock_task = Mock()
+        mock_task.id = "test-task-id"
+        mock_device = Mock()
+        mock_device.status = "AVAILABLE"
+        mock_device.properties = None
+        mock_device.run.return_value = mock_task
+        backend = BraketLocalBackend(
+            name="emulator",
+            device=mock_device,
+            target=BraketLocalBackend().target,
+            is_emulator=True,
+            qubit_labels=(4,),
+            supports_program_sets=True,
+        )
+        sampler = BraketSampler(backend)
+        circuit = QuantumCircuit(1, 1)
+        circuit.h(0)
+        circuit.measure(0, 0)
+
+        job = sampler.run([(circuit,)], shots=5)
+
+        mock_device.run.assert_called_once()
+        program_set = mock_device.run.call_args.args[0]
+        self.assertIsInstance(program_set, ProgramSet)
+        self.assertIs(job.program_set, program_set)
+        self.assertEqual(program_set[0].qubits, {4})
+        self.assertEqual(program_set.total_shots, 5)
 
     def test_run_local_multiple_registers(self):
         """Tests that correct results are returned for circuits with multiple registers"""


### PR DESCRIPTION
*Issue #, if available:*  https://github.com/amazon-braket/qiskit-braket-provider/issues/325

*Description of changes:*

This change addresses https://github.com/amazon-braket/qiskit-braket-provider/issues/325 by adding **a requested minimal path** for using Amazon Braket SDK device emulators from Qiskit. A `BraketAwsBackend` can now create its local emulator through a dedicated `emulator()` method, and `BraketProvider.get_backend(..., emulator=True)` uses that path when resolving supported QPU devices.

The emulator is represented as a `BraketLocalBackend` with a custom target copied from the source AWS backend. This matches the Braket SDK model: `AwsDevice.emulator()` returns a local device object, but that object does not expose the full device properties needed to build a Qiskit target directly. Reusing the source backend target, gateset fallback, qubit labels, and program-set support keeps transpilation and primitive execution aligned with the original device while avoiding a separate AWS-backend-shaped emulator implementation.

The update also marks emulator-backed local backends with `is_emulator`, rejects AWS managed simulators such as `SV1` for `emulator=True`, and adds focused coverage for provider lookup, backend construction, sampler execution, and estimator execution.

*Testing done:* tox pass (327 passed)

  py311: commands succeeded
  py312: commands succeeded
  py313: commands succeeded
  linters: commands succeeded
  coverage: commands succeeded
  docs: commands succeeded

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md) doc
- [X] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md#pr-title-format)
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/README.md) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
