### PR TITLE
feat: group commuting observables in BraketEstimator

### DIFF
--- a/docs/tutorials/6_tutorial_primitives.ipynb
+++ b/docs/tutorials/6_tutorial_primitives.ipynb
@@ -34,7 +34,13 @@
    "source": [
     "## BraketEstimator\n",
     "\n",
-    "An estimator primitive computes the expectation values of one or multiple observables with respect to states prepared by quantum circuits. The circuits may be parametrized, with input values specified alongside the circuit and observable. The BraketEstimator constructs and runs a program set from the given estimator PUBs, which are (circuit, observable, parameter (optional)) triplets."
+    "An estimator primitive computes the expectation values of one or multiple observables with respect to states prepared by quantum circuits. The circuits may be parametrized, with input values specified alongside the circuit and observable. The BraketEstimator constructs and runs a program set from the given estimator PUBs, which are (circuit, observable, parameter (optional)) triplets.\n",
+    "\n",
+    "By default, `BraketEstimator` groups qubit-wise commuting Pauli terms before execution (`abelian_grouping=True`). Grouping can reduce the number of Braket executions by measuring compatible terms in one shared basis, but finite-shot covariance can differ from measuring each term independently. To preserve the legacy per-term execution layout, pass `abelian_grouping=False` when running the estimator:\n",
+    "\n",
+    "```python\n",
+    "task = estimator.run([estimator_pub], abelian_grouping=False)\n",
+    "```"
    ]
   },
   {

--- a/qiskit_braket_provider/providers/braket_estimator.py
+++ b/qiskit_braket_provider/providers/braket_estimator.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import TypeAlias
+from typing import SupportsFloat, SupportsIndex, TypeAlias, cast
 from uuid import uuid4
 
 import numpy as np
@@ -23,7 +23,7 @@ from braket.circuits.observables import Sum
 from braket.program_sets import CircuitBinding, ParameterSets, ProgramSet
 from braket.tasks import ProgramSetQuantumTaskResult, QuantumTask
 from braket.tasks.measurement_utils import samples_from_measurements
-from braket.tasks.program_set_quantum_task_result import MeasuredEntry
+from braket.tasks.program_set_quantum_task_result import CompositeEntry, MeasuredEntry
 from qiskit_braket_provider.providers.adapter import (
     rename_parameter,
     to_braket,
@@ -63,6 +63,9 @@ _ESTIMATOR_OPTION_NAMES = frozenset(BraketEstimatorOptions.__dataclass_fields__)
 
 
 _ParameterIndex: TypeAlias = tuple[int, ...]
+_ObservableValue: TypeAlias = SparsePauliOp | dict[str, complex]
+_TermRoutesByParam: TypeAlias = dict[_ParameterIndex, dict[str, dict[complex, list[int]]]]
+_GroupedPaulis: TypeAlias = list[tuple[str, tuple[str, ...]]]
 
 
 @dataclass(frozen=True)
@@ -395,7 +398,7 @@ class BraketEstimator(BaseEstimatorV2):
         options: BraketEstimatorOptions | dict[str, object] | None,
         run_options: dict[str, object],
     ) -> BraketEstimatorOptions:
-        option_values = (
+        option_values: dict[str, object] = (
             {
                 "default_precision": options.default_precision,
                 "abelian_grouping": options.abelian_grouping,
@@ -418,8 +421,12 @@ class BraketEstimator(BaseEstimatorV2):
         if unknown_options:
             raise ValueError(f"Unsupported estimator options: {unknown_options}")
 
+        default_precision_value = cast(
+            "str | SupportsFloat | SupportsIndex",
+            option_values.pop("default_precision", _DEFAULT_PRECISION),
+        )
         try:
-            default_precision = float(option_values.pop("default_precision", _DEFAULT_PRECISION))
+            default_precision = float(default_precision_value)
         except (TypeError, ValueError) as ex:
             raise TypeError("default_precision must be a positive float") from ex
         abelian_grouping = option_values.pop("abelian_grouping", True)
@@ -519,7 +526,10 @@ class BraketEstimator(BaseEstimatorV2):
         parameter_indices = np.empty(param_values.shape, dtype=object)
         for index in np.ndindex(param_values.shape):
             parameter_indices[index] = index
-        return np.broadcast_arrays(observables, parameter_indices)
+        observables_broadcast, parameter_indices_broadcast = np.broadcast_arrays(
+            observables, parameter_indices
+        )
+        return observables_broadcast, parameter_indices_broadcast
 
     @staticmethod
     def _per_term_bindings(
@@ -619,20 +629,24 @@ class BraketEstimator(BaseEstimatorV2):
         param_indices_broadcast: np.ndarray,
         param_values: BindingsArray,
     ) -> _PubMetadata:
-        term_routes_by_param = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
-        identity_routes = defaultdict(list)
-        for position, (param_indices, obs) in enumerate(
+        term_routes_by_param: _TermRoutesByParam = defaultdict(
+            lambda: defaultdict(lambda: defaultdict(list))
+        )
+        identity_routes: dict[complex, list[int]] = defaultdict(list)
+        for position, (param_indices_value, obs_value) in enumerate(
             zip(param_indices_broadcast.flatten(), observables_broadcast.flatten(), strict=True)
         ):
+            param_indices = cast("_ParameterIndex", param_indices_value)
+            obs = cast("_ObservableValue", obs_value)
             for pauli, coefficient in BraketEstimator._observable_terms(obs):
                 if BraketEstimator._is_identity(pauli):
                     identity_routes[coefficient].append(position)
                 else:
                     term_routes_by_param[param_indices][pauli][coefficient].append(position)
 
-        basis_index_by_param_and_term = {}
-        parameter_indices_by_bases = defaultdict(list)
-        group_cache = {}
+        basis_index_by_param_and_term: dict[_ParameterIndex, dict[str, int]] = {}
+        parameter_indices_by_bases: dict[tuple[str, ...], list[_ParameterIndex]] = defaultdict(list)
+        group_cache: dict[tuple[str, ...], _GroupedPaulis] = {}
         for param_indices, term_routes in sorted(term_routes_by_param.items(), key=str):
             labels_key = tuple(sorted(term_routes))
             if labels_key not in group_cache:
@@ -671,7 +685,7 @@ class BraketEstimator(BaseEstimatorV2):
             )
 
             param_idx_map = {pk: idx for idx, pk in enumerate(matching_param_indices)}
-            routed_terms_by_basis = defaultdict(list)
+            routed_terms_by_basis: dict[int, list[_RoutingTarget]] = defaultdict(list)
             for param_indices in matching_param_indices:
                 for pauli, coefficient_routes in sorted(
                     term_routes_by_param[param_indices].items()
@@ -718,11 +732,11 @@ class BraketEstimator(BaseEstimatorV2):
         )
 
     @staticmethod
-    def _make_obs_key(obs_val: SparsePauliOp | dict[str, float]) -> str:
+    def _make_obs_key(obs_val: _ObservableValue) -> str:
         """Create a hashable key for observable values.
 
         Args:
-            obs_val (SparsePauliOp | dict[str, float]): A SparsePauliOp observable
+            obs_val (SparsePauliOp | dict[str, complex]): A SparsePauliOp observable
                 or dict representation
 
         Returns:
@@ -785,7 +799,7 @@ class BraketEstimator(BaseEstimatorV2):
 
     @staticmethod
     def _group_paulis(paulis: Iterable[str]) -> list[tuple[str, tuple[str, ...]]]:
-        grouped = defaultdict(list)
+        grouped: dict[str, list[str]] = defaultdict(list)
         op = SparsePauliOp.from_list([(pauli, 1.0) for pauli in sorted(paulis)])
         for commuting_group in op.group_commuting(qubit_wise=True):
             terms = tuple(pauli.to_label() for pauli in commuting_group.paulis)
@@ -848,7 +862,7 @@ class BraketEstimator(BaseEstimatorV2):
         return BraketEstimator._standard_error(samples)
 
     @staticmethod
-    def _sum_standard_error(program_result: object, param_idx: int) -> float:
+    def _sum_standard_error(program_result: CompositeEntry, param_idx: int) -> float:
         num_observables = len(program_result.observables)
         start = param_idx * num_observables
         return sum(
@@ -909,9 +923,10 @@ class BraketEstimator(BaseEstimatorV2):
                 binding_location = metadata.binding_locations.get((pub_index, local_binding_idx))
                 if binding_location is None:
                     raise ValueError("No task result location was recorded for estimator binding")
-                program_result = task_results[binding_location.task_index][
-                    binding_location.result_index
-                ]
+                program_result = cast(
+                    "CompositeEntry",
+                    task_results[binding_location.task_index][binding_location.result_index],
+                )
                 num_observables = len(program_result.observables)
 
                 if local_binding_idx in pub_meta.qwc_binding_metadata:

--- a/qiskit_braket_provider/providers/braket_estimator.py
+++ b/qiskit_braket_provider/providers/braket_estimator.py
@@ -1,17 +1,29 @@
 from collections import defaultdict
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import TypeAlias
+from uuid import uuid4
 
 import numpy as np
-from qiskit.primitives import BaseEstimatorV2, DataBin, EstimatorPubLike, PrimitiveResult, PubResult
+from qiskit.primitives import (
+    BaseEstimatorV2,
+    BasePrimitiveJob,
+    DataBin,
+    EstimatorPubLike,
+    PrimitiveResult,
+    PubResult,
+)
 from qiskit.primitives.containers.bindings_array import BindingsArray
 from qiskit.primitives.containers.estimator_pub import EstimatorPub
+from qiskit.providers import JobStatus
 from qiskit.quantum_info import SparsePauliOp
 
 from braket.circuits.observables import Sum
 from braket.program_sets import CircuitBinding, ParameterSets, ProgramSet
-from braket.tasks import ProgramSetQuantumTaskResult
+from braket.tasks import ProgramSetQuantumTaskResult, QuantumTask
+from braket.tasks.measurement_utils import samples_from_measurements
+from braket.tasks.program_set_quantum_task_result import MeasuredEntry
 from qiskit_braket_provider.providers.adapter import (
     rename_parameter,
     to_braket,
@@ -19,8 +31,66 @@ from qiskit_braket_provider.providers.adapter import (
 )
 from qiskit_braket_provider.providers.braket_backend import BraketBackend
 from qiskit_braket_provider.providers.braket_primitive_task import BraketPrimitiveTask
+from qiskit_braket_provider.providers.braket_quantum_task import _TASK_STATUS_MAP
 
 _DEFAULT_PRECISION = 0.015625  # Same value as BackendEstimatorV2
+
+
+@lru_cache(maxsize=4096)
+def _translate_pauli_observable(pauli: str) -> object:
+    return translate_sparse_pauli_op(SparsePauliOp.from_list([(pauli, 1.0)]))
+
+
+@dataclass
+class BraketEstimatorOptions:
+    """Options for :class:`~.BraketEstimator`."""
+
+    default_precision: float = _DEFAULT_PRECISION
+    """The default precision to use if no run-level or pub-level precision is specified."""
+
+    abelian_grouping: bool = True
+    """
+    Whether to group qubit-wise commuting Pauli terms before execution.
+
+    Grouping reduces Braket executions by reconstructing compatible Pauli terms from the same
+    measurement shots. This preserves expectation-value semantics but changes finite-shot
+    covariance compared with measuring each term independently. The reported standard errors for
+    grouped Pauli sums use conservative per-term accumulation and are not fully covariance-aware.
+    """
+
+
+_ESTIMATOR_OPTION_NAMES = frozenset(BraketEstimatorOptions.__dataclass_fields__)
+
+
+_ParameterIndex: TypeAlias = tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class _RoutingTarget:
+    pauli: str
+    coefficient: complex
+    parameter_indices: _ParameterIndex
+    positions: tuple[int, ...]
+    targets: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class _MeasurementGroup:
+    covering_pauli: str
+    routed_terms: tuple[_RoutingTarget, ...]
+
+
+@dataclass(frozen=True)
+class _IdentityContribution:
+    coefficient: complex
+    positions: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class _QWCBindingMetadata:
+    parameter_index_map: dict[_ParameterIndex, int]
+    measurement_groups: tuple[_MeasurementGroup, ...]
+
 
 # (broadcast_position, observable_index_or_None_for_Sum, parameter_set_index)
 _ResultMapEntry: TypeAlias = tuple[int, int | None, int]
@@ -29,17 +99,134 @@ _ResultMap: TypeAlias = dict[int, list[_ResultMapEntry]]
 
 @dataclass
 class _PubMetadata:
+    bindings: list[CircuitBinding]
     num_bindings: int
     binding_to_result_map: _ResultMap
     sum_binding_indices: set[int]
+    qwc_binding_metadata: dict[int, _QWCBindingMetadata]
+    identity_contributions: tuple[_IdentityContribution, ...]
 
 
 @dataclass
 class _JobMetadata:
     pubs: list[EstimatorPub]
     pub_metadata: list[_PubMetadata]
-    precision: float
-    shots: int
+    pub_precisions: list[float]
+    pub_shots: list[int]
+    binding_locations: dict[tuple[int, int], "_BindingLocation"]
+
+
+@dataclass(frozen=True)
+class _BindingRecord:
+    pub_index: int
+    binding_index: int
+    binding: CircuitBinding
+
+
+@dataclass(frozen=True)
+class _BindingLocation:
+    task_index: int
+    result_index: int
+
+
+class _ConstantResultTask(BasePrimitiveJob[PrimitiveResult[PubResult], JobStatus]):
+    """Already-complete primitive job for estimator pubs that need no device execution."""
+
+    def __init__(self, result: PrimitiveResult[PubResult]) -> None:
+        super().__init__(job_id=f"constant-result-{uuid4()}")
+        self._result = result
+
+    def result(self) -> PrimitiveResult[PubResult]:
+        return self._result
+
+    def status(self) -> JobStatus:
+        return JobStatus.DONE
+
+    def cancel(self) -> None:
+        pass
+
+    def done(self) -> bool:
+        return True
+
+    def running(self) -> bool:
+        return False
+
+    def cancelled(self) -> bool:
+        return False
+
+    def in_final_state(self) -> bool:
+        return True
+
+
+class _CompositePrimitiveTask(BasePrimitiveJob[PrimitiveResult[PubResult], JobStatus]):
+    """Primitive job that merges multiple Braket ProgramSet tasks into one result."""
+
+    def __init__(
+        self,
+        tasks: Sequence[QuantumTask],
+        result_translator: Callable[[list[ProgramSetQuantumTaskResult]], PrimitiveResult],
+        program_sets: Sequence[ProgramSet],
+    ) -> None:
+        super().__init__(job_id=";".join(task.id for task in tasks))
+        self._tasks = list(tasks)
+        self._result_translator = result_translator
+        self._program_sets = list(program_sets)
+        self._result = None
+
+    @property
+    def program_sets(self) -> list[ProgramSet]:
+        """The ProgramSets submitted by this primitive job."""
+        return self._program_sets
+
+    @property
+    def program_set(self) -> ProgramSet:
+        """The only ProgramSet submitted by this job."""
+        if len(self._program_sets) != 1:
+            raise ValueError("Composite primitive job has multiple program sets")
+        return self._program_sets[0]
+
+    def result(self) -> PrimitiveResult:
+        if self._result is None:
+            self._result = self._result_translator([task.result() for task in self._tasks])
+        return self._result
+
+    def status(self) -> JobStatus:
+        statuses = [self._get_task_status(task) for task in self._tasks]
+        if all(status == JobStatus.DONE for status in statuses):
+            return JobStatus.DONE
+        for terminal_status in (JobStatus.ERROR, JobStatus.CANCELLED):
+            if any(status == terminal_status for status in statuses):
+                return terminal_status
+        for active_status in (JobStatus.RUNNING, JobStatus.VALIDATING, JobStatus.QUEUED):
+            if any(status == active_status for status in statuses):
+                return active_status
+        return JobStatus.INITIALIZING
+
+    def cancel(self) -> None:
+        for task in self._tasks:
+            task.cancel()
+
+    def job_id(self) -> str:
+        return ";".join(task.id for task in self._tasks)
+
+    def done(self) -> bool:
+        return self.status() == JobStatus.DONE
+
+    def running(self) -> bool:
+        return any(self._get_task_status(task) == JobStatus.RUNNING for task in self._tasks)
+
+    def cancelled(self) -> bool:
+        return all(self._get_task_status(task) == JobStatus.CANCELLED for task in self._tasks)
+
+    def in_final_state(self) -> bool:
+        return all(
+            self._get_task_status(task) in [JobStatus.DONE, JobStatus.ERROR, JobStatus.CANCELLED]
+            for task in self._tasks
+        )
+
+    @staticmethod
+    def _get_task_status(task: QuantumTask) -> JobStatus:
+        return _TASK_STATUS_MAP[task.state()]
 
 
 class BraketEstimator(BaseEstimatorV2):
@@ -54,7 +241,9 @@ class BraketEstimator(BaseEstimatorV2):
         *,
         verbatim: bool = False,
         optimization_level: int = 0,
-        **options,
+        max_program_set_executables: int | None = None,
+        options: BraketEstimatorOptions | dict[str, object] | None = None,
+        **run_options,
     ) -> None:
         """
         Initialize the Braket estimator.
@@ -73,71 +262,223 @@ class BraketEstimator(BaseEstimatorV2):
                 * 3: high optimization - gate resynthesis and unitary-breaking passes
 
                 Default: 0.
+            max_program_set_executables (int | None): Optional maximum number of executables to
+                include in each submitted ProgramSet. If ``None``, no estimator-level chunking is
+                applied. Default: ``None``.
+            options (BraketEstimatorOptions | dict[str, object] | None): Estimator options
+                controlling default precision and qubit-wise commuting observable grouping.
+                Supported keys are ``default_precision`` and ``abelian_grouping``. For
+                compatibility with previous provider code, these estimator options can also be
+                passed directly as constructor keyword arguments.
+                When ``abelian_grouping`` is enabled, compatible Pauli terms can share the same
+                measurement shots, reducing executions but changing finite-shot covariance compared
+                with independent per-term measurements.
+            **run_options: Additional options forwarded to the underlying Braket
+                ``device.run(...)`` call.
         """
         if not backend._supports_program_sets:
             raise ValueError("Braket device must support program sets")
         self._backend = backend
         self._verbatim = verbatim
         self._optimization_level = optimization_level
-        self._options = options
+        self._max_program_set_executables = max_program_set_executables
+        self._options = BraketEstimator._coerce_estimator_options(options, run_options)
+        self._run_options = run_options
+
+    @property
+    def options(self) -> BraketEstimatorOptions:
+        """Return the estimator options."""
+        return self._options
 
     def run(
-        self, pubs: Iterable[EstimatorPubLike], *, precision: float = _DEFAULT_PRECISION
-    ) -> BraketPrimitiveTask:
+        self,
+        pubs: Iterable[EstimatorPubLike],
+        *,
+        precision: float | None = None,
+        abelian_grouping: bool | None = None,
+    ) -> BasePrimitiveJob[PrimitiveResult[PubResult], JobStatus]:
         """
         Run estimator on the given pubs.
 
         Args:
             pubs (Iterable[EstimatorPubLike]): An iterable of ``EstimatorPubLike`` objects
                 to estimate.
-            precision (float): Target precision for expectation value estimates.
-                Default: 0.015625.
+            precision (float | None): Target precision for expectation value estimates.
+                If ``None``, the estimator's ``default_precision`` option is used.
+            abelian_grouping (bool | None): Whether to group qubit-wise commuting Pauli
+                terms before execution. If ``None``, the estimator's ``abelian_grouping``
+                option is used. Default: ``None``.
 
         Returns:
-            BraketPrimitiveTask: A job object containing the estimator results.
+            BasePrimitiveJob: A job object containing the estimator results.
+
+        Notes:
+            Qubit-wise commuting Pauli terms can be reconstructed from shared Braket
+            measurements when ``abelian_grouping`` is enabled. Use
+            ``abelian_grouping=False`` to preserve legacy per-term execution shape for a
+            specific run.
         """
+        precision = self._options.default_precision if precision is None else precision
+        if abelian_grouping is None:
+            abelian_grouping = self._options.abelian_grouping
+        elif not isinstance(abelian_grouping, bool):
+            raise TypeError("abelian_grouping must be a bool")
+
         coerced_pubs = [EstimatorPub.coerce(pub) for pub in pubs]
-        pub_precision = BraketEstimator._pub_precision(coerced_pubs)
+        pub_precisions = [
+            BraketEstimator._effective_precision(pub, precision) for pub in coerced_pubs
+        ]
+        pub_shots = [
+            BraketEstimator._precision_to_shots(pub_precision) for pub_precision in pub_precisions
+        ]
 
-        all_bindings = []
         pub_metadata = []  # Track which bindings belong to which pub
+        records_by_shots: dict[int, list[_BindingRecord]] = defaultdict(list)
 
-        for pub in coerced_pubs:
-            bindings, binding_to_result_map, sum_binding_indices = self._translate_pub(pub)
-            all_bindings.extend(bindings)
-            pub_metadata.append(
-                _PubMetadata(
-                    num_bindings=len(bindings),
-                    binding_to_result_map=binding_to_result_map,
-                    sum_binding_indices=sum_binding_indices,
+        for pub_index, (pub, shots) in enumerate(zip(coerced_pubs, pub_shots, strict=True)):
+            metadata = self._translate_pub(pub, abelian_grouping=abelian_grouping)
+            for binding_index, binding in enumerate(metadata.bindings):
+                records_by_shots[shots].append(
+                    _BindingRecord(
+                        pub_index=pub_index,
+                        binding_index=binding_index,
+                        binding=binding,
+                    )
                 )
-            )
+            pub_metadata.append(metadata)
 
-        shots = int(np.ceil(1.0 / (pub_precision if pub_precision is not None else precision) ** 2))
-        program_set = ProgramSet(all_bindings, shots_per_executable=shots)
-        return BraketPrimitiveTask(
-            self._backend._device.run(program_set, **self._options),
-            lambda result: BraketEstimator._translate_result(
-                result,
-                _JobMetadata(
-                    pubs=coerced_pubs, pub_metadata=pub_metadata, precision=precision, shots=shots
-                ),
-            ),
-            program_set,
+        binding_locations: dict[tuple[int, int], _BindingLocation] = {}
+        job_metadata = _JobMetadata(
+            pubs=coerced_pubs,
+            pub_metadata=pub_metadata,
+            pub_precisions=pub_precisions,
+            pub_shots=pub_shots,
+            binding_locations=binding_locations,
+        )
+        if not records_by_shots:
+            return _ConstantResultTask(BraketEstimator._translate_result(None, job_metadata))
+
+        tasks: list[QuantumTask] = []
+        program_sets: list[ProgramSet] = []
+        for shots, records in sorted(records_by_shots.items()):
+            for chunk in BraketEstimator._chunk_binding_records(
+                records,
+                max_executables=self._max_program_set_executables,
+            ):
+                task_index = len(tasks)
+                program_set = ProgramSet(
+                    [record.binding for record in chunk],
+                    shots_per_executable=shots,
+                )
+                for result_index, record in enumerate(chunk):
+                    binding_locations[record.pub_index, record.binding_index] = _BindingLocation(
+                        task_index=task_index,
+                        result_index=result_index,
+                    )
+                program_sets.append(program_set)
+                tasks.append(self._backend._device.run(program_set, **self._run_options))
+
+        if len(tasks) == 1:
+            return BraketPrimitiveTask(
+                tasks[0],
+                lambda result: BraketEstimator._translate_result([result], job_metadata),
+                program_sets[0],
+            )
+        return _CompositePrimitiveTask(
+            tasks,
+            lambda results: BraketEstimator._translate_result(results, job_metadata),
+            program_sets,
         )
 
     @staticmethod
-    def _pub_precision(pubs: list[EstimatorPub]) -> float:
-        precision_values = {pub.precision for pub in pubs}
-        if len(precision_values) > 1:
-            raise ValueError(f"All pubs must have the same precision, got: {precision_values}")
-        return next(iter(precision_values))
+    def _coerce_estimator_options(
+        options: BraketEstimatorOptions | dict[str, object] | None,
+        run_options: dict[str, object],
+    ) -> BraketEstimatorOptions:
+        option_values = (
+            {
+                "default_precision": options.default_precision,
+                "abelian_grouping": options.abelian_grouping,
+            }
+            if isinstance(options, BraketEstimatorOptions)
+            else dict(options or {})
+        )
 
-    def _translate_pub(
-        self, pub: EstimatorPub
-    ) -> tuple[list[CircuitBinding], _ResultMap, set[int]]:
+        for option_name in _ESTIMATOR_OPTION_NAMES:
+            if option_name not in run_options:
+                continue
+            if option_name in option_values:
+                raise ValueError(
+                    f"Specify estimator option {option_name!r} either in options or as a "
+                    "constructor keyword argument, not both"
+                )
+            option_values[option_name] = run_options.pop(option_name)
+
+        unknown_options = sorted(set(option_values) - _ESTIMATOR_OPTION_NAMES)
+        if unknown_options:
+            raise ValueError(f"Unsupported estimator options: {unknown_options}")
+
+        try:
+            default_precision = float(option_values.pop("default_precision", _DEFAULT_PRECISION))
+        except (TypeError, ValueError) as ex:
+            raise TypeError("default_precision must be a positive float") from ex
+        abelian_grouping = option_values.pop("abelian_grouping", True)
+        if not isinstance(abelian_grouping, bool):
+            raise TypeError("abelian_grouping must be a bool")
+        if default_precision <= 0:
+            raise ValueError(f"default_precision must be positive, got: {default_precision}")
+        return BraketEstimatorOptions(
+            default_precision=default_precision,
+            abelian_grouping=abelian_grouping,
+        )
+
+    @staticmethod
+    def _effective_precision(pub: EstimatorPub, precision: float | None) -> float:
+        effective_precision = pub.precision if pub.precision is not None else precision
+        if effective_precision is None:
+            effective_precision = _DEFAULT_PRECISION
+        if effective_precision <= 0:
+            raise ValueError(f"Precision must be positive, got: {effective_precision}")
+        return effective_precision
+
+    @staticmethod
+    def _precision_to_shots(precision: float) -> int:
+        return int(np.ceil(1.0 / precision**2))
+
+    @staticmethod
+    def _chunk_binding_records(
+        records: list[_BindingRecord],
+        *,
+        max_executables: int | None,
+    ) -> Iterable[list[_BindingRecord]]:
+        if max_executables is None:
+            yield records
+            return
+        if max_executables <= 0:
+            raise ValueError("max_program_set_executables must be positive")
+
+        chunk: list[_BindingRecord] = []
+        chunk_executables = 0
+        for record in records:
+            record_executables = len(record.binding)
+            if record_executables > max_executables:
+                raise ValueError(
+                    "A single CircuitBinding requires "
+                    f"{record_executables} executables, which exceeds "
+                    f"max_program_set_executables={max_executables}"
+                )
+            if chunk and chunk_executables + record_executables > max_executables:
+                yield chunk
+                chunk = []
+                chunk_executables = 0
+            chunk.append(record)
+            chunk_executables += record_executables
+        if chunk:
+            yield chunk
+
+    def _translate_pub(self, pub: EstimatorPub, *, abelian_grouping: bool) -> _PubMetadata:
         """
-        Convert an EstimatorPub to a list of CircuitBindings.
+        Convert an EstimatorPub to CircuitBindings and result reconstruction metadata.
 
         Since a CircuitBinding only takes one-dimensional parameter and observable arrays,
         multiple CircuitBindings are necessary to capture all the data in an EstimatorPub,
@@ -149,9 +490,7 @@ class BraketEstimator(BaseEstimatorV2):
             pub (EstimatorPub): The EstimatorPub to convert.
 
         Returns:
-            tuple[list[CircuitBinding], _ResultMap, set[int]]:
-            The circuit bindings, pub shape, a map of binding index to array positions,
-            and the indices of bindings with Pauli sum observables.
+            _PubMetadata: The circuit bindings and metadata needed to reconstruct the pub result.
         """
         backend = self._backend
         circuit = to_braket(
@@ -161,18 +500,36 @@ class BraketEstimator(BaseEstimatorV2):
             verbatim=self._verbatim,
             optimization_level=self._optimization_level,
         )
+        observables_broadcast, param_indices_broadcast = BraketEstimator._broadcast_pub(pub)
+        if abelian_grouping:
+            return self._grouped_bindings(
+                circuit, observables_broadcast, param_indices_broadcast, pub.parameter_values
+            )
+        return self._per_term_bindings(
+            circuit, observables_broadcast, param_indices_broadcast, pub.parameter_values
+        )
 
+    @staticmethod
+    def _broadcast_pub(pub: EstimatorPub) -> tuple[np.ndarray, np.ndarray]:
         observables = np.asarray(pub.observables)
         param_values = pub.parameter_values
+        if not param_values.data:
+            return observables, BraketEstimator._empty_parameter_indices(observables.shape)
+
+        parameter_indices = np.empty(param_values.shape, dtype=object)
+        for index in np.ndindex(param_values.shape):
+            parameter_indices[index] = index
+        return np.broadcast_arrays(observables, parameter_indices)
+
+    @staticmethod
+    def _per_term_bindings(
+        circuit: object,
+        observables_broadcast: np.ndarray,
+        param_indices_broadcast: np.ndarray,
+        param_values: BindingsArray,
+    ) -> _PubMetadata:
+        observables = observables_broadcast
         obs_keys = {BraketEstimator._make_obs_key(obs): obs for obs in observables.flatten()}
-        observables_broadcast, param_indices_broadcast = (
-            np.broadcast_arrays(
-                observables,
-                np.fromiter(np.ndindex(shape := param_values.shape), dtype=object).reshape(shape),
-            )
-            if param_values.data
-            else (observables, np.empty(observables.shape, dtype=object))
-        )
 
         # Group parameter sets with the same observable
         obs_groups = defaultdict(list)
@@ -201,14 +558,17 @@ class BraketEstimator(BaseEstimatorV2):
                 )
             ]
             processed_obs_keys.update(matching_obs_keys)
-            param_idx_map = {pk: idx for idx, pk in enumerate(param_indices)}
+            sorted_param_indices = sorted(param_indices)
+            param_idx_map = {pk: idx for idx, pk in enumerate(sorted_param_indices)}
 
             braket_observables = [
                 translate_sparse_pauli_op(SparsePauliOp.from_list(obs_keys[ok].items()))
                 for ok in matching_obs_keys
             ]
             parameter_sets = (
-                BraketEstimator._translate_parameters([param_values[pi] for pi in param_indices])
+                BraketEstimator._translate_parameters([
+                    param_values[pi] for pi in sorted_param_indices
+                ])
                 if param_values.data
                 else None
             )
@@ -243,7 +603,119 @@ class BraketEstimator(BaseEstimatorV2):
                     for ok, _ in monomials
                     for position, pi in obs_groups[ok]
                 ]
-        return bindings, binding_to_result_map, sum_binding_indices
+        return _PubMetadata(
+            bindings=bindings,
+            num_bindings=len(bindings),
+            binding_to_result_map=binding_to_result_map,
+            sum_binding_indices=sum_binding_indices,
+            qwc_binding_metadata={},
+            identity_contributions=(),
+        )
+
+    @staticmethod
+    def _grouped_bindings(
+        circuit: object,
+        observables_broadcast: np.ndarray,
+        param_indices_broadcast: np.ndarray,
+        param_values: BindingsArray,
+    ) -> _PubMetadata:
+        term_routes_by_param = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
+        identity_routes = defaultdict(list)
+        for position, (param_indices, obs) in enumerate(
+            zip(param_indices_broadcast.flatten(), observables_broadcast.flatten(), strict=True)
+        ):
+            for pauli, coefficient in BraketEstimator._observable_terms(obs):
+                if BraketEstimator._is_identity(pauli):
+                    identity_routes[coefficient].append(position)
+                else:
+                    term_routes_by_param[param_indices][pauli][coefficient].append(position)
+
+        basis_index_by_param_and_term = {}
+        parameter_indices_by_bases = defaultdict(list)
+        group_cache = {}
+        for param_indices, term_routes in sorted(term_routes_by_param.items(), key=str):
+            labels_key = tuple(sorted(term_routes))
+            if labels_key not in group_cache:
+                group_cache[labels_key] = BraketEstimator._group_paulis(labels_key)
+            basis_groups = group_cache[labels_key]
+            covering_paulis = tuple(basis for basis, _ in basis_groups)
+            term_to_basis = {
+                term: basis_index
+                for basis_index, (_, terms) in enumerate(basis_groups)
+                for term in terms
+            }
+            basis_index_by_param_and_term[param_indices] = term_to_basis
+            parameter_indices_by_bases[covering_paulis].append(param_indices)
+
+        bindings: list[CircuitBinding] = []
+        qwc_binding_metadata: dict[int, _QWCBindingMetadata] = {}
+        for covering_paulis, unsorted_param_indices in sorted(parameter_indices_by_bases.items()):
+            matching_param_indices = sorted(unsorted_param_indices, key=str)
+            parameter_sets = (
+                BraketEstimator._translate_parameters([
+                    param_values[pi] for pi in matching_param_indices
+                ])
+                if param_values.data
+                else None
+            )
+            binding_idx = len(bindings)
+            bindings.append(
+                CircuitBinding(
+                    circuit,
+                    input_sets=parameter_sets,
+                    observables=[
+                        translate_sparse_pauli_op(SparsePauliOp.from_list([(basis, 1.0)]))
+                        for basis in covering_paulis
+                    ],
+                )
+            )
+
+            param_idx_map = {pk: idx for idx, pk in enumerate(matching_param_indices)}
+            routed_terms_by_basis = defaultdict(list)
+            for param_indices in matching_param_indices:
+                for pauli, coefficient_routes in sorted(
+                    term_routes_by_param[param_indices].items()
+                ):
+                    basis_index = basis_index_by_param_and_term[param_indices][pauli]
+                    for coefficient, positions in sorted(
+                        coefficient_routes.items(),
+                        key=lambda item: BraketEstimator._coefficient_sort_key(item[0]),
+                    ):
+                        routed_terms_by_basis[basis_index].append(
+                            _RoutingTarget(
+                                pauli=pauli,
+                                coefficient=coefficient,
+                                parameter_indices=param_indices,
+                                positions=tuple(positions),
+                                targets=BraketEstimator._pauli_targets(pauli),
+                            )
+                        )
+            qwc_binding_metadata[binding_idx] = _QWCBindingMetadata(
+                parameter_index_map=param_idx_map,
+                measurement_groups=tuple(
+                    _MeasurementGroup(
+                        covering_pauli=covering_paulis[basis_index],
+                        routed_terms=tuple(targets),
+                    )
+                    for basis_index, targets in sorted(routed_terms_by_basis.items())
+                ),
+            )
+
+        identity_contributions = tuple(
+            _IdentityContribution(coefficient=coefficient, positions=tuple(positions))
+            for coefficient, positions in sorted(
+                identity_routes.items(),
+                key=lambda item: BraketEstimator._coefficient_sort_key(item[0]),
+            )
+        )
+        return _PubMetadata(
+            bindings=bindings,
+            num_bindings=len(bindings),
+            binding_to_result_map={},
+            sum_binding_indices=set(),
+            qwc_binding_metadata=qwc_binding_metadata,
+            identity_contributions=identity_contributions,
+        )
 
     @staticmethod
     def _make_obs_key(obs_val: SparsePauliOp | dict[str, float]) -> str:
@@ -257,6 +729,35 @@ class BraketEstimator(BaseEstimatorV2):
             str: A string representation that can be used as a dictionary key
         """
         return str(sorted(obs_val.items())) if isinstance(obs_val, dict) else str(obs_val)
+
+    @staticmethod
+    def _observable_terms(
+        obs_val: SparsePauliOp | dict[str, complex],
+    ) -> tuple[tuple[str, complex], ...]:
+        op = (
+            obs_val
+            if isinstance(obs_val, SparsePauliOp)
+            else SparsePauliOp.from_list(list(obs_val.items()))
+        ).simplify()
+        return tuple(
+            (pauli.to_label(), complex(coefficient))
+            for pauli, coefficient in zip(op.paulis, op.coeffs, strict=True)
+            if not np.isclose(coefficient, 0.0)
+        )
+
+    @staticmethod
+    def _is_identity(pauli: str) -> bool:
+        return all(pauli_char == "I" for pauli_char in pauli)
+
+    @staticmethod
+    def _coefficient_sort_key(value: complex) -> tuple[float, float]:
+        return (float(np.real(value)), float(np.imag(value)))
+
+    @staticmethod
+    def _real_if_close(value: complex, *, context: str) -> float:
+        if not np.isclose(np.imag(value), 0.0):
+            raise ValueError(f"{context} produced a complex expectation value: {value}")
+        return float(np.real(value))
 
     @staticmethod
     def _translate_parameters(param_list: list[BindingsArray]) -> ParameterSets:
@@ -277,57 +778,194 @@ class BraketEstimator(BaseEstimatorV2):
         return ParameterSets(data)
 
     @staticmethod
+    def _empty_parameter_indices(shape: tuple[int, ...]) -> np.ndarray:
+        indices = np.empty(shape, dtype=object)
+        indices.fill(())
+        return indices
+
+    @staticmethod
+    def _group_paulis(paulis: Iterable[str]) -> list[tuple[str, tuple[str, ...]]]:
+        grouped = defaultdict(list)
+        op = SparsePauliOp.from_list([(pauli, 1.0) for pauli in sorted(paulis)])
+        for commuting_group in op.group_commuting(qubit_wise=True):
+            terms = tuple(pauli.to_label() for pauli in commuting_group.paulis)
+            grouped[BraketEstimator._covering_pauli(commuting_group)].extend(terms)
+        return [(basis, tuple(sorted(terms))) for basis, terms in sorted(grouped.items())]
+
+    @staticmethod
+    def _covering_pauli(group: SparsePauliOp) -> str:
+        z_mask = np.logical_or.reduce(group.paulis.z, axis=0)
+        x_mask = np.logical_or.reduce(group.paulis.x, axis=0)
+        basis = []
+        for z_bit, x_bit in zip(reversed(z_mask), reversed(x_mask), strict=True):
+            if z_bit and x_bit:
+                basis.append("Y")
+            elif z_bit:
+                basis.append("Z")
+            elif x_bit:
+                basis.append("X")
+            else:
+                basis.append("I")
+        return "".join(basis)
+
+    @staticmethod
+    def _pauli_targets(pauli: str) -> tuple[int, ...]:
+        return tuple(qubit for qubit, pauli_char in enumerate(reversed(pauli)) if pauli_char != "I")
+
+    @staticmethod
+    def _pauli_statistics(
+        program_result: MeasuredEntry,
+        pauli: str,
+        targets: tuple[int, ...] | None = None,
+    ) -> tuple[float, float]:
+        targets = BraketEstimator._pauli_targets(pauli) if targets is None else targets
+        if not targets:
+            return 1.0, 0.0
+        observable = _translate_pauli_observable(pauli)
+        samples = samples_from_measurements(
+            program_result.measurements,
+            program_result.measured_qubits,
+            observable,
+            list(targets),
+        )
+        expectation = np.mean(samples)
+        return float(expectation), BraketEstimator._standard_error(samples, expectation)
+
+    @staticmethod
+    def _pauli_expectation(program_result: MeasuredEntry, pauli: str) -> float:
+        return BraketEstimator._pauli_statistics(program_result, pauli)[0]
+
+    @staticmethod
+    def _measured_entry_standard_error(measured_entry: MeasuredEntry) -> float:
+        if measured_entry.observable is None:
+            raise ValueError("Measured entry has no observable")
+        samples = samples_from_measurements(
+            measured_entry.measurements,
+            measured_entry.measured_qubits,
+            measured_entry.observable,
+            measured_entry.observable.targets,
+        )
+        return BraketEstimator._standard_error(samples)
+
+    @staticmethod
+    def _sum_standard_error(program_result: object, param_idx: int) -> float:
+        num_observables = len(program_result.observables)
+        start = param_idx * num_observables
+        return sum(
+            BraketEstimator._measured_entry_standard_error(program_result[start + obs_idx])
+            for obs_idx in range(num_observables)
+        )
+
+    @staticmethod
+    def _standard_error(samples: np.ndarray, expectation: float | None = None) -> float:
+        if len(samples) == 0:
+            return 0.0
+        expectation = float(np.mean(samples)) if expectation is None else float(expectation)
+        variance = max(0.0, float(np.mean(np.square(samples))) - expectation**2)
+        return float(np.sqrt(variance / len(samples)))
+
+    @staticmethod
     def _translate_result(
-        task_result: ProgramSetQuantumTaskResult, metadata: _JobMetadata
+        task_results: Sequence[ProgramSetQuantumTaskResult] | None, metadata: _JobMetadata
     ) -> PrimitiveResult[PubResult]:
         """
         Reconstruct PrimitiveResult from Braket task results.
 
         Args:
-            task_result (ProgramSetQuantumTaskResult): The result of a Braket program set task
+            task_results (Sequence[ProgramSetQuantumTaskResult] | None): The results of submitted
+                Braket program set tasks.
             metadata (_JobMetadata): Metadata needed to reconstruct results, including:
                 - circuits: List of QuantumCircuits
                 - pub_metadata: List of metadata for each pub
-                - precision: Target precision
-                - shots: Number of shots used
+                - pub_precisions: Target precision per PUB
+                - pub_shots: Number of shots per PUB
 
         Returns:
             PrimitiveResult[PubResult]: PrimitiveResult containing PubResult for each pub.
         """
 
         pub_results = []
-        binding_offset = 0
 
-        for pub, pub_meta in zip(metadata.pubs, metadata.pub_metadata, strict=True):
+        for pub_index, (pub, pub_meta) in enumerate(
+            zip(metadata.pubs, metadata.pub_metadata, strict=True)
+        ):
             num_bindings = pub_meta.num_bindings
             broadcast_shape = pub.shape
             binding_map = pub_meta.binding_to_result_map
             sum_binding_indices = pub_meta.sum_binding_indices
 
             evs = np.zeros(broadcast_shape, dtype=float)
+            stds = np.zeros(broadcast_shape, dtype=float)
+            for identity in pub_meta.identity_contributions:
+                contribution = BraketEstimator._real_if_close(
+                    identity.coefficient, context="Identity term"
+                )
+                for position in identity.positions:
+                    evs[np.unravel_index(position, broadcast_shape)] += contribution
+
             for local_binding_idx in range(num_bindings):
-                program_result = task_result[binding_offset + local_binding_idx]
+                if task_results is None:
+                    raise ValueError("Task result is required for non-constant estimator pubs")
+                binding_location = metadata.binding_locations.get((pub_index, local_binding_idx))
+                if binding_location is None:
+                    raise ValueError("No task result location was recorded for estimator binding")
+                program_result = task_results[binding_location.task_index][
+                    binding_location.result_index
+                ]
                 num_observables = len(program_result.observables)
+
+                if local_binding_idx in pub_meta.qwc_binding_metadata:
+                    qwc_metadata = pub_meta.qwc_binding_metadata[local_binding_idx]
+                    expectation_cache = {}
+                    for obs_idx, measurement_group in enumerate(qwc_metadata.measurement_groups):
+                        for target in measurement_group.routed_terms:
+                            param_idx = qwc_metadata.parameter_index_map[target.parameter_indices]
+                            cache_key = (param_idx, obs_idx, target.pauli)
+                            if cache_key not in expectation_cache:
+                                expectation_cache[cache_key] = BraketEstimator._pauli_statistics(
+                                    program_result[param_idx * num_observables + obs_idx],
+                                    target.pauli,
+                                    target.targets,
+                                )
+                            expectation, standard_error = expectation_cache[cache_key]
+                            contribution = BraketEstimator._real_if_close(
+                                target.coefficient * expectation,
+                                context=f"Pauli term {target.pauli}",
+                            )
+                            for position in target.positions:
+                                array_index = np.unravel_index(position, broadcast_shape)
+                                evs[array_index] += contribution
+                                stds[array_index] += abs(target.coefficient) * standard_error
+                    continue
 
                 for position, obs_idx, param_idx in binding_map[local_binding_idx]:
                     # CircuitBinding returns results organized by parameter sets
                     # For each parameter, we get all observables
-                    evs[np.unravel_index(position, broadcast_shape)] = (
-                        program_result.expectation(param_idx)
-                        if local_binding_idx in sum_binding_indices
-                        else program_result[param_idx * num_observables + obs_idx].expectation
-                    )
+                    array_index = np.unravel_index(position, broadcast_shape)
+                    if local_binding_idx in sum_binding_indices:
+                        evs[array_index] = program_result.expectation(param_idx)
+                        stds[array_index] = BraketEstimator._sum_standard_error(
+                            program_result,
+                            param_idx,
+                        )
+                    else:
+                        if obs_idx is None:
+                            raise ValueError("Observable result entries must have an index")
+                        measured_entry = program_result[param_idx * num_observables + obs_idx]
+                        evs[array_index] = measured_entry.expectation
+                        stds[array_index] = BraketEstimator._measured_entry_standard_error(
+                            measured_entry
+                        )
 
             pub_results.append(
                 PubResult(
-                    DataBin(evs=evs, shape=broadcast_shape),
+                    DataBin(evs=evs, stds=stds, shape=broadcast_shape),
                     metadata={
-                        "target_precision": metadata.precision,
-                        "shots": metadata.shots,
+                        "target_precision": metadata.pub_precisions[pub_index],
+                        "shots": metadata.pub_shots[pub_index],
                         "circuit_metadata": pub.circuit.metadata,
                     },
                 )
             )
-            binding_offset += num_bindings
 
-        return PrimitiveResult(pub_results)
+        return PrimitiveResult(pub_results, metadata={"version": 2})

--- a/test/unit_tests/test_braket_estimator.py
+++ b/test/unit_tests/test_braket_estimator.py
@@ -1,6 +1,6 @@
 """Tests for BraketEstimator."""
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
@@ -11,12 +11,34 @@ from qiskit.primitives import BackendEstimatorV2, BasePrimitiveJob
 from qiskit.primitives.containers.bindings_array import BindingsArray
 from qiskit.primitives.containers.estimator_pub import EstimatorPub, EstimatorPubLike
 from qiskit.primitives.containers.observables_array import ObservablesArray
+from qiskit.providers import JobStatus
 from qiskit.quantum_info import SparsePauliOp
 
 from braket.program_sets import ProgramSet
 from qiskit_braket_provider.providers import BraketLocalBackend
+from qiskit_braket_provider.providers import braket_estimator as braket_estimator_module
 from qiskit_braket_provider.providers.braket_estimator import BraketEstimator
-from qiskit_braket_provider.providers.braket_primitive_task import BraketPrimitiveTask
+
+
+class _MockProgramResult:
+    """Minimal ProgramSet entry result for estimator result-translation tests."""
+
+    def __init__(self, entries: Sequence[object]) -> None:
+        self._entries = list(entries)
+        self.observables = [object() for _ in self._entries]
+
+    def __getitem__(self, index: int) -> object:
+        return self._entries[index]
+
+
+class _SizedBinding:
+    """Minimal binding object with a configurable executable count."""
+
+    def __init__(self, length: int) -> None:
+        self._length = length
+
+    def __len__(self) -> int:
+        return self._length
 
 
 class TestBraketEstimator(TestCase):
@@ -26,14 +48,38 @@ class TestBraketEstimator(TestCase):
         """Set up test fixtures."""
         self.backend = BraketLocalBackend()
         self.estimator = BraketEstimator(self.backend)
+        self.ungrouped_estimator = BraketEstimator(
+            self.backend, options={"abelian_grouping": False}
+        )
         self.estimator_backend = BackendEstimatorV2(backend=self.backend)
 
-    def assert_correct_results(self, task: BraketPrimitiveTask, pubs: Iterable[EstimatorPubLike]):
+    def assert_correct_results(self, task: BasePrimitiveJob, pubs: Iterable[EstimatorPubLike]):
         """Compares the results from BraketEstimator and BackendEstimatorV2"""
         for actual, expected in zip(
             task.result(), self.estimator_backend.run(pubs).result(), strict=True
         ):
             self.assertTrue(np.allclose(actual.data.evs, expected.data.evs, rtol=0.3, atol=0.2))
+
+    @staticmethod
+    def _mock_measured_entry(bits: object) -> Mock:
+        entry = Mock()
+        entry.measurements = np.asarray(bits, dtype=int)
+        entry.measured_qubits = [0]
+        return entry
+
+    @staticmethod
+    def _mock_task(task_id: str, task_result: object, state: str = "COMPLETED") -> Mock:
+        task = Mock()
+        task.id = task_id
+        task.result.return_value = task_result
+        task.state.return_value = state
+        return task
+
+    @staticmethod
+    def _non_empty_circuit(num_qubits: int) -> QuantumCircuit:
+        circuit = QuantumCircuit(num_qubits)
+        circuit.h(0)
+        return circuit
 
     def test_program_sets_unsupported(self):
         """Tests that initialization raises a ValueError if program sets aren't supported"""
@@ -144,6 +190,55 @@ class TestBraketEstimator(TestCase):
 
             self.assertIsInstance(job, BasePrimitiveJob)
 
+    def test_constructor_default_precision_option(self):
+        """Tests Qiskit-style default_precision estimator option routing."""
+        estimator = BraketEstimator(self.backend, options={"default_precision": 0.05})
+        qc = QuantumCircuit(1)
+        qc.h(0)
+        pub = (qc, SparsePauliOp(["Z"]))
+
+        with patch.object(self.backend._device, "run") as mock_run:
+            mock_task = Mock()
+            mock_task.id = "test-task-id"
+            mock_run.return_value = mock_task
+
+            job = estimator.run([pub])
+
+        mock_run.assert_called_once()
+        self.assertEqual(mock_run.call_args[0][0].shots_per_executable, 400)
+        self.assertIsInstance(job, BasePrimitiveJob)
+
+    def test_options_property_and_validation(self):
+        """Tests estimator option access and validation errors."""
+        options = braket_estimator_module.BraketEstimatorOptions(
+            default_precision=0.05,
+            abelian_grouping=False,
+        )
+        estimator = BraketEstimator(self.backend, options=options)
+
+        self.assertEqual(estimator.options, options)
+
+        with self.assertRaises(ValueError) as duplicate_context:
+            BraketEstimator(
+                self.backend,
+                options={"default_precision": 0.05},
+                default_precision=0.1,
+            )
+        self.assertIn("either in options", str(duplicate_context.exception))
+
+        with self.assertRaises(ValueError) as unknown_context:
+            BraketEstimator(self.backend, options={"unsupported": True})
+        self.assertIn("Unsupported estimator options", str(unknown_context.exception))
+
+        with self.assertRaises(TypeError):
+            BraketEstimator(self.backend, options={"default_precision": object()})
+
+        with self.assertRaises(TypeError):
+            BraketEstimator(self.backend, options={"abelian_grouping": "false"})
+
+        with self.assertRaises(ValueError):
+            BraketEstimator(self.backend, options={"default_precision": 0.0})
+
     def test_custom_precision(self):
         """Test using custom precision."""
         qc = QuantumCircuit(1)
@@ -161,6 +256,85 @@ class TestBraketEstimator(TestCase):
             job = self.estimator.run([pub], precision=custom_precision)
 
             self.assertIsInstance(job, BasePrimitiveJob)
+
+    def test_constructor_abelian_grouping_option_uses_legacy_path(self):
+        """Tests Qiskit-style abelian_grouping estimator option routing."""
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        circuit.cx(0, 1)
+        pub = (circuit, [SparsePauliOp("ZZ"), SparsePauliOp("ZI"), SparsePauliOp("IZ")])
+
+        task = self.ungrouped_estimator.run([pub])
+
+        self.assertEqual(len(task.program_set), 1)
+        self.assertEqual(len(task.program_set[0]), 3)
+        self.assert_correct_results(task, [pub])
+
+    def test_direct_abelian_grouping_constructor_keyword_not_forwarded(self):
+        """Tests legacy constructor keyword routing for abelian_grouping."""
+        estimator = BraketEstimator(self.backend, abelian_grouping=False)
+        qc = self._non_empty_circuit(1)
+        pub = (qc, SparsePauliOp(["Z"]))
+
+        with patch.object(self.backend._device, "run") as mock_run:
+            mock_task = Mock()
+            mock_task.id = "test-task-id"
+            mock_run.return_value = mock_task
+
+            estimator.run([pub])
+
+        mock_run.assert_called_once()
+        self.assertNotIn("abelian_grouping", mock_run.call_args.kwargs)
+
+    def test_run_abelian_grouping_keyword_uses_legacy_path(self):
+        """Tests upstream-style run-level abelian_grouping routing."""
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        circuit.cx(0, 1)
+        pub = (circuit, [SparsePauliOp("ZZ"), SparsePauliOp("ZI"), SparsePauliOp("IZ")])
+
+        task = self.estimator.run([pub], abelian_grouping=False)
+
+        self.assertEqual(len(task.program_set), 1)
+        self.assertEqual(len(task.program_set[0]), 3)
+        self.assert_correct_results(task, [pub])
+
+    def test_run_abelian_grouping_keyword_overrides_constructor_option(self):
+        """Tests that a run-level grouping option overrides the estimator default."""
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        circuit.cx(0, 1)
+        pub = (circuit, [SparsePauliOp("ZZ"), SparsePauliOp("ZI"), SparsePauliOp("IZ")])
+
+        task = self.ungrouped_estimator.run([pub], abelian_grouping=True)
+
+        self.assertEqual(len(task.program_set), 1)
+        self.assertEqual(len(task.program_set[0]), 1)
+        self.assert_correct_results(task, [pub])
+
+    def test_run_rejects_invalid_abelian_grouping_keyword(self):
+        """Tests explicit validation for the run-level abelian_grouping option."""
+        qc = QuantumCircuit(1)
+        pub = (qc, SparsePauliOp(["Z"]))
+
+        with self.assertRaises(TypeError):
+            self.estimator.run([pub], abelian_grouping="false")
+
+    def test_device_run_options_still_forwarded(self):
+        """Tests non-estimator constructor kwargs still route to device.run."""
+        estimator = BraketEstimator(self.backend, disable_qubit_rewiring=True)
+        qc = self._non_empty_circuit(1)
+        pub = (qc, SparsePauliOp(["Z"]))
+
+        with patch.object(self.backend._device, "run") as mock_run:
+            mock_task = Mock()
+            mock_task.id = "test-task-id"
+            mock_run.return_value = mock_task
+
+            estimator.run([pub])
+
+        mock_run.assert_called_once()
+        self.assertEqual(mock_run.call_args.kwargs, {"disable_qubit_rewiring": True})
 
     def test_complex_broadcasting(self):
         """Test with complex broadcasting shapes (2, 3, 6)."""
@@ -245,21 +419,240 @@ class TestBraketEstimator(TestCase):
             mock_run.assert_called_once()
             self.assertIsInstance(job, BasePrimitiveJob)
 
-    def test_different_precisions_raises_error(self):
-        """Test that pubs with different precisions raise an error."""
+    def test_different_precisions_use_shot_buckets(self):
+        """Test that pubs with different precisions are submitted in shot buckets."""
         qc = QuantumCircuit(1)
         qc.h(0)
         observable = SparsePauliOp(["Z"])
 
-        # Create pubs with different precisions
         obs_array = ObservablesArray([observable])
         pub1 = EstimatorPub(circuit=qc, observables=obs_array, precision=0.01)
         pub2 = EstimatorPub(circuit=qc, observables=obs_array, precision=0.02)
 
-        with self.assertRaises(ValueError) as context:
-            self.estimator.run([pub1, pub2])
+        task_1 = Mock()
+        task_1.id = "test-task-id-1"
+        task_2 = Mock()
+        task_2.id = "test-task-id-2"
+        with patch.object(self.backend._device, "run", side_effect=[task_1, task_2]) as mock_run:
+            job = self.estimator.run([pub1, pub2])
 
-        self.assertIn("same precision", str(context.exception))
+        self.assertIsInstance(job, BasePrimitiveJob)
+        self.assertEqual(mock_run.call_count, 2)
+        self.assertEqual(
+            [call_args[0][0].shots_per_executable for call_args in mock_run.call_args_list],
+            [2500, 10000],
+        )
+        self.assertEqual(
+            [program_set.shots_per_executable for program_set in job.program_sets],
+            [2500, 10000],
+        )
+        with self.assertRaises(ValueError):
+            _ = job.program_set
+
+    def test_different_precisions_result_aggregates_shot_buckets(self):
+        """Tests composite result aggregation across mixed-precision shot buckets."""
+        circuit = self._non_empty_circuit(1)
+        observable = SparsePauliOp("Z")
+        observables = ObservablesArray([observable])
+        pub_10000_shots = EstimatorPub(circuit=circuit, observables=observables, precision=0.01)
+        pub_2500_shots = EstimatorPub(circuit=circuit, observables=observables, precision=0.02)
+
+        task_2500_shots = self._mock_task(
+            "test-task-id-2500",
+            [_MockProgramResult([self._mock_measured_entry([[0], [0], [0], [0]])])],
+        )
+        task_10000_shots = self._mock_task(
+            "test-task-id-10000",
+            [_MockProgramResult([self._mock_measured_entry([[1], [1], [1], [1]])])],
+        )
+        with patch.object(
+            self.backend._device,
+            "run",
+            side_effect=[task_2500_shots, task_10000_shots],
+        ) as mock_run:
+            job = self.estimator.run([pub_10000_shots, pub_2500_shots])
+
+        self.assertEqual(
+            [call_args[0][0].shots_per_executable for call_args in mock_run.call_args_list],
+            [2500, 10000],
+        )
+
+        results = job.result()
+        self.assertEqual(results.metadata, {"version": 2})
+        self.assertTrue(np.allclose(results[0].data.evs, [-1.0]))
+        self.assertTrue(np.allclose(results[1].data.evs, [1.0]))
+        self.assertTrue(np.allclose(results[0].data.stds, [0.0]))
+        self.assertTrue(np.allclose(results[1].data.stds, [0.0]))
+        self.assertEqual(results[0].metadata["target_precision"], 0.01)
+        self.assertEqual(results[0].metadata["shots"], 10000)
+        self.assertEqual(results[1].metadata["target_precision"], 0.02)
+        self.assertEqual(results[1].metadata["shots"], 2500)
+
+        self.assertIs(job.result(), results)
+        self.assertEqual(task_2500_shots.result.call_count, 1)
+        self.assertEqual(task_10000_shots.result.call_count, 1)
+
+    def test_constant_pub_metadata_uses_effective_precision(self):
+        """Tests per-PUB precision metadata for analytical constant results."""
+        circuit = self._non_empty_circuit(1)
+        observables = ObservablesArray([SparsePauliOp("I")])
+        pub1 = EstimatorPub(circuit=circuit, observables=observables, precision=0.01)
+        pub2 = EstimatorPub(circuit=circuit, observables=observables, precision=None)
+
+        with patch.object(self.backend._device, "run") as mock_run:
+            job = self.estimator.run([pub1, pub2], precision=0.02)
+
+        mock_run.assert_not_called()
+        results = job.result()
+        self.assertEqual(results.metadata, {"version": 2})
+        self.assertEqual(results[0].metadata["target_precision"], 0.01)
+        self.assertEqual(results[0].metadata["shots"], 10000)
+        self.assertEqual(results[1].metadata["target_precision"], 0.02)
+        self.assertEqual(results[1].metadata["shots"], 2500)
+        self.assertTrue(np.allclose(results[0].data.stds, 0.0))
+        self.assertTrue(np.allclose(results[1].data.stds, 0.0))
+
+    def test_max_program_set_executables_chunks_submissions(self):
+        """Tests optional ProgramSet chunking by executable count."""
+        estimator = BraketEstimator(self.backend, max_program_set_executables=1)
+        qc = self._non_empty_circuit(1)
+        pubs = [(qc, SparsePauliOp("Z")), (qc, SparsePauliOp("X"))]
+
+        task_1 = Mock()
+        task_1.id = "test-task-id-1"
+        task_2 = Mock()
+        task_2.id = "test-task-id-2"
+        with patch.object(self.backend._device, "run", side_effect=[task_1, task_2]) as mock_run:
+            job = estimator.run(pubs, precision=0.1)
+
+        self.assertIsInstance(job, BasePrimitiveJob)
+        self.assertEqual(mock_run.call_count, 2)
+        self.assertEqual(
+            [call_args[0][0].total_executables for call_args in mock_run.call_args_list],
+            [1, 1],
+        )
+        self.assertEqual(len(job.program_sets), 2)
+
+    def test_chunked_program_sets_result_aggregates(self):
+        """Tests composite result aggregation across chunked ProgramSet submissions."""
+        estimator = BraketEstimator(self.backend, max_program_set_executables=1)
+        circuit = self._non_empty_circuit(1)
+        pubs = [(circuit, SparsePauliOp("Z")), (circuit, SparsePauliOp("X"))]
+
+        z_task = self._mock_task(
+            "test-task-id-z",
+            [_MockProgramResult([self._mock_measured_entry([[0], [0], [0], [0]])])],
+        )
+        x_task = self._mock_task(
+            "test-task-id-x",
+            [_MockProgramResult([self._mock_measured_entry([[1], [1], [1], [1]])])],
+        )
+        with patch.object(self.backend._device, "run", side_effect=[z_task, x_task]):
+            job = estimator.run(pubs, precision=0.1)
+
+        results = job.result()
+        self.assertEqual(results.metadata, {"version": 2})
+        self.assertTrue(np.allclose(results[0].data.evs, 1.0))
+        self.assertTrue(np.allclose(results[1].data.evs, -1.0))
+        self.assertTrue(np.allclose(results[0].data.stds, 0.0))
+        self.assertTrue(np.allclose(results[1].data.stds, 0.0))
+
+    def test_chunking_rejects_non_positive_limits(self):
+        """Tests explicit validation for invalid ProgramSet chunk limits."""
+        for max_executables in (0, -1):
+            with self.subTest(max_executables=max_executables):
+                with self.assertRaises(ValueError) as context:
+                    list(
+                        BraketEstimator._chunk_binding_records(
+                            [],
+                            max_executables=max_executables,
+                        )
+                    )
+                self.assertIn("must be positive", str(context.exception))
+
+    def test_chunking_rejects_binding_larger_than_limit(self):
+        """Tests validation when one CircuitBinding exceeds the chunk executable limit."""
+        record = Mock()
+        record.binding = _SizedBinding(2)
+
+        with self.assertRaises(ValueError) as context:
+            list(BraketEstimator._chunk_binding_records([record], max_executables=1))
+
+        self.assertIn("exceeds max_program_set_executables=1", str(context.exception))
+
+    def test_effective_precision_defaults_and_validation(self):
+        """Tests direct effective precision fallback and validation."""
+        pub = EstimatorPub.coerce((QuantumCircuit(1), SparsePauliOp("Z")))
+
+        self.assertEqual(BraketEstimator._effective_precision(pub, None), 0.015625)
+        with self.assertRaises(ValueError):
+            BraketEstimator._effective_precision(pub, 0.0)
+
+    def test_composite_task_result_status_and_controls(self):
+        """Tests composite primitive task result caching and status helpers."""
+        program_set = object()
+        task = self._mock_task("done-task", "raw-result")
+        result_translator = Mock(return_value="translated-result")
+        job = braket_estimator_module._CompositePrimitiveTask(
+            [task],
+            result_translator,
+            [program_set],
+        )
+
+        self.assertIs(job.program_set, program_set)
+        self.assertEqual(job.job_id(), "done-task")
+        self.assertEqual(job.result(), "translated-result")
+        self.assertEqual(job.result(), "translated-result")
+        task.result.assert_called_once()
+        result_translator.assert_called_once_with(["raw-result"])
+        self.assertEqual(job.status(), JobStatus.DONE)
+        self.assertTrue(job.done())
+        self.assertFalse(job.running())
+        self.assertFalse(job.cancelled())
+        self.assertTrue(job.in_final_state())
+
+        job.cancel()
+        task.cancel.assert_called_once()
+
+    def test_composite_task_status_precedence(self):
+        """Tests composite primitive task status precedence across Braket states."""
+        completed_task = self._mock_task("completed-task", object(), state="COMPLETED")
+        failed_task = self._mock_task("failed-task", object(), state="FAILED")
+        running_task = self._mock_task("running-task", object(), state="RUNNING")
+        cancelled_task = self._mock_task("cancelled-task", object(), state="CANCELLED")
+        initialized_task = self._mock_task("initialized-task", object(), state="INITIALIZED")
+
+        failed_job = braket_estimator_module._CompositePrimitiveTask(
+            [completed_task, failed_task],
+            Mock(),
+            [object(), object()],
+        )
+        self.assertEqual(failed_job.status(), JobStatus.ERROR)
+        self.assertTrue(failed_job.in_final_state())
+
+        running_job = braket_estimator_module._CompositePrimitiveTask(
+            [completed_task, running_task],
+            Mock(),
+            [object(), object()],
+        )
+        self.assertEqual(running_job.status(), JobStatus.RUNNING)
+        self.assertTrue(running_job.running())
+        self.assertFalse(running_job.in_final_state())
+
+        cancelled_job = braket_estimator_module._CompositePrimitiveTask(
+            [cancelled_task],
+            Mock(),
+            [object()],
+        )
+        self.assertEqual(cancelled_job.status(), JobStatus.CANCELLED)
+        self.assertTrue(cancelled_job.cancelled())
+
+        initialized_job = braket_estimator_module._CompositePrimitiveTask(
+            [initialized_task],
+            Mock(),
+            [object()],
+        )
+        self.assertEqual(initialized_job.status(), JobStatus.INITIALIZING)
 
     def test_non_broadcastable_shapes_raises_error(self):
         """Test that non-broadcastable shapes raise an error."""
@@ -298,7 +691,7 @@ class TestBraketEstimator(TestCase):
             (circuit, observables, parameters[0]),
             (circuit, observables[1], parameters[1]),
         ]
-        task = self.estimator.run(pubs)
+        task = self.ungrouped_estimator.run(pubs)
         program_set = task.program_set
         self.assertEqual(len(program_set), 3)
         self.assertEqual(len(program_set[0]), 2)
@@ -314,7 +707,7 @@ class TestBraketEstimator(TestCase):
         circuit.ry(np.pi / 3, 0)
         observables = [SparsePauliOp("ZX"), SparsePauliOp("XZ")]
         pubs = [(circuit, observables), (circuit, observables[0])]
-        task = self.estimator.run(pubs)
+        task = self.ungrouped_estimator.run(pubs)
         program_set = task.program_set
         self.assertEqual(len(program_set), 2)
         self.assertEqual(len(program_set[0]), 2)
@@ -346,12 +739,508 @@ class TestBraketEstimator(TestCase):
             ]).T,
         )
 
-        task = self.estimator.run([pub])
+        task = self.ungrouped_estimator.run([pub])
         program_set = task.program_set
         self.assertEqual(len(program_set), 2)
         self.assertEqual(len(program_set[0]), num_params * 2)
         self.assertEqual(len(program_set[1]), num_params * 3)
         self.assert_correct_results(task, [pub])
+
+    def test_run_local_abelian_grouping(self):
+        """Tests that commuting Pauli terms are grouped into representative executions."""
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        circuit.cx(0, 1)
+
+        pub = (
+            circuit,
+            [
+                SparsePauliOp("ZZ"),
+                SparsePauliOp("ZI"),
+                SparsePauliOp("IZ"),
+                SparsePauliOp(["ZZ", "ZI"], [0.5, -0.25]),
+                SparsePauliOp("XX"),
+            ],
+        )
+
+        task = self.estimator.run([pub])
+        program_set = task.program_set
+        self.assertEqual(len(program_set), 1)
+        self.assertEqual(len(program_set[0]), 2)
+        self.assert_correct_results(task, [pub])
+
+    def test_run_local_abelian_grouping_broadcasting(self):
+        """Tests grouped results with broadcasted parameters and Pauli sums."""
+        theta = Parameter("theta")
+        circuit = QuantumCircuit(2)
+        circuit.ry(theta, 0)
+        circuit.cx(0, 1)
+
+        num_params = 8
+        pub = (
+            circuit,
+            [
+                [SparsePauliOp("ZZ")],
+                [SparsePauliOp(["ZI", "IZ"], [0.3, 0.7])],
+                [SparsePauliOp("XX")],
+            ],
+            np.linspace(0, np.pi, num_params),
+        )
+
+        task = self.estimator.run([pub])
+        program_set = task.program_set
+        self.assertEqual(len(program_set), 1)
+        self.assertEqual(len(program_set[0]), num_params * 2)
+        self.assert_correct_results(task, [pub])
+
+    def test_run_local_abelian_grouping_group_collapse(self):
+        """Tests that Z-basis QWC terms collapse into one covering executable."""
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        circuit.cx(0, 1)
+
+        pub = (circuit, [SparsePauliOp("ZZ"), SparsePauliOp("ZI"), SparsePauliOp("IZ")])
+
+        task = self.estimator.run([pub])
+        program_set = task.program_set
+        self.assertEqual(len(program_set), 1)
+        self.assertEqual(len(program_set[0]), 1)
+        result = task.result()[0]
+        self.assertEqual(result.data.stds.shape, result.data.evs.shape)
+        self.assertTrue(np.all(result.data.stds >= 0.0))
+        self.assert_correct_results(task, [pub])
+
+    def test_run_local_abelian_grouping_shared_terms(self):
+        """Tests that shared Pauli terms are reconstructed from one covering measurement."""
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        circuit.cx(0, 1)
+
+        pub = (
+            circuit,
+            [
+                SparsePauliOp(["ZI", "IZ"], [0.5, 0.25]),
+                SparsePauliOp(["ZI", "ZZ"], [-0.75, 0.5]),
+            ],
+        )
+
+        task = self.estimator.run([pub])
+        program_set = task.program_set
+        self.assertEqual(len(program_set), 1)
+        self.assertEqual(len(program_set[0]), 1)
+        self.assert_correct_results(task, [pub])
+
+    def test_run_local_abelian_grouping_identity_with_active_terms(self):
+        """Tests that identity terms are added analytically without extra executions."""
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        circuit.cx(0, 1)
+
+        pub = (circuit, SparsePauliOp(["II", "ZZ"], [0.5, 1.25]))
+
+        task = self.estimator.run([pub])
+        program_set = task.program_set
+        self.assertEqual(len(program_set), 1)
+        self.assertEqual(len(program_set[0]), 1)
+        self.assert_correct_results(task, [pub])
+
+    def test_run_local_abelian_grouping_pure_identity(self):
+        """Tests that pure identity observables complete without submitting a Braket task."""
+        circuit = self._non_empty_circuit(2)
+        observable = SparsePauliOp("II") * 2.5
+        pub = (circuit, observable)
+
+        with patch.object(self.backend._device, "run") as mock_run:
+            job = self.estimator.run([pub])
+
+        mock_run.assert_not_called()
+        self.assertEqual(job.status(), JobStatus.DONE)
+        self.assertTrue(job.done())
+        self.assertTrue(job.in_final_state())
+        self.assertFalse(job.running())
+        self.assertFalse(job.cancelled())
+        self.assertIsNone(job.cancel())
+        result = job.result()[0]
+        self.assertTrue(np.allclose(result.data.evs, 2.5))
+        self.assertTrue(np.allclose(result.data.stds, 0.0))
+
+    def test_run_local_abelian_grouping_constant_pub_with_active_pub(self):
+        """Tests that mixed constant and active pubs submit only active grouped work."""
+        constant_circuit = self._non_empty_circuit(2)
+        active_circuit = QuantumCircuit(2)
+        active_circuit.h(0)
+        active_circuit.cx(0, 1)
+
+        constant_pub = (constant_circuit, SparsePauliOp("II") * 3.0)
+        active_pub = (active_circuit, [SparsePauliOp("ZZ"), SparsePauliOp("ZI")])
+
+        task = self.estimator.run([constant_pub, active_pub])
+        program_set = task.program_set
+        self.assertEqual(len(program_set), 1)
+        self.assertEqual(len(program_set[0]), 1)
+
+        results = task.result()
+        self.assertTrue(np.allclose(results[0].data.evs, 3.0))
+        self.assert_correct_results(task, [constant_pub, active_pub])
+
+    def test_run_local_abelian_grouping_broadcast_identity_only(self):
+        """Tests that broadcasted identity-only observables stay fully analytical."""
+        theta = Parameter("theta")
+        circuit = QuantumCircuit(1)
+        circuit.ry(theta, 0)
+
+        pub = (
+            circuit,
+            [[SparsePauliOp("I") * 1.5], [SparsePauliOp("I") * -2.0]],
+            np.array([0.0, np.pi / 4, np.pi / 2]),
+        )
+
+        with patch.object(self.backend._device, "run") as mock_run:
+            job = self.estimator.run([pub])
+
+        mock_run.assert_not_called()
+        expected = np.array([[1.5, 1.5, 1.5], [-2.0, -2.0, -2.0]])
+        result = job.result()[0]
+        self.assertEqual(result.data.evs.shape, (2, 3))
+        self.assertEqual(result.data.stds.shape, (2, 3))
+        self.assertTrue(np.allclose(result.data.evs, expected))
+        self.assertTrue(np.allclose(result.data.stds, 0.0))
+
+    def test_grouped_bindings_zero_observable_after_simplify(self):
+        """Tests that provider grouping treats zero-simplified observables as constant."""
+        observable = SparsePauliOp(["Z", "Z"], [1.0, -1.0])
+        observables = np.empty((), dtype=object)
+        observables[()] = observable
+        parameter_indices = BraketEstimator._empty_parameter_indices(())
+
+        metadata = BraketEstimator._grouped_bindings(
+            object(), observables, parameter_indices, BindingsArray()
+        )
+
+        self.assertEqual(metadata.num_bindings, 0)
+        self.assertEqual(metadata.bindings, [])
+        self.assertEqual(metadata.identity_contributions, ())
+
+    def test_run_local_abelian_grouping_rejects_zero_observable_after_qiskit_simplify(self):
+        """Tests that Qiskit container validation rejects zero-simplified observables."""
+        circuit = QuantumCircuit(1)
+        observable = SparsePauliOp(["Z", "Z"], [1.0, -1.0])
+        pub = (circuit, observable)
+
+        with (
+            patch.object(self.backend._device, "run") as mock_run,
+            self.assertRaises(ValueError) as context,
+        ):
+            self.estimator.run([pub])
+
+        mock_run.assert_not_called()
+        self.assertIn("Empty observable was detected", str(context.exception))
+
+    def test_grouped_bindings_reuses_grouping_plan_for_matching_terms(self):
+        """Tests grouped parameter slices reuse the same QWC grouping plan."""
+        observables = np.empty((2,), dtype=object)
+        observables[:] = [SparsePauliOp(["ZI", "IZ"], [0.5, 0.25])] * 2
+        parameter_indices = np.empty((2,), dtype=object)
+        parameter_indices[:] = [(0,), (1,)]
+
+        with (
+            patch.object(
+                BraketEstimator,
+                "_group_paulis",
+                wraps=BraketEstimator._group_paulis,
+            ) as group_paulis,
+            patch.object(braket_estimator_module, "CircuitBinding", return_value=Mock()),
+        ):
+            metadata = BraketEstimator._grouped_bindings(
+                object(), observables, parameter_indices, BindingsArray()
+            )
+
+        self.assertEqual(metadata.num_bindings, 1)
+        self.assertEqual(group_paulis.call_count, 1)
+
+    def test_pauli_statistics_computes_expectation_from_samples(self):
+        """Tests Pauli statistics only processes measurement samples once."""
+        measured_entry = Mock()
+        measured_entry.measurements = np.array([[0], [1], [0], [0]])
+        measured_entry.measured_qubits = [0]
+        observable = Mock()
+        samples = np.array([1.0, -1.0, 1.0, 1.0])
+
+        with (
+            patch.object(
+                braket_estimator_module,
+                "_translate_pauli_observable",
+                return_value=observable,
+            ) as translate_observable,
+            patch.object(
+                braket_estimator_module,
+                "samples_from_measurements",
+                return_value=samples,
+            ) as samples_from_measurements,
+        ):
+            expectation, standard_error = BraketEstimator._pauli_statistics(
+                measured_entry, "Z", (0,)
+            )
+
+        translate_observable.assert_called_once_with("Z")
+        samples_from_measurements.assert_called_once_with(
+            measured_entry.measurements,
+            measured_entry.measured_qubits,
+            observable,
+            [0],
+        )
+        self.assertEqual(expectation, 0.5)
+        self.assertAlmostEqual(
+            standard_error,
+            np.sqrt(1 - expectation**2) / np.sqrt(len(samples)),
+        )
+        self.assertAlmostEqual(
+            BraketEstimator._standard_error(2.0 * samples),
+            2.0 * np.sqrt(1 - expectation**2) / np.sqrt(len(samples)),
+        )
+        self.assertEqual(BraketEstimator._pauli_statistics(measured_entry, "I"), (1.0, 0.0))
+        self.assertEqual(BraketEstimator._standard_error(np.array([])), 0.0)
+
+    def test_measured_entry_standard_error_rejects_missing_observable(self):
+        """Tests measured entry standard-error validation."""
+        measured_entry = Mock()
+        measured_entry.observable = None
+
+        with self.assertRaises(ValueError) as context:
+            BraketEstimator._measured_entry_standard_error(measured_entry)
+
+        self.assertIn("no observable", str(context.exception))
+
+    def test_translate_result_rejects_missing_task_results(self):
+        """Tests result translation validation when task results are absent."""
+        pub = EstimatorPub.coerce((QuantumCircuit(1), SparsePauliOp("Z")))
+        metadata = braket_estimator_module._JobMetadata(
+            pubs=[pub],
+            pub_metadata=[
+                braket_estimator_module._PubMetadata(
+                    bindings=[],
+                    num_bindings=1,
+                    binding_to_result_map={0: [(0, 0, 0)]},
+                    sum_binding_indices=set(),
+                    qwc_binding_metadata={},
+                    identity_contributions=(),
+                )
+            ],
+            pub_precisions=[0.1],
+            pub_shots=[100],
+            binding_locations={},
+        )
+
+        with self.assertRaises(ValueError) as context:
+            BraketEstimator._translate_result(None, metadata)
+
+        self.assertIn("Task result is required", str(context.exception))
+
+    def test_translate_result_rejects_missing_binding_location(self):
+        """Tests result translation validation when binding locations are absent."""
+        pub = EstimatorPub.coerce((QuantumCircuit(1), SparsePauliOp("Z")))
+        metadata = braket_estimator_module._JobMetadata(
+            pubs=[pub],
+            pub_metadata=[
+                braket_estimator_module._PubMetadata(
+                    bindings=[],
+                    num_bindings=1,
+                    binding_to_result_map={0: [(0, 0, 0)]},
+                    sum_binding_indices=set(),
+                    qwc_binding_metadata={},
+                    identity_contributions=(),
+                )
+            ],
+            pub_precisions=[0.1],
+            pub_shots=[100],
+            binding_locations={},
+        )
+
+        with self.assertRaises(ValueError) as context:
+            BraketEstimator._translate_result([[]], metadata)
+
+        self.assertIn("No task result location", str(context.exception))
+
+    def test_translate_result_rejects_missing_observable_index(self):
+        """Tests result translation validation for malformed observable result maps."""
+        pub = EstimatorPub.coerce((QuantumCircuit(1), SparsePauliOp("Z")))
+        program_result = _MockProgramResult([Mock()])
+        metadata = braket_estimator_module._JobMetadata(
+            pubs=[pub],
+            pub_metadata=[
+                braket_estimator_module._PubMetadata(
+                    bindings=[],
+                    num_bindings=1,
+                    binding_to_result_map={0: [(0, None, 0)]},
+                    sum_binding_indices=set(),
+                    qwc_binding_metadata={},
+                    identity_contributions=(),
+                )
+            ],
+            pub_precisions=[0.1],
+            pub_shots=[100],
+            binding_locations={(0, 0): braket_estimator_module._BindingLocation(0, 0)},
+        )
+
+        with self.assertRaises(ValueError) as context:
+            BraketEstimator._translate_result([[program_result]], metadata)
+
+        self.assertIn("Observable result entries", str(context.exception))
+
+    def test_run_local_abelian_grouping_identity_with_parameter_sweep(self):
+        """Tests analytical identity routing alongside active terms across parameters."""
+        theta = Parameter("theta")
+        circuit = QuantumCircuit(1)
+        circuit.ry(theta, 0)
+
+        num_params = 6
+        pub = (
+            circuit,
+            SparsePauliOp(["I", "Z"], [1.25, -0.5]),
+            np.linspace(0, np.pi, num_params),
+        )
+
+        task = self.estimator.run([pub])
+        program_set = task.program_set
+        self.assertEqual(len(program_set), 1)
+        self.assertEqual(len(program_set[0]), num_params)
+        self.assert_correct_results(task, [pub])
+
+    def test_run_local_abelian_grouping_dict_observable(self):
+        """Tests grouped reconstruction for dictionary observables."""
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        circuit.cx(0, 1)
+
+        pub = (circuit, {"ZZ": 0.5, "ZI": -0.25, "IZ": 0.75})
+
+        task = self.estimator.run([pub])
+        program_set = task.program_set
+        self.assertEqual(len(program_set), 1)
+        self.assertEqual(len(program_set[0]), 1)
+        self.assert_correct_results(task, [pub])
+
+    def test_real_if_close_accepts_negligible_imaginary_part(self):
+        """Tests that near-real contributions are accepted explicitly."""
+        value = BraketEstimator._real_if_close(1.25 + 1e-12j, context="test")
+
+        self.assertEqual(value, 1.25)
+
+    def test_real_if_close_rejects_complex_contribution(self):
+        """Tests that complex grouped or identity contributions are rejected explicitly."""
+        with self.assertRaises(ValueError) as context:
+            BraketEstimator._real_if_close(1.0 + 0.5j, context="test")
+
+        self.assertIn("complex expectation value", str(context.exception))
+
+    def test_run_local_abelian_grouping_y_basis(self):
+        """Tests grouped reconstruction for Y-basis covering measurements."""
+        circuit = QuantumCircuit(2)
+        circuit.rx(np.pi / 4, 0)
+        circuit.ry(np.pi / 3, 1)
+
+        pub = (circuit, [SparsePauliOp("YY"), SparsePauliOp("YI"), SparsePauliOp("IY")])
+
+        task = self.estimator.run([pub])
+        program_set = task.program_set
+        self.assertEqual(len(program_set), 1)
+        self.assertEqual(len(program_set[0]), 1)
+        self.assert_correct_results(task, [pub])
+
+    def test_run_local_abelian_grouping_mixed_basis(self):
+        """Tests grouped reconstruction for compatible mixed-basis Pauli terms."""
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        circuit.ry(np.pi / 5, 1)
+
+        pub = (circuit, [SparsePauliOp("ZI"), SparsePauliOp("IX"), SparsePauliOp("ZX")])
+
+        task = self.estimator.run([pub])
+        program_set = task.program_set
+        self.assertEqual(len(program_set), 1)
+        self.assertEqual(len(program_set[0]), 1)
+        self.assert_correct_results(task, [pub])
+
+    def test_run_local_abelian_grouping_multiple_qwc_groups(self):
+        """Tests that non-QWC terms split into multiple covering measurements."""
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        circuit.cx(0, 1)
+
+        pub = (circuit, SparsePauliOp(["ZI", "XI"], [0.5, 0.5]))
+
+        task = self.estimator.run([pub])
+        program_set = task.program_set
+        self.assertEqual(len(program_set), 1)
+        self.assertEqual(len(program_set[0]), 2)
+        self.assert_correct_results(task, [pub])
+
+    def test_run_local_abelian_grouping_splits_global_commuting_non_qwc_terms(self):
+        """Tests that globally commuting XX and YY terms remain separate QWC executions."""
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        circuit.cx(0, 1)
+
+        pub = (circuit, SparsePauliOp(["XX", "YY"], [0.5, 0.5]))
+
+        task = self.estimator.run([pub])
+        program_set = task.program_set
+        self.assertEqual(len(program_set), 1)
+        self.assertEqual(program_set.total_executables, 2)
+        self.assertEqual(len(program_set[0]), 2)
+        self.assert_correct_results(task, [pub])
+
+    def test_run_local_abelian_grouping_four_qubit_reduces_executions(self):
+        """Tests that grouped execution uses fewer executables on a four-qubit workload."""
+        circuit = QuantumCircuit(4)
+        circuit.h(0)
+        circuit.cx(0, 1)
+        circuit.cx(2, 3)
+
+        pub = (
+            circuit,
+            [
+                SparsePauliOp(["ZZII", "ZIII", "IZII"], [0.4, 0.2, -0.1]),
+                SparsePauliOp(["IIXX", "IIXI", "IIIX"], [0.3, -0.2, 0.5]),
+                SparsePauliOp(["ZZXX", "ZIXX"], [0.1, 0.7]),
+            ],
+        )
+
+        grouped_task = self.estimator.run([pub])
+        ungrouped_task = self.ungrouped_estimator.run([pub])
+        self.assertLess(
+            grouped_task.program_set.total_executables,
+            ungrouped_task.program_set.total_executables,
+        )
+        self.assert_correct_results(grouped_task, [pub])
+
+    def test_run_local_abelian_grouping_2d_broadcasting(self):
+        """Tests grouped reconstruction across a two-dimensional broadcast result."""
+        theta = Parameter("theta")
+        circuit = QuantumCircuit(2)
+        circuit.ry(theta, 0)
+        circuit.cx(0, 1)
+
+        pub = (
+            circuit,
+            [[SparsePauliOp("ZZ")], [SparsePauliOp("XX")]],
+            np.array([[0.0, np.pi / 4, np.pi / 2]]),
+        )
+
+        task = self.estimator.run([pub])
+        program_set = task.program_set
+        self.assertEqual(len(program_set), 1)
+        self.assertEqual(len(program_set[0]), 6)
+        self.assertEqual(task.result()[0].data.evs.shape, (2, 3))
+        self.assert_correct_results(task, [pub])
+
+    def test_pauli_expectation_uses_measured_qubits_metadata(self):
+        """Tests that grouped reconstruction respects Braket measurement column metadata."""
+        measured_entry = Mock()
+        measured_entry.measurements = np.array([[0, 0], [0, 0], [0, 1], [0, 1]])
+        measured_entry.measured_qubits = [1, 0]
+
+        self.assertAlmostEqual(BraketEstimator._pauli_expectation(measured_entry, "ZI"), 1.0)
 
     def test_run_local_all_pauli_sums(self):
         """Tests that correct results are returned when all observables are Pauli sums"""
@@ -376,7 +1265,7 @@ class TestBraketEstimator(TestCase):
             ]).T,
         )
 
-        task = self.estimator.run([pub])
+        task = self.ungrouped_estimator.run([pub])
         program_set = task.program_set
         self.assertEqual(len(program_set), 2)
         self.assertEqual(len(program_set[0]), num_params * 2)
@@ -407,7 +1296,7 @@ class TestBraketEstimator(TestCase):
             ),
         )
 
-        task = self.estimator.run([pub])
+        task = self.ungrouped_estimator.run([pub])
         program_set = task.program_set
         self.assertEqual(len(program_set), 3)
         for entry in task.program_set:

--- a/test/unit_tests/test_braket_estimator.py
+++ b/test/unit_tests/test_braket_estimator.py
@@ -924,6 +924,7 @@ class TestBraketEstimator(TestCase):
     def test_run_local_abelian_grouping_rejects_zero_observable_after_qiskit_simplify(self):
         """Tests that Qiskit container validation rejects zero-simplified observables."""
         circuit = QuantumCircuit(1)
+        circuit.h(0)
         observable = SparsePauliOp(["Z", "Z"], [1.0, -1.0])
         pub = (circuit, observable)
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/amazon-braket/qiskit-braket-provider/issues/255

*Description of changes:*

The current local fix implements a Braket-native qubit-wise commuting (QWC) grouping path. It reuses Qiskit's Pauli grouping utilities for the graph-colouring step, but keeps BraketEstimator responsible for Braket `CircuitBinding` / `ProgramSet` creation, task submission, metadata routing, and primitive result reconstruction.

Public API and option handling now cover the expected control surface:

- `BraketEstimatorOptions` stores `default_precision` and   `abelian_grouping`, with QWC grouping enabled by default.
- `abelian_grouping=False` can be supplied through `options`, the compatibility   constructor keyword, or the run-level
  `BraketEstimator.run(..., abelian_grouping=False)` override. - Run-level `abelian_grouping` overrides the estimator default and rejects non-boolean values.
- Estimator options are separated from Braket `device.run(...)` options, so local estimator flags are not forwarded to Braket as device options.
- `max_program_set_executables` optionally chunks submitted ProgramSets and validates invalid or impossible chunk limits.

The grouped execution path now:

- Broadcasts each PUB's observables and parameter values once.
- Converts `SparsePauliOp` and dictionary observables into simplified Pauli terms, filters zero coefficients, and routes identity terms analytically.
- Deduplicates active Pauli terms by parameter index and routes shared terms to every original observable position that needs them.
- Uses `SparsePauliOp.group_commuting(qubit_wise=True)` for QWC graph colouring.
- Builds one covering Pauli basis per QWC group by combining the grouped Pauli masks.
- Preserves QWC semantics rather than global-commuting semantics; globally commuting but non-QWC terms such as `XX` and `YY` remain separate executions.
- Builds Braket `CircuitBinding` objects for the covering bases and packs them into ProgramSets by shot bucket.
- Caches repeated grouping plans across parameter slices with the same Pauli label set. 
- Caches Pauli-to-Braket observable translation for repeated reconstruction labels.
- Reconstructs original term expectations from Braket measurement samples in a single sample-processing pass, using Braket `measured_qubits` metadata.

Result and job handling are also covered:

- Constant-only and zero-after-simplify PUBs return a completed `_ConstantResultTask` without submitting Braket work.
- Mixed PUB precisions are bucketed by effective shot count instead of being rejected.
- Multiple Braket submissions are merged by `_CompositePrimitiveTask`.
- `PubResult.data` includes both `evs` and `stds`.
- Top-level results use `PrimitiveResult(..., metadata={"version": 2})`.
- Per-PUB metadata records `target_precision`, computed `shots`, and circuit metadata.

*Testing done:* tox pass (361 passed)

  py311: commands succeeded
  py312: commands succeeded
  py313: commands succeeded
  linters: commands succeeded
  coverage: commands succeeded
  docs: commands succeeded

- Constructor and run-level `abelian_grouping` option routing.
- Legacy `abelian_grouping=False` execution shape.
- Group collapse for compatible Pauli terms.
- Shared Pauli-term routing.
- Identity-only and identity-plus-active observables.
- Zero-after-simplify observables.
- Dictionary observables.
- Y-basis and mixed-basis groups.
- Multiple QWC groups.
- The `XX` / `YY` non-QWC split.
- Parameter sweeps and two-dimensional broadcasting.
- Mixed precision shot buckets.
- Composite result aggregation.
- ProgramSet chunking and chunk-limit errors.
- Measured-qubit metadata handling.
- Non-negative `stds` shape and constant-result `stds`.

The tutorial note in
`qiskit-braket-provider/docs/tutorials/6_tutorial_primitives.ipynb` now tells
users that `BraketEstimator` groups qubit-wise commuting Pauli terms by default,
mentions the finite-shot covariance difference, and shows
`abelian_grouping=False` for callers that need the legacy per-term layout.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md) doc
- [X] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md#pr-title-format)
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/README.md) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
