### PR TITLE
feat: add abelian grouping of commuting observables to BraketEstimator

### DIFF
--- a/qiskit_braket_provider/providers/braket_estimator.py
+++ b/qiskit_braket_provider/providers/braket_estimator.py
@@ -329,9 +329,7 @@ class BraketEstimator(BaseEstimatorV2):
             grouped_colmap (dict): Per-binding qubit-to-column maps to populate (mutated in place).
         """
         # Collect every unique Pauli label across observables that share these parameter sets.
-        unique_labels = list({
-            label for ok in matching_obs_keys for label, _ in obs_keys[ok].items()
-        })
+        unique_labels = list({label for ok in matching_obs_keys for label in obs_keys[ok]})
         groups = SparsePauliOp(unique_labels).group_commuting(qubit_wise=True)
 
         # One binding per qubit-wise-commuting group, measured in that group's shared basis.
@@ -339,12 +337,12 @@ class BraketEstimator(BaseEstimatorV2):
         for group in groups:
             basis_label = BraketEstimator._group_basis_label(group)
             representative = translate_sparse_pauli_op(SparsePauliOp(basis_label))
-            support = sorted(BraketEstimator._pauli_support(basis_label))
+            basis_support = sorted(BraketEstimator._pauli_support(basis_label))
             binding_idx = len(bindings)
             bindings.append(
                 CircuitBinding(circuit, input_sets=parameter_sets, observables=[representative])
             )
-            grouped_colmap[binding_idx] = {qubit: col for col, qubit in enumerate(support)}
+            grouped_colmap[binding_idx] = {qubit: col for col, qubit in enumerate(basis_support)}
             grouped_binding_map[binding_idx] = []
             for label in group.paulis.to_labels():
                 label_to_binding[label] = binding_idx

--- a/qiskit_braket_provider/providers/braket_estimator.py
+++ b/qiskit_braket_provider/providers/braket_estimator.py
@@ -466,14 +466,13 @@ class BraketEstimator(BaseEstimatorV2):
             for local_binding_idx in range(num_bindings):
                 program_result = task_result[binding_offset + local_binding_idx]
 
-                if local_binding_idx in grouped_binding_map:
+                grouped_result_map_entry = grouped_binding_map.get(local_binding_idx)
+                if grouped_result_map_entry is not None:
                     # Abelian-grouped binding: recover each term's expectation from raw measurements
                     # via the parity of the bitstring on the term's support, then accumulate the
                     # coefficient-weighted contribution to its observable.
                     col_map = grouped_colmap[local_binding_idx]
-                    for position, param_idx, coeff, support in grouped_binding_map[
-                        local_binding_idx
-                    ]:
+                    for position, param_idx, coeff, support in grouped_result_map_entry:
                         if support:
                             measurements = program_result.entries[param_idx].measurements
                             cols = [col_map[qubit] for qubit in support]

--- a/qiskit_braket_provider/providers/braket_estimator.py
+++ b/qiskit_braket_provider/providers/braket_estimator.py
@@ -9,6 +9,7 @@ from qiskit.primitives.containers.bindings_array import BindingsArray
 from qiskit.primitives.containers.estimator_pub import EstimatorPub
 from qiskit.quantum_info import SparsePauliOp
 
+from braket.circuits import Circuit
 from braket.circuits.observables import Sum
 from braket.program_sets import CircuitBinding, ParameterSets, ProgramSet
 from braket.tasks import ProgramSetQuantumTaskResult
@@ -26,12 +27,20 @@ _DEFAULT_PRECISION = 0.015625  # Same value as BackendEstimatorV2
 _ResultMapEntry: TypeAlias = tuple[int, int | None, int]
 _ResultMap: TypeAlias = dict[int, list[_ResultMapEntry]]
 
+# Reconstruction data for an abelian-grouped binding:
+# binding_index -> [(broadcast_position, parameter_set_index, coefficient, pauli_support)]
+# where pauli_support is the tuple of qubits the Pauli term acts on non-trivially.
+_GroupedResultMapEntry: TypeAlias = tuple[int, int, float, tuple[int, ...]]
+_GroupedResultMap: TypeAlias = dict[int, list[_GroupedResultMapEntry]]
+
 
 @dataclass
 class _PubMetadata:
     num_bindings: int
     binding_to_result_map: _ResultMap
     sum_binding_indices: set[int]
+    grouped_binding_map: _GroupedResultMap
+    grouped_colmap: dict[int, dict[int, int]]
 
 
 @dataclass
@@ -54,6 +63,7 @@ class BraketEstimator(BaseEstimatorV2):
         *,
         verbatim: bool = False,
         optimization_level: int = 0,
+        abelian_grouping: bool = False,
         **options,
     ) -> None:
         """
@@ -73,12 +83,18 @@ class BraketEstimator(BaseEstimatorV2):
                 * 3: high optimization - gate resynthesis and unitary-breaking passes
 
                 Default: 0.
+            abelian_grouping (bool): Whether to group mutually qubit-wise-commuting observables so
+                that each group is estimated with a single Braket executable per parameter set,
+                rather than one executable per observable. When ``False`` every observable is
+                estimated with its own executable(s). Qiskit's ``BackendEstimatorV2`` enables the
+                equivalent grouping by default. Default: ``False``.
         """
         if not backend._supports_program_sets:
             raise ValueError("Braket device must support program sets")
         self._backend = backend
         self._verbatim = verbatim
         self._optimization_level = optimization_level
+        self._abelian_grouping = abelian_grouping
         self._options = options
 
     def run(
@@ -103,13 +119,21 @@ class BraketEstimator(BaseEstimatorV2):
         pub_metadata = []  # Track which bindings belong to which pub
 
         for pub in coerced_pubs:
-            bindings, binding_to_result_map, sum_binding_indices = self._translate_pub(pub)
+            (
+                bindings,
+                binding_to_result_map,
+                sum_binding_indices,
+                grouped_binding_map,
+                grouped_colmap,
+            ) = self._translate_pub(pub)
             all_bindings.extend(bindings)
             pub_metadata.append(
                 _PubMetadata(
                     num_bindings=len(bindings),
                     binding_to_result_map=binding_to_result_map,
                     sum_binding_indices=sum_binding_indices,
+                    grouped_binding_map=grouped_binding_map,
+                    grouped_colmap=grouped_colmap,
                 )
             )
 
@@ -135,7 +159,9 @@ class BraketEstimator(BaseEstimatorV2):
 
     def _translate_pub(
         self, pub: EstimatorPub
-    ) -> tuple[list[CircuitBinding], _ResultMap, set[int]]:
+    ) -> tuple[
+        list[CircuitBinding], _ResultMap, set[int], _GroupedResultMap, dict[int, dict[int, int]]
+    ]:
         """
         Convert an EstimatorPub to a list of CircuitBindings.
 
@@ -149,9 +175,13 @@ class BraketEstimator(BaseEstimatorV2):
             pub (EstimatorPub): The EstimatorPub to convert.
 
         Returns:
-            tuple[list[CircuitBinding], _ResultMap, set[int]]:
-            The circuit bindings, pub shape, a map of binding index to array positions,
-            and the indices of bindings with Pauli sum observables.
+            tuple[list[CircuitBinding], _ResultMap, set[int], _GroupedResultMap,
+            dict[int, dict[int, int]]]:
+            The circuit bindings, a map of binding index to array positions for
+            ungrouped bindings, the indices of bindings with Pauli sum observables,
+            a map of binding index to grouped reconstruction entries (when
+            ``abelian_grouping`` is enabled), and per-grouped-binding maps from qubit
+            index to measurement column.
         """
         backend = self._backend
         circuit = to_braket(
@@ -183,7 +213,9 @@ class BraketEstimator(BaseEstimatorV2):
 
         bindings: list[CircuitBinding] = []
         binding_to_result_map: _ResultMap = {}
-        sum_binding_indices = set()
+        sum_binding_indices: set[int] = set()
+        grouped_binding_map: _GroupedResultMap = {}
+        grouped_colmap: dict[int, dict[int, int]] = {}
         processed_obs_keys = set()
 
         for obs_key, pairs in obs_groups.items():
@@ -202,16 +234,30 @@ class BraketEstimator(BaseEstimatorV2):
             ]
             processed_obs_keys.update(matching_obs_keys)
             param_idx_map = {pk: idx for idx, pk in enumerate(param_indices)}
-
-            braket_observables = [
-                translate_sparse_pauli_op(SparsePauliOp.from_list(obs_keys[ok].items()))
-                for ok in matching_obs_keys
-            ]
             parameter_sets = (
                 BraketEstimator._translate_parameters([param_values[pi] for pi in param_indices])
                 if param_values.data
                 else None
             )
+
+            if self._abelian_grouping:
+                self._emit_commuting_groups(
+                    circuit,
+                    matching_obs_keys,
+                    obs_keys,
+                    obs_groups,
+                    param_idx_map,
+                    parameter_sets,
+                    bindings,
+                    grouped_binding_map,
+                    grouped_colmap,
+                )
+                continue
+
+            braket_observables = [
+                translate_sparse_pauli_op(SparsePauliOp.from_list(obs_keys[ok].items()))
+                for ok in matching_obs_keys
+            ]
             binding_idx = len(bindings)
             monomials = []
             for ok, observable in zip(matching_obs_keys, braket_observables, strict=True):
@@ -243,7 +289,119 @@ class BraketEstimator(BaseEstimatorV2):
                     for ok, _ in monomials
                     for position, pi in obs_groups[ok]
                 ]
-        return bindings, binding_to_result_map, sum_binding_indices
+        return (
+            bindings,
+            binding_to_result_map,
+            sum_binding_indices,
+            grouped_binding_map,
+            grouped_colmap,
+        )
+
+    def _emit_commuting_groups(
+        self,
+        circuit: Circuit,
+        matching_obs_keys: list,
+        obs_keys: dict,
+        obs_groups: dict,
+        param_idx_map: dict,
+        parameter_sets: ParameterSets | None,
+        bindings: list[CircuitBinding],
+        grouped_binding_map: _GroupedResultMap,
+        grouped_colmap: dict[int, dict[int, int]],
+    ) -> None:
+        """
+        Partition the Pauli terms of the given observables into qubit-wise-commuting groups and
+        append one ``CircuitBinding`` (one Braket executable per parameter set) per group.
+
+        Every term in a qubit-wise-commuting group shares the same single-qubit measurement basis,
+        so a single basis-representative observable measures all of them at once. The per-term
+        expectation values are recovered from the raw measurements during result reconstruction.
+
+        Args:
+            circuit: The translated Braket circuit shared by these observables.
+            matching_obs_keys (list): Observable keys sharing the same parameter sets.
+            obs_keys (dict): Map from observable key to the observable (Pauli label -> coefficient).
+            obs_groups (dict): Map from observable key to ``(broadcast_position, param_index)`` pairs.
+            param_idx_map (dict): Map from broadcast parameter index to its position in the binding.
+            parameter_sets: Translated Braket parameter sets, or ``None`` for non-parameterized pubs.
+            bindings (list[CircuitBinding]): The binding list to append to (mutated in place).
+            grouped_binding_map (_GroupedResultMap): Reconstruction map to populate (mutated in place).
+            grouped_colmap (dict): Per-binding qubit-to-column maps to populate (mutated in place).
+        """
+        # Collect every unique Pauli label across observables that share these parameter sets.
+        unique_labels = list({
+            label for ok in matching_obs_keys for label, _ in obs_keys[ok].items()
+        })
+        groups = SparsePauliOp(unique_labels).group_commuting(qubit_wise=True)
+
+        # One binding per qubit-wise-commuting group, measured in that group's shared basis.
+        label_to_binding: dict[str, int] = {}
+        for group in groups:
+            basis_label = BraketEstimator._group_basis_label(group)
+            representative = translate_sparse_pauli_op(SparsePauliOp(basis_label))
+            support = sorted(BraketEstimator._pauli_support(basis_label))
+            binding_idx = len(bindings)
+            bindings.append(
+                CircuitBinding(circuit, input_sets=parameter_sets, observables=[representative])
+            )
+            grouped_colmap[binding_idx] = {qubit: col for col, qubit in enumerate(support)}
+            grouped_binding_map[binding_idx] = []
+            for label in group.paulis.to_labels():
+                label_to_binding[label] = binding_idx
+
+        # Route each observable's terms to the binding that measures their group.
+        for ok in matching_obs_keys:
+            positions = obs_groups[ok]
+            for label, coeff in obs_keys[ok].items():
+                binding_idx = label_to_binding[label]
+                support = BraketEstimator._pauli_support(label)
+                weight = float(np.real(coeff))
+                grouped_binding_map[binding_idx].extend(
+                    (position, param_idx_map[pi], weight, support) for position, pi in positions
+                )
+
+    @staticmethod
+    def _pauli_support(label: str) -> tuple[int, ...]:
+        """Return the qubit indices on which a Pauli ``label`` acts non-trivially.
+
+        Args:
+            label (str): A Qiskit Pauli label (little-endian: rightmost character is qubit 0).
+
+        Returns:
+            tuple[int, ...]: The qubit indices whose character is not ``"I"``.
+        """
+        n = len(label)
+        return tuple(q for q in range(n) if label[n - 1 - q] != "I")
+
+    @staticmethod
+    def _group_basis_label(group: SparsePauliOp) -> str:
+        """Return the shared single-qubit measurement basis of a qubit-wise-commuting group.
+
+        Within such a group every non-identity term agrees on each qubit's Pauli, so the basis is
+        well defined per qubit (``X``/``Y``/``Z``, or ``I`` where no term acts).
+
+        Args:
+            group (SparsePauliOp): A qubit-wise-commuting group of Pauli terms.
+
+        Returns:
+            str: A Qiskit Pauli label describing the per-qubit measurement basis.
+        """
+        x = group.paulis.x
+        z = group.paulis.z
+        num_qubits = x.shape[1]
+        chars = []
+        for q in range(num_qubits):
+            has_x = bool(x[:, q].any())
+            has_z = bool(z[:, q].any())
+            if has_x and not has_z:
+                chars.append("X")
+            elif has_x and has_z:
+                chars.append("Y")
+            elif has_z:
+                chars.append("Z")
+            else:
+                chars.append("I")
+        return "".join(reversed(chars))
 
     @staticmethod
     def _make_obs_key(obs_val: SparsePauliOp | dict[str, float]) -> str:
@@ -303,12 +461,32 @@ class BraketEstimator(BaseEstimatorV2):
             broadcast_shape = pub.shape
             binding_map = pub_meta.binding_to_result_map
             sum_binding_indices = pub_meta.sum_binding_indices
+            grouped_binding_map = pub_meta.grouped_binding_map
+            grouped_colmap = pub_meta.grouped_colmap
 
             evs = np.zeros(broadcast_shape, dtype=float)
             for local_binding_idx in range(num_bindings):
                 program_result = task_result[binding_offset + local_binding_idx]
-                num_observables = len(program_result.observables)
 
+                if local_binding_idx in grouped_binding_map:
+                    # Abelian-grouped binding: recover each term's expectation from raw measurements
+                    # via the parity of the bitstring on the term's support, then accumulate the
+                    # coefficient-weighted contribution to its observable.
+                    col_map = grouped_colmap[local_binding_idx]
+                    for position, param_idx, coeff, support in grouped_binding_map[
+                        local_binding_idx
+                    ]:
+                        if support:
+                            measurements = program_result.entries[param_idx].measurements
+                            cols = [col_map[qubit] for qubit in support]
+                            parity = measurements[:, cols].sum(axis=1) % 2
+                            expectation = float(np.mean(1.0 - 2.0 * parity))
+                        else:
+                            expectation = 1.0  # identity term
+                        evs[np.unravel_index(position, broadcast_shape)] += coeff * expectation
+                    continue
+
+                num_observables = len(program_result.observables)
                 for position, obs_idx, param_idx in binding_map[local_binding_idx]:
                     # CircuitBinding returns results organized by parameter sets
                     # For each parameter, we get all observables

--- a/test/unit_tests/test_braket_estimator.py
+++ b/test/unit_tests/test_braket_estimator.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Iterable
 from unittest import TestCase
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import numpy as np
 from qiskit import QuantumCircuit
@@ -15,7 +15,11 @@ from qiskit.quantum_info import SparsePauliOp
 
 from braket.program_sets import ProgramSet
 from qiskit_braket_provider.providers import BraketLocalBackend
-from qiskit_braket_provider.providers.braket_estimator import BraketEstimator
+from qiskit_braket_provider.providers.braket_estimator import (
+    BraketEstimator,
+    _JobMetadata,
+    _PubMetadata,
+)
 from qiskit_braket_provider.providers.braket_primitive_task import BraketPrimitiveTask
 
 
@@ -413,3 +417,92 @@ class TestBraketEstimator(TestCase):
         for entry in task.program_set:
             self.assertEqual(len(entry), num_steps * 2)
         self.assert_correct_results(task, [pub])
+
+    def test_abelian_grouping_reduces_executables(self):
+        """Grouping co-measures qubit-wise-commuting observables, cutting Braket executables."""
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        circuit.cx(0, 1)
+        # Z-basis {ZZ, IZ, ZI}, X-basis {XX, XI}, Y-basis {YY}: 6 observables, 3 commuting groups.
+        observables = [SparsePauliOp(p) for p in ["ZZ", "IZ", "ZI", "XX", "XI", "YY"]]
+        pub = (circuit, observables)
+
+        ungrouped = BraketEstimator(self.backend, abelian_grouping=False).run([pub], precision=0.05)
+        grouped = BraketEstimator(self.backend, abelian_grouping=True).run([pub], precision=0.05)
+
+        self.assertEqual(ungrouped.program_set.total_executables, 6)
+        self.assertEqual(grouped.program_set.total_executables, 3)
+        self.assert_correct_results(grouped, [pub])
+
+    def test_abelian_grouping_matches_reference_no_parameters(self):
+        """Grouped estimates match BackendEstimatorV2 for mixed commuting / sum / identity terms."""
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        circuit.cx(0, 1)
+        observables = [
+            SparsePauliOp(["ZZ", "ZI", "II"], [1.0, 0.5, 0.25]),  # commuting terms plus identity
+            SparsePauliOp(["XX", "YY"], [0.5, 0.5]),  # spans two measurement bases
+            SparsePauliOp("XI"),
+        ]
+        pub = (circuit, observables)
+        task = BraketEstimator(self.backend, abelian_grouping=True).run([pub], precision=0.02)
+        self.assert_correct_results(task, [pub])
+
+    def test_abelian_grouping_matches_reference_parameterized(self):
+        """Grouped estimates match BackendEstimatorV2 with parameters and broadcasting."""
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        circuit.cx(0, 1)
+        circuit.ry(Parameter("θ"), 0)
+        num_steps = 5
+        pub = (
+            circuit,
+            [[SparsePauliOp("ZZ")], [SparsePauliOp("ZI")], [SparsePauliOp("XX")]],
+            np.linspace(0, np.pi, num_steps),
+        )
+        task = BraketEstimator(self.backend, abelian_grouping=True).run([pub], precision=0.03)
+        self.assert_correct_results(task, [pub])
+
+    def test_abelian_grouping_parity_reconstruction_exact(self):
+        """Deterministically pin the grouped parity reconstruction without the simulator.
+
+        Feeds a hand-built bitstring array through ``_translate_result`` and asserts exact
+        expectation values. The single-qubit observables have distinct values so a qubit-to-column
+        swap would change the result and fail the test.
+        """
+        # One Z-basis group binding over 2 qubits; columns chosen so <Z_q0> != <Z_q1>.
+        measurements = np.array([[0, 0], [0, 1], [0, 1], [1, 1]])
+        # col0 = [0,0,0,1] -> <Z on q0> = +0.5 ; col1 = [0,1,1,1] -> <Z on q1> = -0.5
+
+        # task_result[binding][param].measurements -> the hand-built bitstrings
+        composite_entry = Mock(entries=[Mock(measurements=measurements)])
+        task_result = MagicMock()
+        task_result.__getitem__.return_value = composite_entry
+
+        circuit = QuantumCircuit(2)
+        observables = [
+            SparsePauliOp("ZZ"),  # support q0, q1            -> 0.0
+            SparsePauliOp("IZ"),  # Z on q0 (little-endian)   -> +0.5
+            SparsePauliOp("ZI"),  # Z on q1                   -> -0.5
+            SparsePauliOp(["II"], [0.5]),  # identity         -> 0.5 * 1
+        ]
+        pub = EstimatorPub.coerce((circuit, observables))
+
+        pub_meta = _PubMetadata(
+            num_bindings=1,
+            binding_to_result_map={},
+            sum_binding_indices=set(),
+            grouped_binding_map={
+                0: [
+                    (0, 0, 1.0, (0, 1)),
+                    (1, 0, 1.0, (0,)),
+                    (2, 0, 1.0, (1,)),
+                    (3, 0, 0.5, ()),
+                ]
+            },
+            grouped_colmap={0: {0: 0, 1: 1}},
+        )
+        metadata = _JobMetadata(pubs=[pub], pub_metadata=[pub_meta], precision=0.01, shots=4)
+
+        evs = BraketEstimator._translate_result(task_result, metadata)[0].data.evs
+        np.testing.assert_allclose(evs, [0.0, 0.5, -0.5, 0.5])

--- a/test/unit_tests/test_braket_estimator.py
+++ b/test/unit_tests/test_braket_estimator.py
@@ -448,6 +448,21 @@ class TestBraketEstimator(TestCase):
         task = BraketEstimator(self.backend, abelian_grouping=True).run([pub], precision=0.02)
         self.assert_correct_results(task, [pub])
 
+    def test_abelian_grouping_partial_support_identity_basis(self):
+        """A group acting on only some qubits measures identity on the untouched qubits.
+
+        ``IX`` and ``IZ`` don't qubit-wise commute, so each forms its own single-term group whose
+        shared basis is identity on the qubit no term acts on, exercising the identity branch of
+        the per-qubit basis construction.
+        """
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        circuit.cx(0, 1)
+        observables = [SparsePauliOp("IX"), SparsePauliOp("IZ")]
+        pub = (circuit, observables)
+        task = BraketEstimator(self.backend, abelian_grouping=True).run([pub], precision=0.02)
+        self.assert_correct_results(task, [pub])
+
     def test_abelian_grouping_matches_reference_parameterized(self):
         """Grouped estimates match BackendEstimatorV2 with parameters and broadcasting."""
         circuit = QuantumCircuit(2)


### PR DESCRIPTION
*Issue #, if available:* Closes #255

*Description of changes:*

This is a unitaryHACK 2026 bounty submission for #255.

`BraketEstimator` currently submits at least one Braket executable for every
observable in an `EstimatorPub`, even when several observables share a
measurement basis. This adds an opt-in `abelian_grouping` option that groups
mutually qubit-wise-commuting Pauli terms across a pub's observables and submits
a single executable per group per parameter set, mirroring Qiskit's
`BackendEstimatorV2`.

How it works:
- Collect the unique Pauli terms across the pub's observables and partition them
  with `SparsePauliOp.group_commuting(qubit_wise=True)`.
- Emit one `CircuitBinding` per group, measured in that group's shared
  single-qubit basis.
- Reconstruct each observable's expectation from the group's raw measurements via
  bitstring parity on each term's support.

Two design choices worth calling out:
- The default is `False`, which preserves the current executable layout and
  leaves every existing test unchanged. Pass `abelian_grouping=True` to enable.
  `BackendEstimatorV2` enables the equivalent grouping by default, so I am happy
  to flip the default to match if you prefer.
- The flag lives on the constructor rather than `run()`, because
  `BaseEstimatorV2.run(pubs, *, precision)` has a fixed signature and
  `BackendEstimatorV2` carries the equivalent setting as an option. Easy to move
  to `run()` if you would rather follow the issue text literally.

On semantics: grouped observables share one executable's shots, so each
observable keeps the same per-observable precision while total shots drop, and
estimates within a group become correlated (they come from the same measurement
samples). This is the expected behavior of abelian grouping.

*Testing done:*

All offline against `BraketLocalBackend` (no AWS account or region required):
- `test_abelian_grouping_reduces_executables`: six observables collapse from six
  executables to three, and the values still match the reference.
- `test_abelian_grouping_matches_reference_no_parameters` and
  `test_abelian_grouping_matches_reference_parameterized`: grouped expectation
  values match `BackendEstimatorV2` on the local simulator, covering a multi-term
  sum, an identity term, parameters, and broadcasting.
- `test_abelian_grouping_parity_reconstruction_exact`: feeds a hand-built
  measurement array through the reconstruction and asserts exact values, pinning
  the parity math and qubit-to-column mapping without simulator noise.
- Full estimator suite passes (21 passed); the 17 pre-existing tests are
  unchanged. `ruff check` and `ruff format` are clean.

AI assistance: I used an AI coding assistant (Claude Code) while implementing and
testing this, with a human in the loop throughout. I reviewed every line, made
the design decisions above, and can explain and defend the implementation.
Disclosed per unitaryHACK's AI policy.

## Merge Checklist

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md#pr-title-format)
- [x] I have updated any necessary documentation (the new option is documented in the `BraketEstimator` docstring)

#### Tests

- [x] I have added tests that prove my feature works
- [x] I have checked that my tests are not configured for a specific region or account

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
