### PR TITLE
feat: support Braket parameter expressions in to_qiskit

### DIFF
--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -46,7 +46,7 @@ from qiskit.transpiler import (
     TransformationPass,
 )
 from qiskit_ionq import add_equivalences, ionq_gates
-from sympy import Add, Expr, Mul, Pow, Symbol
+from sympy import Add, Expr, Function, Mul, Pow, Symbol
 
 from braket import experimental_capabilities as braket_expcaps
 from braket.aws import AwsDevice, AwsDeviceType
@@ -300,6 +300,27 @@ _PAULI_MAP = {
     "Y": braket_observables.Y,
     "Z": braket_observables.Z,
 }
+
+_SYMPY_UNARY_TO_QISKIT_METHOD: dict[str, str] = {
+    "sin": "sin",
+    "cos": "cos",
+    "tan": "tan",
+    "exp": "exp",
+    "log": "log",
+    "asin": "arcsin",
+    "acos": "arccos",
+    "atan": "arctan",
+}
+
+_UNSUPPORTED_SYMPY_FUNCTIONS = frozenset({
+    "Mod",
+    "ceiling",
+    "floor",
+    "Abs",
+    "re",
+    "im",
+    "conjugate",
+})
 
 _BRAKET_VERBATIM_BOX_NAME = "verbatim"
 
@@ -1798,7 +1819,7 @@ def _translate_to_braket(
     if has_nonzero_phase:
         if (target and "global_phase" in target) or (basis_gates and "global_phase" in basis_gates):
             if isinstance(global_phase, ParameterExpression):
-                global_phase = FreeParameterExpression(rename_parameter(global_phase))
+                global_phase = _parameter_expression_to_braket(global_phase)
             braket_circuit.gphase(global_phase)
         else:
             warnings.warn(
@@ -1842,7 +1863,7 @@ def _create_free_parameters(operation: QiskitInstruction) -> list[Any]:
             case Parameter() | ParameterVectorElement():
                 params[i] = FreeParameter(rename_parameter(param))
             case ParameterExpression():
-                params[i] = FreeParameterExpression(rename_parameter(param))
+                params[i] = _parameter_expression_to_braket(param)
     return params
 
 
@@ -1901,6 +1922,24 @@ def rename_parameter(parameter: Parameter) -> str:
         str: The Braket-compatible parameter name.
     """
     return str(parameter).replace("[", "_").replace("]", "")
+
+
+def _rename_sympy_symbols(expr: Expr) -> Expr:
+    renames = {
+        symbol: Symbol(str(symbol).replace("[", "_").replace("]", ""))
+        for symbol in expr.free_symbols
+        if "[" in str(symbol) or "]" in str(symbol)
+    }
+    return expr.subs(renames) if renames else expr
+
+
+def _parameter_expression_to_braket(
+    parameter_expression: ParameterExpression,
+) -> FreeParameterExpression:
+    try:
+        return FreeParameterExpression(rename_parameter(parameter_expression))
+    except ValueError:
+        return FreeParameterExpression(_rename_sympy_symbols(parameter_expression.sympify()))
 
 
 def _validate_name_conflicts(parameters: Collection[Parameter]) -> None:
@@ -2063,6 +2102,12 @@ def _create_qiskit_kraus(gate_params: list[np.ndarray]) -> Instruction:
     return qiskit_qi.Kraus(gate_params)
 
 
+def _numeric_exponent(exp: Expr) -> int | float:
+    if not getattr(exp, "is_number", False) or not getattr(exp, "is_real", False):
+        raise TypeError(f"unrecognized parameter type in conversion: {type(exp)}")
+    return int(exp) if getattr(exp, "is_integer", False) else float(exp)
+
+
 def _sympy_to_qiskit(
     expr: Expr, param_map: dict[str, Parameter]
 ) -> ParameterExpression | Parameter:
@@ -2077,8 +2122,22 @@ def _sympy_to_qiskit(
         case Mul(args=args):
             return prod(_sympy_to_qiskit(arg, param_map) for arg in args)
         case Pow(base=base, exp=exp):
-            return _sympy_to_qiskit(base, param_map) ** int(exp)
-        case obj if getattr(obj, "is_real", False):
+            return _sympy_to_qiskit(base, param_map) ** _numeric_exponent(exp)
+        case obj if isinstance(obj, Function):
+            fn_name = obj.func.__name__
+            if fn_name in _UNSUPPORTED_SYMPY_FUNCTIONS:
+                raise TypeError(
+                    f"OpenQASM 3 function '{fn_name}' has no Qiskit ParameterExpression equivalent"
+                )
+            if fn_name == "sqrt":
+                if len(obj.args) != 1:
+                    raise TypeError(f"unrecognized parameter type in conversion: {fn_name}")
+                return _sympy_to_qiskit(obj.args[0], param_map) ** 0.5
+            if fn_name not in _SYMPY_UNARY_TO_QISKIT_METHOD or len(obj.args) != 1:
+                raise TypeError(f"unrecognized parameter type in conversion: {fn_name}")
+            qiskit_arg = _sympy_to_qiskit(obj.args[0], param_map)
+            return getattr(qiskit_arg, _SYMPY_UNARY_TO_QISKIT_METHOD[fn_name])()
+        case obj if getattr(obj, "is_number", False) and getattr(obj, "is_real", False):
             return float(obj)
     raise TypeError(f"unrecognized parameter type in conversion: {type(expr)}")
 

--- a/test/unit_tests/test_adapter.py
+++ b/test/unit_tests/test_adapter.py
@@ -35,7 +35,21 @@ from braket.device_schema.standardized_gate_model_qpu_device_properties_v1 impor
 from braket.devices import LocalSimulator
 from braket.experimental_capabilities import EnableExperimentalCapability
 from braket.ir.openqasm import Program
-from braket.parametric import FreeParameter
+from braket.parametric import (
+    FreeParameter,
+    arccos,
+    arcsin,
+    arctan,
+    ceiling,
+    cos,
+    exp,
+    floor,
+    log,
+    mod,
+    sin,
+    sqrt,
+    tan,
+)
 from braket.pulse import PulseSequence
 from braket.registers import QubitSet
 from qiskit_braket_provider import exception, to_braket, to_qiskit
@@ -931,6 +945,54 @@ class TestAdapter(TestCase):
         )
         assert braket_circuit == expected_braket_circuit
 
+    def test_parameter_expression_division(self):
+        """Tests ParameterExpression translation with division."""
+        qiskit_circuit = QuantumCircuit(1)
+        qiskit_circuit.rx(Parameter("alpha") / Parameter("beta"), 0)
+        braket_circuit = to_braket(qiskit_circuit)
+
+        expected_braket_circuit = Circuit().rx(
+            0, FreeParameter("alpha") / FreeParameter("beta")
+        )
+        assert braket_circuit == expected_braket_circuit
+
+    def test_parameter_expression_trig(self):
+        """Tests ParameterExpression translation with transcendental functions."""
+        qiskit_circuit = QuantumCircuit(1)
+        alpha, beta = Parameter("alpha"), Parameter("beta")
+        qiskit_circuit.rx(alpha.sin() + beta.cos(), 0)
+        qiskit_circuit.ry(alpha.arcsin(), 0)
+        qiskit_circuit.rz(alpha**0.5 + beta.log(), 0)
+        braket_circuit = to_braket(qiskit_circuit)
+
+        expected_braket_circuit = (
+            Circuit()
+            .rx(0, sin(FreeParameter("alpha")) + cos(FreeParameter("beta")))
+            .ry(0, arcsin(FreeParameter("alpha")))
+            .rz(0, FreeParameter("alpha") ** 0.5 + log(FreeParameter("beta")))
+        )
+        assert braket_circuit == expected_braket_circuit
+
+    def test_parameter_expression_trig_round_trip(self):
+        """Tests Qiskit to Braket to Qiskit round trip for parameter functions."""
+        qiskit_circuit = QuantumCircuit(1)
+        alpha, beta = Parameter("alpha"), Parameter("beta")
+        qiskit_circuit.rx(alpha.sin() + beta / alpha, 0)
+        qiskit_circuit.ry(alpha.arcsin(), 0)
+
+        qiskit_back = to_qiskit(to_braket(qiskit_circuit), add_measurements=False)
+
+        inputs = {"alpha": 0.3, "beta": 0.7}
+        original_angles = [
+            qiskit_circuit.assign_parameters(inputs).data[index].operation.params[0]
+            for index in range(2)
+        ]
+        round_trip_angles = [
+            qiskit_back.assign_parameters(inputs).data[index].operation.params[0]
+            for index in range(2)
+        ]
+        assert np.allclose(original_angles, round_trip_angles)
+
     def test_name_conflict_with_parameter_vector(self):
         """Tests ParameterExpression translation."""
         qiskit_circuit = QuantumCircuit(1)
@@ -1488,6 +1550,190 @@ class TestFromBraket(TestCase):
         expected_qiskit_circuit.measure_all()
         self.assertEqual(qiskit_circuit, expected_qiskit_circuit)
 
+    def test_parametric_symbolic_power_rejected(self):
+        """Tests Braket to Qiskit conversion rejects non-numeric exponents."""
+        braket_circuit = Circuit().rx(0, FreeParameter("alpha") ** FreeParameter("beta"))
+
+        with pytest.raises(
+            TypeError,
+            match=r"unrecognized parameter type in conversion: ",
+        ):
+            to_qiskit(braket_circuit)
+
+    def test_parametric_unary_functions(self):
+        """Tests Braket to Qiskit conversion with unary parameter functions."""
+        alpha = FreeParameter("alpha")
+        unary_methods = {
+            sin: "sin",
+            cos: "cos",
+            tan: "tan",
+            exp: "exp",
+            log: "log",
+            arcsin: "arcsin",
+            arccos: "arccos",
+            arctan: "arctan",
+        }
+
+        for braket_fn, qiskit_method in unary_methods.items():
+            with self.subTest(braket_fn=braket_fn.__name__):
+                braket_circuit = Circuit().rx(0, braket_fn(alpha))
+                qiskit_circuit = to_qiskit(braket_circuit)
+
+                uuid = qiskit_circuit.parameters[0].uuid
+
+                expected_qiskit_circuit = QuantumCircuit(1)
+                qiskit_alpha = Parameter("alpha", uuid=uuid)
+                expected_qiskit_circuit.rx(getattr(qiskit_alpha, qiskit_method)(), 0)
+                expected_qiskit_circuit.measure_all()
+
+                self.assertEqual(qiskit_circuit, expected_qiskit_circuit)
+
+        braket_circuit = Circuit().rx(0, sqrt(alpha))
+        qiskit_circuit = to_qiskit(braket_circuit)
+
+        uuid = qiskit_circuit.parameters[0].uuid
+
+        expected_qiskit_circuit = QuantumCircuit(1)
+        expected_qiskit_circuit.rx(Parameter("alpha", uuid=uuid) ** 0.5, 0)
+        expected_qiskit_circuit.measure_all()
+
+        self.assertEqual(qiskit_circuit, expected_qiskit_circuit)
+
+    def test_parametric_nested_expression(self):
+        """Tests Braket to Qiskit conversion with nested function and arithmetic."""
+        braket_circuit = Circuit().rx(
+            0, sqrt(sin(FreeParameter("alpha")) + FreeParameter("beta") ** 2)
+        )
+        qiskit_circuit = to_qiskit(braket_circuit, add_measurements=False)
+
+        alpha = next(
+            parameter for parameter in qiskit_circuit.parameters if parameter.name == "alpha"
+        )
+        beta = next(
+            parameter for parameter in qiskit_circuit.parameters if parameter.name == "beta"
+        )
+        expected_angle = (alpha.sin() + beta**2) ** 0.5
+
+        inputs = {"alpha": 0.2, "beta": 0.5}
+        braket_angle = braket_circuit(**inputs).instructions[0].operator.angle
+        qiskit_angle = qiskit_circuit.assign_parameters(inputs).data[0].operation.params[0]
+
+        self.assertTrue(np.isclose(braket_angle, qiskit_angle))
+        self.assertEqual(qiskit_circuit.data[0].operation.params[0], expected_angle)
+
+    def test_parametric_arithmetic_expressions(self):
+        """Tests Braket to Qiskit conversion with arithmetic parameter expressions."""
+        braket_circuit = (
+            Circuit()
+            .rx(0, FreeParameter("alpha") / FreeParameter("beta"))
+            .ry(0, 2 * FreeParameter("alpha") - FreeParameter("beta"))
+            .rz(0, FreeParameter("alpha") ** 2 + FreeParameter("beta") ** 0.5)
+        )
+        qiskit_circuit = to_qiskit(braket_circuit, add_measurements=False)
+
+        inputs = {"alpha": 0.7, "beta": 0.3}
+        braket_angles = [
+            braket_circuit(**inputs).instructions[index].operator.angle
+            for index in range(3)
+        ]
+        qiskit_angles = [
+            qiskit_circuit.assign_parameters(inputs)
+            .data[index]
+            .operation.params[0]
+            for index in range(3)
+        ]
+        self.assertTrue(np.allclose(braket_angles, qiskit_angles))
+
+    def test_parametric_transcendental_expressions(self):
+        """Tests Braket to Qiskit conversion with transcendental parameter expressions."""
+        braket_circuit = (
+            Circuit()
+            .rx(
+                0,
+                sin(FreeParameter("alpha"))
+                + cos(FreeParameter("beta"))
+                + tan(FreeParameter("gamma")),
+            )
+            .ry(
+                0,
+                exp(FreeParameter("delta"))
+                + log(FreeParameter("epsilon"))
+                + sqrt(FreeParameter("zeta")),
+            )
+            .rz(
+                0,
+                arcsin(FreeParameter("eta"))
+                + arccos(FreeParameter("theta"))
+                + arctan(FreeParameter("iota")),
+            )
+        )
+        qiskit_circuit = to_qiskit(braket_circuit, add_measurements=False)
+
+        params = {param.name: param for param in qiskit_circuit.parameters}
+
+        expected_qiskit_circuit = QuantumCircuit(1)
+        expected_qiskit_circuit.rx(
+            params["alpha"].sin()
+            + params["beta"].cos()
+            + params["gamma"].tan(),
+            0,
+        )
+        expected_qiskit_circuit.ry(
+            params["delta"].exp()
+            + params["epsilon"].log()
+            + params["zeta"] ** 0.5,
+            0,
+        )
+        expected_qiskit_circuit.rz(
+            params["eta"].arcsin()
+            + params["theta"].arccos()
+            + params["iota"].arctan(),
+            0,
+        )
+
+        self.assertEqual(qiskit_circuit, expected_qiskit_circuit)
+
+    def test_openqasm3_parametric_expressions(self):
+        """Tests OpenQASM 3 gate angles with composite parameter expressions."""
+        braket_circuit = (
+            Circuit()
+            .rx(
+                0,
+                sin(FreeParameter("theta"))
+                + FreeParameter("alpha") / FreeParameter("beta"),
+            )
+            .ry(0, sqrt(FreeParameter("gamma")))
+        )
+        qiskit_circuit = to_qiskit(braket_circuit.to_ir().source, add_measurements=False)
+
+        inputs = {"theta": 0.4, "alpha": 1.0, "beta": 2.0, "gamma": 0.25}
+        braket_angles = [
+            braket_circuit(**inputs).instructions[index].operator.angle
+            for index in range(2)
+        ]
+        qiskit_angles = [
+            qiskit_circuit.assign_parameters(inputs)
+            .data[index]
+            .operation.params[0]
+            for index in range(2)
+        ]
+        self.assertTrue(np.allclose(braket_angles, qiskit_angles))
+
+    def test_unsupported_openqasm_functions(self):
+        """Tests if TypeError is raised for unsupported OpenQASM 3 functions."""
+        unsupported_expressions = [
+            mod(FreeParameter("alpha"), 2),
+            ceiling(FreeParameter("alpha")),
+            floor(FreeParameter("alpha")),
+        ]
+        for expression in unsupported_expressions:
+            braket_circuit = Circuit().rx(0, expression)
+            with pytest.raises(
+                TypeError,
+                match=r"OpenQASM 3 function '.+' has no Qiskit ParameterExpression equivalent",
+            ):
+                to_qiskit(braket_circuit)
+
     def test_unsupported_parameter_division(self):
         """Tests if TypeError is raised for parameter division."""
         braket_circuit = Circuit().rx(0, 1j * FreeParameter("alpha"))
@@ -1706,6 +1952,38 @@ class TestThereAndBackAgain(TestCase):
             to_braket(to_qiskit(circ, add_measurements=False)), add_measurements=False
         )  # fails
         assert np.allclose(Operator(stayed_home).data, Operator(lonely_mountain_and_back).data)
+
+    def test_parameter_expression_round_trip(self):
+        """Tests numeric equivalence for Braket to Qiskit parameter expression conversion."""
+        braket_circuit = (
+            Circuit()
+            .rx(
+                0,
+                sin(FreeParameter("alpha"))
+                + FreeParameter("beta") / FreeParameter("gamma"),
+            )
+            .ry(0, FreeParameter("delta") ** 2 + sqrt(FreeParameter("epsilon")))
+        )
+        qiskit_circuit = to_qiskit(braket_circuit, add_measurements=False)
+
+        inputs = {
+            "alpha": 0.3,
+            "beta": 1.0,
+            "gamma": 2.0,
+            "delta": 0.4,
+            "epsilon": 0.25,
+        }
+        braket_angles = [
+            braket_circuit(**inputs).instructions[index].operator.angle
+            for index in range(2)
+        ]
+        qiskit_angles = [
+            qiskit_circuit.assign_parameters(inputs)
+            .data[index]
+            .operation.params[0]
+            for index in range(2)
+        ]
+        assert np.allclose(braket_angles, qiskit_angles)
 
     def test_missing_qubit_in_properties_handled_gracefully(self):
         """Tests that missing qubits in topology are handled gracefully with warnings."""


### PR DESCRIPTION
*Issue #, if available:*
Closes #153

*Description of changes:*

- Introduced new functions to handle parameter expressions, including support for unary and transcendental functions.
- Updated the translation logic to accommodate division and nested expressions.


*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md) doc
- [X] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md#pr-title-format)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/README.md) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
