### PR TITLE
fix: accept op-less QuantumCircuit in _get_circuits

### DIFF
--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -1637,11 +1637,11 @@ def _get_circuits(
     circuit: _Translatable | Iterable[_Translatable] | None,
     add_measurements: bool,
 ) -> tuple[list[QuantumCircuit], bool]:
-    if not (circuits or circuit):
+    if circuit is not None and circuits is not None:
+        raise ValueError("Cannot specify both circuits and circuit")
+    if circuit is None and circuits is None:
         raise ValueError("Must specify circuits to transpile")
-    if circuit:
-        if circuits:
-            raise ValueError("Cannot specify both circuits and circuit")
+    if circuit is not None:
         warnings.warn(
             "circuit is deprecated; use circuits instead.", DeprecationWarning, stacklevel=1
         )

--- a/test/unit_tests/test_adapter.py
+++ b/test/unit_tests/test_adapter.py
@@ -492,6 +492,13 @@ class TestAdapter(TestCase):
         with pytest.raises(ValueError, match="Cannot specify both circuits and circuit"):
             to_braket([circuit], circuit=[circuit])
 
+    def test_op_less_circuit_is_accepted(self):
+        assert isinstance(to_braket(QuantumCircuit(2, 1)), Circuit)
+
+    def test_op_less_circuit_via_circuit_kwarg_is_accepted(self):
+        with pytest.warns(DeprecationWarning, match="circuit is deprecated"):
+            assert isinstance(to_braket(circuit=QuantumCircuit(2, 1)), Circuit)
+
     def test_circuit_deprecated(self):
         """Tests that to_braket raises a DeprecationWarning if circuit is specified."""
         circuit = QuantumCircuit(1, 1)


### PR DESCRIPTION
  *Description of changes:*
  
  `_get_circuits` validated its `circuits` and `circuit` arguments with truthiness checks (`if not (circuits or circuit)`, `if circuit:`, `if circuits:`). `QuantumCircuit.__bool__` returns `False` whenever the circuit has no instructions, so a perfectly valid circuit that declared qubits but had no gates yet was rejected with `ValueError: Must specify circuits to transpile`.
  
  
  Behavior preserved:
  - `to_braket()` (no arguments) still raises `Must specify circuits to transpile`.
  - `to_braket(circuits=qc, circuit=qc)` still raises `Cannot specify both circuits and circuit`.
  - `to_braket(circuit=qc)` still emits the existing `DeprecationWarning`.
  
  *Testing done:*
  
  Added two regression tests in `test/unit_tests/test_adapter.py`:
  - `test_op_less_circuit_is_accepted` — `to_braket(QuantumCircuit(2, 1))` succeeds.
  - `test_op_less_circuit_via_circuit_kwarg_is_accepted` — same via the deprecated `circuit=` kwarg.
  
  Existing argument-validation tests (`test_no_circuits_specified`, `test_circuits_and_circuit`, `test_circuit_deprecated`) still pass.
  
  ## Merge Checklist
  
  _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._
  
  #### General
  
  - [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md) doc
  - [x] I used the PR title format described in
  [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md#pr-title-format)
  - [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/README.md) (if
  appropriate)
  
  #### Tests
  
  - [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
  - [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
  
  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.