### PR TITLE
feature: add verbatim support from Circuits to QuantumCircuit

### DIFF
--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -2026,6 +2026,7 @@ def to_qiskit(
         isinstance(instr.operator, measure.Measure) for instr in circuit.instructions
     )
     qiskit_circuit = QuantumCircuit(circuit.qubit_count, num_measurements)
+    verbatim_buffer: QuantumCircuit | None = None
     qubit_map = {int(qubit): index for index, qubit in enumerate(sorted(circuit.qubits))}
     parameter_map: dict[str, Parameter] = {}
     cbit = 0
@@ -2038,11 +2039,16 @@ def to_qiskit(
             barrier_qubits = [qiskit_circuit.qubits[qubit_map[i]] for i in instruction.target]
             qiskit_circuit.barrier(barrier_qubits)
             continue
-
         if gate_name in _BRAKET_SUPPORTED_NOISES:
             gate = _create_qiskit_kraus(operator.to_matrix())
         elif gate_name == "unitary":
             gate = _create_qiskit_unitary(operator.to_matrix())
+        elif gate_name == "startverbatimbox":
+            if verbatim_buffer is not None:
+                raise ValueError("Nested verbatim boxes are not supported")
+            verbatim_buffer = QuantumCircuit(circuit.qubit_count, num_measurements)
+        elif gate_name == "endverbatimbox":
+            pass
         else:
             gate = _create_qiskit_gate(
                 gate_name,
@@ -2061,6 +2067,15 @@ def to_qiskit(
         if gate_name == "measure":
             qiskit_circuit.append(gate, target, [cbit])
             cbit += 1
+        elif gate_name == "startverbatimbox":
+            continue
+        elif gate_name == "endverbatimbox":
+            qiskit_circuit = qiskit_circuit.compose(
+                BoxOp(verbatim_buffer, label=_BRAKET_VERBATIM_BOX_NAME)
+            )
+            verbatim_buffer = None
+        elif verbatim_buffer is not None:
+            verbatim_buffer.append(gate, target)
         else:
             qiskit_circuit.append(gate, target)
     if num_measurements == 0 and add_measurements:

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -2063,20 +2063,21 @@ def to_qiskit(
         target = [qiskit_circuit.qubits[qubit_map[i]] for i in control_qubits]
         target += [qiskit_circuit.qubits[qubit_map[i]] for i in instruction.target]
 
-        if gate_name == "measure":
-            qiskit_circuit.append(gate, target, [cbit])
-            cbit += 1
-        elif gate_name == "startverbatimbox":
-            continue
-        elif gate_name == "endverbatimbox":
-            qiskit_circuit = qiskit_circuit.compose(
-                BoxOp(verbatim_buffer, label=_BRAKET_VERBATIM_BOX_NAME)
-            )
-            verbatim_buffer = None
-        elif verbatim_buffer is not None:
-            verbatim_buffer.append(gate, target)
-        else:
-            qiskit_circuit.append(gate, target)
+        match operator, verbatim_buffer is None:
+            case measure.Measure(), _:
+                qiskit_circuit.append(gate, target, [cbit])
+                cbit += 1
+            case compiler_directives.StartVerbatimBox(), _:
+                continue
+            case compiler_directives.EndVerbatimBox(), _:
+                qiskit_circuit = qiskit_circuit.compose(
+                    BoxOp(verbatim_buffer, label=_BRAKET_VERBATIM_BOX_NAME)
+                )
+                verbatim_buffer = None
+            case _, False:
+                verbatim_buffer.append(gate, target)
+            case _, True:
+                qiskit_circuit.append(gate, target)
     if num_measurements == 0 and add_measurements:
         qiskit_circuit.measure_all()
     return qiskit_circuit

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -50,7 +50,7 @@ from sympy import Add, Expr, Mul, Pow, Symbol, acos, asin, atan, cos, exp, log, 
 
 from braket import experimental_capabilities as braket_expcaps
 from braket.aws import AwsDevice, AwsDeviceType
-from braket.circuits import Circuit, Instruction, measure
+from braket.circuits import Circuit, Instruction, compiler_directives, measure
 from braket.circuits import Observable as BraketObservable
 from braket.circuits import gates as braket_gates
 from braket.circuits import noises as braket_noises
@@ -2033,28 +2033,27 @@ def to_qiskit(
     for instruction in circuit.instructions:
         operator = instruction.operator
         gate_name = operator.name.lower()
-
-        # Handle barrier separately
-        if gate_name == "barrier":
-            barrier_qubits = [qiskit_circuit.qubits[qubit_map[i]] for i in instruction.target]
-            qiskit_circuit.barrier(barrier_qubits)
-            continue
-        if gate_name in _BRAKET_SUPPORTED_NOISES:
-            gate = _create_qiskit_kraus(operator.to_matrix())
-        elif gate_name == "unitary":
-            gate = _create_qiskit_unitary(operator.to_matrix())
-        elif gate_name == "startverbatimbox":
-            if verbatim_buffer is not None:
-                raise ValueError("Nested verbatim boxes are not supported")
-            verbatim_buffer = QuantumCircuit(circuit.qubit_count, num_measurements)
-        elif gate_name == "endverbatimbox":
-            pass
-        else:
-            gate = _create_qiskit_gate(
-                gate_name,
-                (operator.parameters if isinstance(operator, Parameterizable) else []),
-                parameter_map,
-            )
+        match operator:
+            case compiler_directives.Barrier():
+                barrier_qubits = [qiskit_circuit.qubits[qubit_map[i]] for i in instruction.target]
+                qiskit_circuit.barrier(barrier_qubits)
+                continue
+            case braket_noises.Noise() | braket_noises.Kraus():
+                gate = _create_qiskit_kraus(operator.to_matrix())
+            case braket_gates.Unitary():
+                gate = _create_qiskit_unitary(operator.to_matrix())
+            case compiler_directives.StartVerbatimBox():
+                if verbatim_buffer is not None:
+                    raise ValueError("Nested verbatim boxes are not supported")
+                verbatim_buffer = QuantumCircuit(circuit.qubit_count, num_measurements)
+            case compiler_directives.EndVerbatimBox():
+                pass
+            case _:
+                gate = _create_qiskit_gate(
+                    gate_name,
+                    (operator.parameters if isinstance(operator, Parameterizable) else []),
+                    parameter_map,
+                )
         if (power := instruction.power) != 1:
             gate = gate**power
         if control_qubits := instruction.control:

--- a/test/unit_tests/test_adapter_to_qiskit_verbatim.py
+++ b/test/unit_tests/test_adapter_to_qiskit_verbatim.py
@@ -11,7 +11,10 @@ from braket.default_simulator.openqasm.interpreter import VerbatimBoxDelimiter
 from braket.default_simulator.openqasm.parser.openqasm_ast import BitType, Identifier
 from braket.ir.openqasm import Program
 from qiskit_braket_provider import to_qiskit
-from qiskit_braket_provider.providers.adapter import _QiskitProgramContext
+from qiskit_braket_provider.providers.adapter import (
+    _BRAKET_VERBATIM_BOX_NAME,
+    _QiskitProgramContext,
+)
 
 
 def _get_box_ops(qiskit_circuit: QuantumCircuit) -> list[CircuitInstruction]:
@@ -349,3 +352,25 @@ def test_bit_declaration_with_identifier_size_in_verbatim():
     ctx = _QiskitProgramContext()
     ctx.declare_variable("c", BitType(size=Identifier(name="n")))
     assert ctx.circuit.num_clbits == 0
+
+
+def test_braket_to_qiskit_verbatim_instruciton():
+    test = Circuit()
+    test.add_verbatim_box(Circuit().h(0).x(1))
+
+    circuit = QuantumCircuit(
+        2,
+    )
+    circuit.h(0)
+    circuit.x(1)
+    boxed = QuantumCircuit(
+        2,
+    )
+    boxed = boxed.compose(BoxOp(circuit, label=_BRAKET_VERBATIM_BOX_NAME))
+    assert to_qiskit(test, add_measurements=False) == boxed
+
+
+def test_nested_error():
+    test = Circuit().add_verbatim_box(Circuit().add_verbatim_box(Circuit().h(0).x(1)))
+    with pytest.raises(ValueError, match="Nested verbatim boxes are not supported"):
+        assert to_qiskit(test)


### PR DESCRIPTION
*Issue #, if available:*

Close #309. Adds a buffer verbatim circuit which picks up additional instructions and is added as a BoxOp. Does not allow for nested operations.  

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md) doc
- [ ] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md#pr-title-format)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/README.md) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
