### PR TITLE
fix: classical bit in box

### DIFF
--- a/qiskit_braket_provider/providers/compilation.py
+++ b/qiskit_braket_provider/providers/compilation.py
@@ -49,14 +49,14 @@ def _extract_verbatim_boxes(
         operation = instruction.operation
 
         qubit_indices = [circuit.find_bit(q).index for q in instruction.qubits]
-        clbit_indices = [circuit.find_bit(q).index for q in instruction.clbits]
 
         if isinstance(operation, BoxOp) and getattr(operation, "label", None) == verbatim_box_name:
             box_circuit = operation.blocks[0]
             verbatim_boxes.append((box_circuit, qubit_indices))
             barrier = Barrier(len(instruction.qubits), label=verbatim_box_name)
-            modified_circuit.append(barrier, qubit_indices, clbit_indices)
+            modified_circuit.append(barrier, qubit_indices)
         else:
+            clbit_indices = [circuit.find_bit(c).index for c in instruction.clbits]
             modified_circuit.append(operation, qubit_indices, clbit_indices)
 
     return modified_circuit, verbatim_boxes

--- a/test/unit_tests/test_adapter_to_braket_verbatim.py
+++ b/test/unit_tests/test_adapter_to_braket_verbatim.py
@@ -501,3 +501,19 @@ box {
     assert info[x_idx][1] == [1]
     assert info[cnot_indices[0]][1] == QUBIT_PAIR
     assert info[cnot_indices[1]][1] == [1, 2]
+
+
+def test_to_braket_handles_verbatim_box_with_clbits():
+    """to_braket on a verbatim BoxOp carrying clbits succeeds."""
+    body = QuantumCircuit(1, 1)
+    body.h(0)
+    body.measure(0, 0)  # gives the body a clbit, which propagates to the BoxOp
+
+    qc = QuantumCircuit(1, 1)
+    qc.append(BoxOp(body, label=VERBATIM_LABEL), qc.qubits, qc.clbits)
+
+    bc = to_braket(qc, verbatim=True)
+
+    source = bc.to_ir(ir_type="OPENQASM").source
+    assert "bit[1] b;" in source
+    assert "b[0] = measure $0;" in source


### PR DESCRIPTION
  *Description of changes:*  
  `_extract_verbatim_boxes` forwarded `clbit_indices` to its `Barrier` placeholder. Qiskit's `Barrier` is qubit-only, so this raised `CircuitError` whenever a verbatim `BoxOp` carried clbits (e.g. a body containing a measurement). The clbit wiring lives in the box body and is restored by `_restore_verbatim_boxes`, so the placeholder doesn't need clbits.
  
  *Testing done:*
  
  New unit test that round-trips a verbatim `BoxOp` with a measurement through `to_braket` and asserts the emitted OpenQASM preserves the clbit declaration and measurement wiring. Fails on mainline with the expected `CircuitError`. `tox -e py313,linters_check` passes.

Example:
```
  from qiskit import QuantumCircuit
  from qiskit_braket_provider.providers.adapter import to_braket
  
  qc = QuantumCircuit(2, 2)
  with qc.box(label="verbatim"):
      qc.h(0)
      qc.cx(0, 1)
      qc.measure([0, 1], [0, 1])
  
  to_braket(qc)
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md#pr-title-format)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/README.md) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
