### PR TITLE
fix: Share parent bits in control-flow body circuits in to_qiskit

### DIFF
--- a/qiskit_braket_provider/providers/qasm_context.py
+++ b/qiskit_braket_provider/providers/qasm_context.py
@@ -133,6 +133,17 @@ class _QiskitProgramContext(AbstractProgramContext):
             )
         return self._circuit_stack[0]
 
+    def _push_scoped_circuit(self) -> QuantumCircuit:
+        """Push an empty body circuit onto the stack that shares the parent's bit objects."""
+        body = self._active_circuit.copy_empty_like()
+        self._circuit_stack.append(body)
+        return body
+
+    def _extend_bits(self, target: QuantumCircuit, source: QuantumCircuit) -> None:
+        """Add to target any bits that source has beyond target's current bit list."""
+        target.add_bits(source.qubits[target.num_qubits :])
+        target.add_bits(source.clbits[target.num_clbits :])
+
     def add_qubits(self, name: str, num_qubits: int | None = 1) -> None:
         super().add_qubits(name, num_qubits)
         self._active_circuit.add_register(num_qubits)
@@ -322,15 +333,11 @@ class _QiskitProgramContext(AbstractProgramContext):
                 f"Only Identifier, IndexExpression, and BinaryExpression (==) are supported."
             )
 
-        true_body = QuantumCircuit(main.num_qubits, main.num_clbits)
-        self._circuit_stack.append(true_body)
+        true_body = self._push_scoped_circuit()
         yield True
         self._circuit_stack.pop()
 
-        # Push circuit for else-block (the interpreter always consumes this yield
-        # even for if-only blocks; the empty circuit is discarded below)
-        false_body = QuantumCircuit(main.num_qubits, main.num_clbits)
-        self._circuit_stack.append(false_body)
+        false_body = self._push_scoped_circuit()
         yield False
         self._circuit_stack.pop()
 
@@ -342,18 +349,14 @@ class _QiskitProgramContext(AbstractProgramContext):
                 "Both if and else branches contain no quantum operations."
             )
 
-        # Sync main circuit dimensions if branch bodies grew
-        max_qubits = max(true_body.num_qubits, false_body.num_qubits)
-        max_clbits = max(true_body.num_clbits, false_body.num_clbits)
-        if max_qubits > main.num_qubits:
-            main.add_bits([Qubit() for _ in range(max_qubits - main.num_qubits)])
-        if max_clbits > main.num_clbits:
-            main.add_bits([Clbit() for _ in range(max_clbits - main.num_clbits)])
+        # Sync parent and both bodies to the same bit layout (IfElseOp requires it).
+        self._extend_bits(main, true_body)
+        self._extend_bits(main, false_body)
+        self._extend_bits(true_body, main)
+        self._extend_bits(false_body, main)
 
         if_else_op = IfElseOp(resolved_condition, true_body, actual_false)
-        qubits = list(range(max_qubits))
-        clbits = list(range(max_clbits))
-        main.append(if_else_op, qubits, clbits)
+        main.append(if_else_op, main.qubits, main.clbits)
 
     def evaluate_for_range(
         self, set_declaration: Expression, loop_var: str, loop_type: ClassicalType
@@ -377,8 +380,7 @@ class _QiskitProgramContext(AbstractProgramContext):
         # First pass: capture with concrete value to detect classical vs quantum body
         # Snapshot outer scope variables to detect classical side effects
         outer_vars = dict(self.variable_table.current_scope)
-        probe = QuantumCircuit(main.num_qubits, main.num_clbits)
-        self._circuit_stack.append(probe)
+        probe = self._push_scoped_circuit()
         with self.enter_scope():
             self.declare_variable(loop_var, loop_type, index_values[0])
             yield
@@ -407,8 +409,7 @@ class _QiskitProgramContext(AbstractProgramContext):
             )
 
         # Second pass: re-capture with symbolic loop variable for correct ForLoopOp binding
-        body = QuantumCircuit(main.num_qubits, main.num_clbits)
-        self._circuit_stack.append(body)
+        body = self._push_scoped_circuit()
         with self.enter_scope():
             self.declare_variable(loop_var, loop_type, SymbolLiteral(Symbol(loop_var)))
             yield
@@ -417,13 +418,8 @@ class _QiskitProgramContext(AbstractProgramContext):
         indexset = tuple(iv.value for iv in index_values)
         loop_param = self._param_map.get(loop_var) or Parameter(loop_var)
         for_op = ForLoopOp(indexset, loop_param, body)
-        max_qubits = max(body.num_qubits, main.num_qubits)
-        max_clbits = max(body.num_clbits, main.num_clbits)
-        if max_qubits > main.num_qubits:
-            main.add_bits([Qubit() for _ in range(max_qubits - main.num_qubits)])
-        if max_clbits > main.num_clbits:
-            main.add_bits([Clbit() for _ in range(max_clbits - main.num_clbits)])
-        main.append(for_op, list(range(max_qubits)), list(range(max_clbits)))
+        self._extend_bits(main, body)
+        main.append(for_op, main.qubits, main.clbits)
 
     def handle_loop_break(self):
         """Reject break statements since Qiskit's ForLoopOp/WhileLoopOp do not support them."""
@@ -452,8 +448,7 @@ class _QiskitProgramContext(AbstractProgramContext):
                 f"Only Identifier, IndexExpression, and BinaryExpression (==) are supported."
             )
 
-        body = QuantumCircuit(main.num_qubits, main.num_clbits)
-        self._circuit_stack.append(body)
+        body = self._push_scoped_circuit()
         yield True
         self._circuit_stack.pop()
 
@@ -463,15 +458,9 @@ class _QiskitProgramContext(AbstractProgramContext):
                 "This would result in an infinite loop."
             )
 
-        max_qubits = max(body.num_qubits, main.num_qubits)
-        max_clbits = max(body.num_clbits, main.num_clbits)
-        if max_qubits > main.num_qubits:
-            main.add_bits([Qubit() for _ in range(max_qubits - main.num_qubits)])
-        if max_clbits > main.num_clbits:
-            main.add_bits([Clbit() for _ in range(max_clbits - main.num_clbits)])
-
+        self._extend_bits(main, body)
         while_op = WhileLoopOp(resolved_condition, body)
-        main.append(while_op, list(range(max_qubits)), list(range(max_clbits)))
+        main.append(while_op, main.qubits, main.clbits)
 
     def _evaluate_expression(self, expression: Expression | list[Expression]) -> Any:  # noqa: ANN401
         """Lightweight expression evaluator for loop conditions and ranges."""

--- a/test/unit_tests/test_adapter_dynamic_circuits.py
+++ b/test/unit_tests/test_adapter_dynamic_circuits.py
@@ -1,5 +1,7 @@
 """Tests for dynamic circuit support (if/else, for loops, while loops) in the Qiskit adapter."""
 
+import math
+
 import pytest
 from qiskit.circuit import (
     CircuitInstruction,
@@ -1295,3 +1297,33 @@ def test_control_flow_body_circuit_is_drawable(qasm: str):
     for block in ctrl_op.operation.blocks:
         assert list(block.qubits) == list(qc.qubits)
         assert list(block.clbits) == list(qc.clbits)
+
+
+@pytest.mark.parametrize(
+    "parent_gphase,expected_parent,body_gphase,expected_body",
+    [
+        ("", 0, "", 0),
+        ("gphase(pi/4);", math.pi / 4, "", math.pi / 4),
+        ("", 0, "gphase(pi/2);", math.pi / 2),
+        ("gphase(pi/4);", math.pi / 4, "gphase(pi/2);", math.pi / 4 + math.pi / 2),
+    ],
+    ids=["no-phase", "parent-only", "body-only", "both"],
+)
+def test_control_flow_body_global_phase_behavior(
+    parent_gphase: str, expected_parent: float, body_gphase: str, expected_body: float
+):
+    """Document the full global_phase behavior across control-flow scope boundaries."""
+    qasm = f"""
+    OPENQASM 3.0;
+    bit[1] b;
+    qubit[1] q;
+    {parent_gphase}
+    b[0] = measure q[0];
+    if (b[0] == 1) {{ {body_gphase} x q[0]; }}
+    """
+    qc = to_qiskit(qasm)
+    if_op = next(inst for inst in qc.data if isinstance(inst.operation, IfElseOp))
+    [body] = if_op.operation.blocks
+
+    assert qc.global_phase == pytest.approx(expected_parent)
+    assert body.global_phase == pytest.approx(expected_body)

--- a/test/unit_tests/test_adapter_dynamic_circuits.py
+++ b/test/unit_tests/test_adapter_dynamic_circuits.py
@@ -1256,3 +1256,42 @@ if (mcm[0] == 1) {
     qc = to_qiskit(qasm)
     if_else_ops = _get_if_else_ops(qc)
     assert len(if_else_ops) == 1
+
+
+@pytest.mark.parametrize(
+    "qasm",
+    [
+        """
+        OPENQASM 3.0;
+        bit[1] b;
+        qubit[1] q;
+        b[0] = measure q[0];
+        if (b[0] == 1) { x q[0]; } else { h q[0]; }
+        """,
+        """
+        OPENQASM 3.0;
+        bit[1] b;
+        qubit[1] q;
+        b[0] = measure q[0];
+        while (b[0] == 0) { x q[0]; b[0] = measure q[0]; }
+        """,
+        """
+        OPENQASM 3.0;
+        bit[1] b;
+        qubit[1] q;
+        for int i in [0:2] { h q[0]; b[0] = measure q[0]; }
+        """,
+    ],
+    ids=["if-else", "while", "for"],
+)
+def test_control_flow_body_circuit_is_drawable(qasm: str):
+    """Control-flow body sub-circuits share the parent's bit objects so the drawer works."""
+    qc = to_qiskit(qasm)
+    print(qc)
+
+    ctrl_op = next(
+        inst for inst in qc.data if isinstance(inst.operation, (IfElseOp, ForLoopOp, WhileLoopOp))
+    )
+    for block in ctrl_op.operation.blocks:
+        assert list(block.qubits) == list(qc.qubits)
+        assert list(block.clbits) == list(qc.clbits)


### PR DESCRIPTION
  *Description of changes:*
  
  Control-flow body sub-circuits used by `IfElseOp` / `ForLoopOp` / `WhileLoopOp` were being built with `QuantumCircuit(num_qubits, num_clbits)`, which allocates fresh register-backed `Qubit`/`Clbit` objects. Qiskit's
  drawer (and any tooling that recurses into `.blocks`) resolves inner bits in the parent's scope via object identity, so this raised `CircuitError: Could not locate provided bit` and made the circuit unprintable.
  
  Build each body with `copy_empty_like()` on the active circuit, then adopt any bits the body grew back into the parent. For `IfElseOp`, sync both bodies through the parent so they share the same bit layout. Two helpers on `_QiskitProgramContext` factor the pattern across the three call sites.
  
  *Testing done:*
  
  New parametrized test `test_control_flow_body_circuit_is_drawable` with three cases (if/else, while, for). Each asserts `print(qc)` works and that the control-flow body blocks reference the parent's exact bit objects. All three cases fail on mainline with the original `CircuitError`. `tox -e py313,linters_check` passes.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md#pr-title-format)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/README.md) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
