### PR TITLE
fix: Preserve if/measure inside verbatim box in to_qiskit

### DIFF
--- a/qiskit_braket_provider/providers/qasm_context.py
+++ b/qiskit_braket_provider/providers/qasm_context.py
@@ -115,7 +115,6 @@ class _QiskitProgramContext(AbstractProgramContext):
         self._circuit_stack: list[QuantumCircuit] = [QuantumCircuit()]
         self._param_map: dict[str, Parameter] = {}
         self._in_verbatim_box = False
-        self._verbatim_circuit: QuantumCircuit | None = None
         self._verbatim_box_name = verbatim_box_name
         self._clbit_offset: dict[str, int] = {}
 
@@ -218,13 +217,7 @@ class _QiskitProgramContext(AbstractProgramContext):
         active.add_bits([Qubit() for _ in range(num_missing_qubits)])
         self.num_qubits = max(self.num_qubits, active.num_qubits)
 
-        if self._in_verbatim_box:
-            # Ensure verbatim circuit also has enough qubits by adding missing qubits
-            num_missing_qubits = max_qubits - self._verbatim_circuit.num_qubits
-            self._verbatim_circuit.add_bits([Qubit() for _ in range(num_missing_qubits)])
-            self._verbatim_circuit.append(CircuitInstruction(gate, target))
-        else:
-            active.append(CircuitInstruction(gate, target))
+        active.append(CircuitInstruction(gate, target))
 
     def handle_parameter_value(self, value: Number | Expr) -> Number | Parameter:
         return _sympy_to_qiskit(value, self._param_map) if isinstance(value, Expr) else value
@@ -246,44 +239,23 @@ class _QiskitProgramContext(AbstractProgramContext):
             active.measure(qubit, index)
 
     def add_verbatim_marker(self, marker: VerbatimBoxDelimiter) -> None:
-        """Handle verbatim box start/end markers.
-
-        When START_VERBATIM is received:
-        - Create a new QuantumCircuit to collect verbatim gates
-        - Set _in_verbatim_box flag to True
-
-        When END_VERBATIM is received:
-        - Wrap the collected gates in a BoxOp
-        - Append the BoxOp to the main circuit
-        - Reset verbatim state
-
-        Args:
-            marker: VerbatimBoxDelimiter indicating START_VERBATIM or END_VERBATIM
-
-        Raises:
-            ValueError: If nested verbatim boxes are encountered or if END_VERBATIM is called without START_VERBATIM
-        """
-
+        """Handle verbatim box start/end markers by scoping body construction on the stack."""
         if marker == VerbatimBoxDelimiter.START_VERBATIM:
             if self._in_verbatim_box:
                 raise ValueError("Nested verbatim boxes are not supported")
 
-            self._verbatim_circuit = QuantumCircuit()
+            self._push_scoped_circuit()
             self._in_verbatim_box = True
 
         elif marker == VerbatimBoxDelimiter.END_VERBATIM:
             if not self._in_verbatim_box:
                 raise ValueError("Verbatim box end marker without matching start")
 
-            box_op = BoxOp(self._verbatim_circuit, label=self._verbatim_box_name)
-
-            active = self._active_circuit
-            # Append BoxOp to active circuit with all qubits (convert indices to Qubit objects)
-            qubit_objects = [active.qubits[i] for i in range(self._verbatim_circuit.num_qubits)]
-            active.append(box_op, qubit_objects)
-
+            body = self._circuit_stack.pop()
+            parent = self._active_circuit
+            self._extend_bits(parent, body)
+            parent.append(BoxOp(body, label=self._verbatim_box_name), parent.qubits, parent.clbits)
             self._in_verbatim_box = False
-            self._verbatim_circuit = None
 
         else:
             raise ValueError("Verbatim box created using invalid marker")
@@ -506,14 +478,14 @@ class _QiskitProgramContext(AbstractProgramContext):
         else:
             clbit_index = self._resolve_clbit_index(condition.rhs)
             value = condition.lhs.value
-        return (self.circuit.clbits[clbit_index], int(value))
+        return (self._active_circuit.clbits[clbit_index], int(value))
 
     def _resolve_condition_from_identifier(
         self, condition: Identifier | IndexExpression
     ) -> tuple[Clbit, int]:
         """Convert a bare identifier condition (e.g., `c` or `c[0]`) to (Clbit, 1)."""
         clbit_index = self._resolve_clbit_index(condition)
-        return (self.circuit.clbits[clbit_index], 1)
+        return (self._active_circuit.clbits[clbit_index], 1)
 
     def _resolve_clbit_index(self, node: Identifier | IndexExpression) -> int:
         """Resolve an identifier or indexed identifier to a classical bit index."""

--- a/qiskit_braket_provider/providers/qasm_context.py
+++ b/qiskit_braket_provider/providers/qasm_context.py
@@ -239,7 +239,24 @@ class _QiskitProgramContext(AbstractProgramContext):
             active.measure(qubit, index)
 
     def add_verbatim_marker(self, marker: VerbatimBoxDelimiter) -> None:
-        """Handle verbatim box start/end markers by scoping body construction on the stack."""
+        """Handle verbatim box start/end markers.
+
+        When START_VERBATIM is received:
+        - Push a scoped body circuit onto the stack that shares the parent's bits
+        - Set _in_verbatim_box flag to True
+
+        When END_VERBATIM is received:
+        - Pop the scoped body and propagate any new qubits/clbits back to the parent
+        - Wrap the body in a BoxOp and append it to the parent circuit
+        - Reset verbatim state
+
+        Args:
+            marker: VerbatimBoxDelimiter indicating START_VERBATIM or END_VERBATIM
+
+        Raises:
+            ValueError: On nested verbatim boxes, an unmatched END_VERBATIM, or an invalid marker
+        """
+
         if marker == VerbatimBoxDelimiter.START_VERBATIM:
             if self._in_verbatim_box:
                 raise ValueError("Nested verbatim boxes are not supported")

--- a/qiskit_braket_provider/providers/qasm_context.py
+++ b/qiskit_braket_provider/providers/qasm_context.py
@@ -133,6 +133,17 @@ class _QiskitProgramContext(AbstractProgramContext):
             )
         return self._circuit_stack[0]
 
+    def _push_scoped_circuit(self) -> QuantumCircuit:
+        """Push an empty body circuit onto the stack that shares the parent's bit objects."""
+        body = self._active_circuit.copy_empty_like()
+        self._circuit_stack.append(body)
+        return body
+
+    def _extend_bits(self, target: QuantumCircuit, source: QuantumCircuit) -> None:
+        """Add to target any bits that source has beyond target's current bit list."""
+        target.add_bits(source.qubits[target.num_qubits :])
+        target.add_bits(source.clbits[target.num_clbits :])
+
     def add_qubits(self, name: str, num_qubits: int | None = 1) -> None:
         super().add_qubits(name, num_qubits)
         self._active_circuit.add_register(num_qubits)
@@ -322,15 +333,11 @@ class _QiskitProgramContext(AbstractProgramContext):
                 f"Only Identifier, IndexExpression, and BinaryExpression (==) are supported."
             )
 
-        true_body = QuantumCircuit(main.num_qubits, main.num_clbits)
-        self._circuit_stack.append(true_body)
+        true_body = self._push_scoped_circuit()
         yield True
         self._circuit_stack.pop()
 
-        # Push circuit for else-block (the interpreter always consumes this yield
-        # even for if-only blocks; the empty circuit is discarded below)
-        false_body = QuantumCircuit(main.num_qubits, main.num_clbits)
-        self._circuit_stack.append(false_body)
+        false_body = self._push_scoped_circuit()
         yield False
         self._circuit_stack.pop()
 
@@ -342,18 +349,14 @@ class _QiskitProgramContext(AbstractProgramContext):
                 "Both if and else branches contain no quantum operations."
             )
 
-        # Sync main circuit dimensions if branch bodies grew
-        max_qubits = max(true_body.num_qubits, false_body.num_qubits)
-        max_clbits = max(true_body.num_clbits, false_body.num_clbits)
-        if max_qubits > main.num_qubits:
-            main.add_bits([Qubit() for _ in range(max_qubits - main.num_qubits)])
-        if max_clbits > main.num_clbits:
-            main.add_bits([Clbit() for _ in range(max_clbits - main.num_clbits)])
+        # Sync parent and both bodies to the same bit layout (IfElseOp requires it).
+        self._extend_bits(main, true_body)
+        self._extend_bits(main, false_body)
+        self._extend_bits(true_body, main)
+        self._extend_bits(false_body, main)
 
         if_else_op = IfElseOp(resolved_condition, true_body, actual_false)
-        qubits = list(range(max_qubits))
-        clbits = list(range(max_clbits))
-        main.append(if_else_op, qubits, clbits)
+        main.append(if_else_op, main.qubits, main.clbits)
 
     def evaluate_for_range(
         self, set_declaration: Expression, loop_var: str, loop_type: ClassicalType
@@ -377,8 +380,7 @@ class _QiskitProgramContext(AbstractProgramContext):
         # First pass: capture with concrete value to detect classical vs quantum body
         # Snapshot outer scope variables to detect classical side effects
         outer_vars = dict(self.variable_table.current_scope)
-        probe = QuantumCircuit(main.num_qubits, main.num_clbits)
-        self._circuit_stack.append(probe)
+        probe = self._push_scoped_circuit()
         with self.enter_scope():
             self.declare_variable(loop_var, loop_type, index_values[0])
             yield
@@ -407,8 +409,7 @@ class _QiskitProgramContext(AbstractProgramContext):
             )
 
         # Second pass: re-capture with symbolic loop variable for correct ForLoopOp binding
-        body = QuantumCircuit(main.num_qubits, main.num_clbits)
-        self._circuit_stack.append(body)
+        body = self._push_scoped_circuit()
         with self.enter_scope():
             self.declare_variable(loop_var, loop_type, SymbolLiteral(Symbol(loop_var)))
             yield
@@ -417,13 +418,8 @@ class _QiskitProgramContext(AbstractProgramContext):
         indexset = tuple(iv.value for iv in index_values)
         loop_param = self._param_map.get(loop_var) or Parameter(loop_var)
         for_op = ForLoopOp(indexset, loop_param, body)
-        max_qubits = max(body.num_qubits, main.num_qubits)
-        max_clbits = max(body.num_clbits, main.num_clbits)
-        if max_qubits > main.num_qubits:
-            main.add_bits([Qubit() for _ in range(max_qubits - main.num_qubits)])
-        if max_clbits > main.num_clbits:
-            main.add_bits([Clbit() for _ in range(max_clbits - main.num_clbits)])
-        main.append(for_op, list(range(max_qubits)), list(range(max_clbits)))
+        self._extend_bits(main, body)
+        main.append(for_op, main.qubits, main.clbits)
 
     def handle_loop_break(self):
         """Reject break statements since Qiskit's ForLoopOp/WhileLoopOp do not support them."""
@@ -452,8 +448,7 @@ class _QiskitProgramContext(AbstractProgramContext):
                 f"Only Identifier, IndexExpression, and BinaryExpression (==) are supported."
             )
 
-        body = QuantumCircuit(main.num_qubits, main.num_clbits)
-        self._circuit_stack.append(body)
+        body = self._push_scoped_circuit()
         yield True
         self._circuit_stack.pop()
 
@@ -463,15 +458,9 @@ class _QiskitProgramContext(AbstractProgramContext):
                 "This would result in an infinite loop."
             )
 
-        max_qubits = max(body.num_qubits, main.num_qubits)
-        max_clbits = max(body.num_clbits, main.num_clbits)
-        if max_qubits > main.num_qubits:
-            main.add_bits([Qubit() for _ in range(max_qubits - main.num_qubits)])
-        if max_clbits > main.num_clbits:
-            main.add_bits([Clbit() for _ in range(max_clbits - main.num_clbits)])
-
+        self._extend_bits(main, body)
         while_op = WhileLoopOp(resolved_condition, body)
-        main.append(while_op, list(range(max_qubits)), list(range(max_clbits)))
+        main.append(while_op, main.qubits, main.clbits)
 
     def _evaluate_expression(self, expression: Expression | list[Expression]) -> Any:  # noqa: ANN401
         """Lightweight expression evaluator for loop conditions and ranges."""

--- a/test/unit_tests/test_adapter_dynamic_circuits.py
+++ b/test/unit_tests/test_adapter_dynamic_circuits.py
@@ -1256,3 +1256,42 @@ if (mcm[0] == 1) {
     qc = to_qiskit(qasm)
     if_else_ops = _get_if_else_ops(qc)
     assert len(if_else_ops) == 1
+
+
+@pytest.mark.parametrize(
+    "qasm",
+    [
+        """
+        OPENQASM 3.0;
+        bit[1] b;
+        qubit[1] q;
+        b[0] = measure q[0];
+        if (b[0] == 1) { x q[0]; } else { h q[0]; }
+        """,
+        """
+        OPENQASM 3.0;
+        bit[1] b;
+        qubit[1] q;
+        b[0] = measure q[0];
+        while (b[0] == 0) { x q[0]; b[0] = measure q[0]; }
+        """,
+        """
+        OPENQASM 3.0;
+        bit[1] b;
+        qubit[1] q;
+        for int i in [0:2] { h q[0]; b[0] = measure q[0]; }
+        """,
+    ],
+    ids=["if-else", "while", "for"],
+)
+def test_control_flow_body_circuit_is_drawable(qasm: str):
+    """Control-flow body sub-circuits share the parent's bit objects so the drawer works."""
+    qc = to_qiskit(qasm)
+    print(qc)
+
+    ctrl_op = next(
+        inst for inst in qc.data if isinstance(inst.operation, (IfElseOp, ForLoopOp, WhileLoopOp))
+    )
+    for block in ctrl_op.operation.blocks:
+        assert list(block.qubits) == list(qc.qubits)
+        assert list(block.clbits) == list(qc.clbits)

--- a/test/unit_tests/test_adapter_to_braket_verbatim.py
+++ b/test/unit_tests/test_adapter_to_braket_verbatim.py
@@ -517,3 +517,27 @@ def test_to_braket_handles_verbatim_box_with_clbits():
     source = bc.to_ir(ir_type="OPENQASM").source
     assert "bit[1] b;" in source
     assert "b[0] = measure $0;" in source
+
+
+def test_to_braket_round_trip_preserves_verbatim_box_with_measurement():
+    """QASM → Qiskit → Braket QASM preserves verbatim gates and non-identity clbit mapping."""
+    src = """
+    OPENQASM 3.0;
+    bit[2] b;
+    #pragma braket verbatim
+    box {
+        h $0;
+        cnot $0, $1;
+        b[1] = measure $0;
+        b[0] = measure $1;
+    }
+    """
+    qc = to_qiskit(src)
+    bc = to_braket(qc, verbatim=True)
+    out = bc.to_ir(ir_type="OPENQASM").source
+
+    assert "#pragma braket verbatim" in out
+    assert "h $0;" in out
+    assert "cnot $0, $1;" in out
+    assert "b[0] = measure $1;" in out
+    assert "b[1] = measure $0;" in out

--- a/test/unit_tests/test_adapter_to_qiskit_verbatim.py
+++ b/test/unit_tests/test_adapter_to_qiskit_verbatim.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import pytest
 from qiskit import QuantumCircuit
-from qiskit.circuit import BoxOp, CircuitInstruction
+from qiskit.circuit import BoxOp, CircuitInstruction, IfElseOp
 
 from braket.circuits import Circuit
 from braket.default_simulator.openqasm.interpreter import VerbatimBoxDelimiter
@@ -374,3 +374,34 @@ def test_nested_error():
     test = Circuit().add_verbatim_box(Circuit().add_verbatim_box(Circuit().h(0).x(1)))
     with pytest.raises(ValueError, match="Nested verbatim boxes are not supported"):
         assert to_qiskit(test)
+
+
+def test_if_statement_inside_verbatim_box():
+    """An if-statement inside a verbatim box is preserved as IfElseOp in the BoxOp body."""
+    qasm = """
+    OPENQASM 3.0;
+    bit b;
+    #pragma braket verbatim
+    box {
+        h $0;
+        b = measure $0;
+        if (b == 1) { x $0; }
+    }
+    """
+    qc = to_qiskit(qasm)
+
+    box_inst = qc.data[0]
+    assert isinstance(box_inst.operation, BoxOp)
+    assert box_inst.operation.label == _BRAKET_VERBATIM_BOX_NAME
+
+    body = box_inst.operation.blocks[0]
+    assert [i.operation.name for i in body.data] == ["h", "measure", "if_else"]
+
+    if_inst = next(i for i in body.data if isinstance(i.operation, IfElseOp))
+    cond_bit, cond_val = if_inst.operation.condition
+    assert cond_bit == qc.clbits[0]
+    assert cond_val == 1
+
+    if_body = if_inst.operation.blocks[0]
+    assert [i.operation.name for i in if_body.data] == ["x"]
+    assert if_body.data[0].qubits[0] == qc.qubits[0]


### PR DESCRIPTION
  *Description of changes:*
  
  `measure` and `if` inside `#pragma braket verbatim box { ... }` weren't being placed in the box body — they landed on the top-level circuit. Push a scoped body at `START_VERBATIM` so every construct appends inside the box; pop and wrap as a `BoxOp` at `END_VERBATIM`. `_resolve_condition_*` now reads `_active_circuit.clbits`.
  
Example:
```python
from qiskit_braket_provider.providers.adapter import to_qiskit
qasm = """
OPENQASM 3.0;
bit b;
#pragma braket verbatim
box {
    h $0;
    b = measure $0;
    if (b == 1) { x $0; }
}
"""
qc = to_qiskit(qasm)
```
  
  *Testing done:*
  
  Structural test (verbatim+if+measure preserved as nested `IfElseOp`) + round-trip test (QASM → Qiskit → QASM with non-identity clbit mapping survives). Both fail on mainline; `tox` passes here.
  
  **Known limitation:** `to_braket` of a verbatim BoxOp containing `if` raises `NotImplementedError` — Braket Circuit IR has no generic `if`.
  


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md#pr-title-format)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/README.md) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
