### PR TITLE
feature: support parametric function conversion from OQ3 to qiskit

### DIFF
--- a/test/unit_tests/test_adapter.py
+++ b/test/unit_tests/test_adapter.py
@@ -1556,6 +1556,60 @@ class TestFromBraket(TestCase):
         expected_qiskit_circuit.measure_all()
         self.assertEqual(qiskit_circuit, expected_qiskit_circuit)
 
+    def test_oq3_parametric_function_direct_input(self):
+        """Tests OQ3 string -> Qiskit conversion with transcendental fns of input floats.
+
+        This covers the direct-application path: a built-in gate is called with an
+        expression involving a transcendental function of an ``input float`` variable,
+        e.g. ``rx(sin(theta)) q[0]``.  No user-defined gate wrapping is involved.
+        Resolves issue #347.
+        """
+        function_conversions = {
+            "sin": lambda p: p.sin(),
+            "cos": lambda p: p.cos(),
+            "tan": lambda p: p.tan(),
+            "arcsin": lambda p: p.arcsin(),
+            "arccos": lambda p: p.arccos(),
+            "arctan": lambda p: p.arctan(),
+            "exp": lambda p: p.exp(),
+            "log": lambda p: p.log(),
+        }
+        for fn_name, qiskit_fn in function_conversions.items():
+            with self.subTest(fn=fn_name):
+                qasm = f"""OPENQASM 3.0;
+input float theta;
+qubit[1] q;
+rx({fn_name}(theta)) q[0];"""
+                qiskit_circuit = to_qiskit(qasm.strip(), add_measurements=False)
+
+                self.assertEqual(len(qiskit_circuit.parameters), 1)
+                uuid = qiskit_circuit.parameters[0].uuid
+                qiskit_theta = Parameter("theta", uuid=uuid)
+
+                expected = QuantumCircuit(1)
+                expected.rx(qiskit_fn(qiskit_theta), 0)
+                self.assertEqual(qiskit_circuit, expected)
+
+    def test_oq3_parametric_function_direct_composite(self):
+        """Tests OQ3 -> Qiskit conversion with composite transcendental expressions.
+        Resolves issue #347.
+        """
+        qasm = """OPENQASM 3.0;
+input float theta;
+input float phi;
+qubit[1] q;
+rx(sin(theta) + 2.0*phi) q[0];"""
+        qiskit_circuit = to_qiskit(qasm.strip(), add_measurements=False)
+
+        self.assertEqual({p.name for p in qiskit_circuit.parameters}, {"theta", "phi"})
+        uuids = {p.name: p.uuid for p in qiskit_circuit.parameters}
+        qiskit_theta = Parameter("theta", uuid=uuids["theta"])
+        qiskit_phi = Parameter("phi", uuid=uuids["phi"])
+
+        expected = QuantumCircuit(1)
+        expected.rx(qiskit_theta.sin() + 2.0 * qiskit_phi, 0)
+        self.assertEqual(qiskit_circuit, expected)
+
     def test_unsupported_parameter_division(self):
         """Tests if TypeError is raised for parameter division."""
         braket_circuit = Circuit().rx(0, 1j * FreeParameter("alpha"))


### PR DESCRIPTION
Issue #347

**Description of changes:**

Adds test coverage for transcendental function expressions (`sin`, `cos`, `tan`,
`arcsin`, `arccos`, `arctan`, `exp`, `log`) in parametric gate parameters when
converting from OpenQASM 3 to Qiskit (`to_qiskit`).

The direct `input float` path (e.g. `rx(sin(theta)) q[0]` where `theta` is an
OQ3 `input float`) already worked at runtime but had zero test coverage. This PR
adds that coverage.

Note: the user-defined gate path and roundtrip tests are out of scope here —
those depend on upstream fixes tracked in
amazon-braket-default-simulator-python#387 and amazon-braket-sdk-python#1322.

**Testing done (`test/unit_tests/test_adapter.py`):**

2 new test methods, 9 subtests:

- `test_oq3_parametric_function_direct_input` — 8 functions × direct `input float` path
- `test_oq3_parametric_function_direct_composite` — multi-param composite expression

---
*Note: AI assistance (Claude) was used during diagnosis.*

## Merge Checklist

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md#pr-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/README.md) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.