### PR TITLE
infra: replace verbatim box functions with TransformationPasses

### DIFF
--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -41,8 +41,6 @@ from qiskit_braket_provider.providers.compilation import (
     _CompilationContext,  # noqa: F401
     _compile,
     _default_target,  # noqa: F401
-    _extract_verbatim_boxes,  # noqa: F401
-    _restore_verbatim_boxes,  # noqa: F401
 )
 from qiskit_braket_provider.providers.gate_mappings import (
     _BRAKET_GATE_NAME_TO_QISKIT_GATE,
@@ -145,7 +143,7 @@ def to_braket(
     basis_gates: Collection[str] | None = None,
     coupling_map: list[list[int]] | None = None,
     angle_restrictions: Mapping[str, Mapping[int, set[float] | tuple[float, float]]] | None = None,
-    optimization_level: int = 0,
+    optimization_level: int | None = 0,
     callback: Callable | None = None,
     num_processes: int | None = None,
     pass_manager: PassManager | None = None,

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -143,7 +143,7 @@ def to_braket(
     basis_gates: Collection[str] | None = None,
     coupling_map: list[list[int]] | None = None,
     angle_restrictions: Mapping[str, Mapping[int, set[float] | tuple[float, float]]] | None = None,
-    optimization_level: int | None = 0,
+    optimization_level: int = 0,
     callback: Callable | None = None,
     num_processes: int | None = None,
     pass_manager: PassManager | None = None,
@@ -182,7 +182,7 @@ def to_braket(
         angle_restrictions (Mapping[str, Mapping[int, set[float] | tuple[float, float]]] | None):
             Mapping of gate names to parameter angle constraints used to
             validate numeric parameters. Default: ``None``.
-        optimization_level (int | None): The optimization level to pass to ``qiskit.transpile``.
+        optimization_level (int): The optimization level to pass to ``qiskit.transpile``.
             From Qiskit:
 
             * 0: no optimization - basic translation, no optimization, trivial layout

--- a/qiskit_braket_provider/providers/compilation.py
+++ b/qiskit_braket_provider/providers/compilation.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 
 from qiskit import QuantumCircuit, generate_preset_pass_manager
 from qiskit.circuit import Barrier, BoxOp, Measure
-from qiskit.transpiler import PassManager, Target
+from qiskit.transpiler import PassManager, StagedPassManager, Target
 
 from braket.aws import AwsDevice
 from braket.devices import Device
@@ -216,8 +216,12 @@ def _compile(
                 seed_transpiler=seed_transpiler,
             )
             if has_verbatim_boxes:
-                pm.pre_init = PassManager([ExtractVerbatimBoxes(verbatim_box_name)])
-                pm.post_optimization = PassManager([RestoreVerbatimBoxes(verbatim_box_name)])
+                pm = StagedPassManager(
+                    stages=("verbatim_extract", "transpile", "verbatim_restore"),
+                    verbatim_extract=PassManager([ExtractVerbatimBoxes(verbatim_box_name)]),
+                    transpile=pm,
+                    verbatim_restore=PassManager([RestoreVerbatimBoxes(verbatim_box_name)]),
+                )
             circuits = pm.run(circuits, callback=callback, num_processes=num_processes)
         elif has_verbatim_boxes:
             circuits = [_inline_verbatim_boxes(circ, verbatim_box_name) for circ in circuits]

--- a/qiskit_braket_provider/providers/compilation.py
+++ b/qiskit_braket_provider/providers/compilation.py
@@ -64,6 +64,20 @@ def _default_target(circuits: Iterable[QuantumCircuit]) -> Target:
     return target
 
 
+def _inline_verbatim_boxes(circuit: QuantumCircuit, verbatim_box_name: str) -> QuantumCircuit:
+    """Replace BoxOps with the given label by their contents at the top level."""
+    out = circuit.copy_empty_like()
+    for instr in circuit.data:
+        op = instr.operation
+        if isinstance(op, BoxOp) and getattr(op, "label", None) == verbatim_box_name:
+            qubit_idx = [circuit.find_bit(q).index for q in instr.qubits]
+            clbit_idx = [circuit.find_bit(c).index for c in instr.clbits]
+            out.compose(op.blocks[0], qubits=qubit_idx, clbits=clbit_idx, inplace=True)
+        else:
+            out.append(instr.operation, instr.qubits, instr.clbits)
+    return out
+
+
 def _compile(
     circuits: QuantumCircuit | Iterable[QuantumCircuit],
     *,
@@ -193,10 +207,7 @@ def _compile(
             )
         ):
             pm = generate_preset_pass_manager(
-                # generate_preset_pass_manager does not accept None unlike transpile().
-                # If user explicitly passes None, default to 2 to match Qiskit's transpile() behavior.
-                # When not passed, the signature default of 0 is used (no optimization).
-                optimization_level=optimization_level if optimization_level is not None else 2,
+                optimization_level=optimization_level,
                 basis_gates=list(basis_gates) if basis_gates else None,
                 coupling_map=coupling_map,
                 target=target,
@@ -209,19 +220,9 @@ def _compile(
                 pm.post_optimization = PassManager([RestoreVerbatimBoxes(verbatim_box_name)])
             circuits = pm.run(circuits, callback=callback, num_processes=num_processes)
         elif has_verbatim_boxes:
-            # No transpilation needed but still need to extract/restore verbatim boxes
-            verbatim_pm = PassManager([
-                ExtractVerbatimBoxes(verbatim_box_name),
-                RestoreVerbatimBoxes(verbatim_box_name),
-            ])
-            circuits = verbatim_pm.run(circuits)
+            circuits = [_inline_verbatim_boxes(circ, verbatim_box_name) for circ in circuits]
     elif has_verbatim_boxes:
-        # verbatim=True: unpack BoxOps without transpilation
-        verbatim_pm = PassManager([
-            ExtractVerbatimBoxes(verbatim_box_name),
-            RestoreVerbatimBoxes(verbatim_box_name),
-        ])
-        circuits = verbatim_pm.run(circuits)
+        circuits = [_inline_verbatim_boxes(circ, verbatim_box_name) for circ in circuits]
 
     if isinstance(target, _SubstitutedTarget):
         circuits = target._substitute(circuits)

--- a/qiskit_braket_provider/providers/compilation.py
+++ b/qiskit_braket_provider/providers/compilation.py
@@ -7,7 +7,6 @@ and the run() endpoints, including verbatim box handling and transpilation.
 import warnings
 from collections.abc import Callable, Collection, Iterable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import TypeVar
 
 from qiskit import QuantumCircuit, generate_preset_pass_manager
 from qiskit.circuit import Barrier, BoxOp, Measure
@@ -30,12 +29,20 @@ from qiskit_braket_provider.providers.target import (
     local_simulator_to_target,
 )
 
-_T = TypeVar("_T")
-
 
 @dataclass(frozen=True)
 class _CompilationContext:
-    """Internal result from _compile containing compiled circuits and resolved state."""
+    """Result of :func:`_compile` containing compiled circuits and resolved state.
+
+    Attributes:
+        circuits: The compiled Qiskit QuantumCircuits.
+        target: The resolved transpiler target, if any.
+        qubit_labels: Physical qubit indices on the target device.
+        verbatim: Whether verbatim mode was requested.
+        basis_gates: The basis gate set used for compilation.
+        angle_restrictions: Per-gate angle constraints from the device.
+        pass_manager: The custom PassManager used, if any.
+    """
 
     circuits: list[QuantumCircuit]
     target: Target | None
@@ -58,8 +65,8 @@ def _default_target(circuits: Iterable[QuantumCircuit]) -> Target:
 
 
 def _compile(
-    circuits: QuantumCircuit | Iterable[QuantumCircuit] = None,
-    *args,
+    circuits: QuantumCircuit | Iterable[QuantumCircuit],
+    *,
     qubit_labels: Sequence[int] | None = None,
     target: Target | None = None,
     verbatim: bool | None = None,
@@ -77,35 +84,63 @@ def _compile(
     routing_method: str | None = None,
     seed_transpiler: int | None = None,
 ) -> _CompilationContext:
+    """Compile Qiskit circuits for execution on a Braket device.
+
+    This is the compilation pipeline used by :func:`to_braket`. It handles
+    verbatim box extraction/restoration, transpilation via Qiskit's pass infrastructure,
+    and device-specific gate substitutions.
+
+    Args:
+        circuits: One or more Qiskit QuantumCircuits to compile.
+        qubit_labels: Physical qubit indices on the target device. If not supplied,
+            contiguous indices are assumed.
+        target: A Qiskit transpiler target describing device constraints.
+        verbatim: If ``True``, skip transpilation (pass circuits through unchanged).
+        basis_gates: Set of gate names supported by the target device.
+        coupling_map: Qubit connectivity as a list of ``[control, target]`` pairs.
+        angle_restrictions: Per-gate angle constraints from the device.
+        optimization_level: Transpiler optimization level (0-3). Default: 0.
+        callback: Callback function passed to the transpiler.
+        num_processes: Number of parallel processes for transpilation.
+        pass_manager: A custom Qiskit PassManager. Mutually exclusive with other
+            transpilation options.
+        braket_device: A Braket Device to derive target and qubit labels from.
+        connectivity: Deprecated alias for ``coupling_map``.
+        verbatim_box_name: Label identifying verbatim BoxOp nodes.
+        layout_method: Layout method for the transpiler.
+        routing_method: Routing method for the transpiler.
+        seed_transpiler: Seed for reproducible transpilation.
+
+    Returns:
+        A :class:`_CompilationContext` containing the compiled circuits and resolved
+        compilation state.
+
+    Raises:
+        ValueError: If mutually exclusive options are specified together.
+        TypeError: If inputs are not QuantumCircuits.
+    """
     if isinstance(circuits, QuantumCircuit):
         circuits = [circuits]
     circuits = list(circuits)
 
-    if len(args) > 4:
-        raise ValueError(f"Unknown arguments passed: {args[4:]}")
-    padded = args + (None,) * max(0, 4 - len(args))
-    basis_gates = _check_positional(padded[0], basis_gates, "basis_gates")
-    verbatim = _check_positional(padded[1], verbatim, "verbatim")
-    connectivity = _check_positional(padded[2], connectivity, "connectivity")
-    angle_restrictions = _check_positional(padded[3], angle_restrictions, "angle_restrictions")
     _validate_arguments(
         circuits, target, basis_gates, coupling_map, connectivity, pass_manager, braket_device
     )
     coupling_map = coupling_map or connectivity
 
-    has_verbatim_boxes = any(
-        isinstance(instr.operation, BoxOp)
-        and getattr(instr.operation, "label", None) == verbatim_box_name
-        for circ in circuits
-        for instr in circ.data
-    )
+    has_barriers_named_verbatim = False
+    has_verbatim_boxes = False
 
-    if any(
-        isinstance(instr.operation, Barrier)
-        and getattr(instr.operation, "label", None) == verbatim_box_name
-        for circ in circuits
-        for instr in circ.data
-    ):
+    for circ in circuits:
+        for instr in circ.data:
+            label = getattr(instr.operation, "label", None)
+            if label == verbatim_box_name:
+                if isinstance(instr.operation, Barrier):
+                    has_barriers_named_verbatim = True
+                elif isinstance(instr.operation, BoxOp):
+                    has_verbatim_boxes = True
+
+    if has_barriers_named_verbatim:
         raise ValueError(
             "Cannot have a Barrier labeled with the same label used for verbatim boxes"
         )
@@ -200,19 +235,6 @@ def _compile(
         angle_restrictions=angle_restrictions,
         pass_manager=pass_manager,
     )
-
-
-def _check_positional(pos: _T, kw: _T, name: str) -> _T:
-    if pos is None:
-        return kw
-    if kw is not None:
-        raise TypeError(f"Multiple values for {name}: {pos, kw}")
-    warnings.warn(
-        f"Passing {name} as a positional argument is deprecated.",
-        DeprecationWarning,
-        stacklevel=1,
-    )
-    return pos
 
 
 def _validate_arguments(

--- a/qiskit_braket_provider/providers/compilation.py
+++ b/qiskit_braket_provider/providers/compilation.py
@@ -7,8 +7,9 @@ and the run() endpoints, including verbatim box handling and transpilation.
 import warnings
 from collections.abc import Callable, Collection, Iterable, Mapping, Sequence
 from dataclasses import dataclass
+from typing import TypeVar
 
-from qiskit import QuantumCircuit, transpile
+from qiskit import QuantumCircuit, generate_preset_pass_manager
 from qiskit.circuit import Barrier, BoxOp, Measure
 from qiskit.transpiler import PassManager, Target
 
@@ -19,123 +20,22 @@ from qiskit_braket_provider.providers.gate_mappings import (
     _BRAKET_TO_QISKIT_NAMES,
     _BRAKET_VERBATIM_BOX_NAME,
 )
+from qiskit_braket_provider.providers.passes import (
+    ExtractVerbatimBoxes,
+    RestoreVerbatimBoxes,
+)
 from qiskit_braket_provider.providers.target import (
     _SubstitutedTarget,
     aws_device_to_target,
     local_simulator_to_target,
 )
 
-
-def _extract_verbatim_boxes(
-    circuit: QuantumCircuit, verbatim_box_name: str
-) -> tuple[QuantumCircuit, list[tuple[QuantumCircuit, list[int]]]]:
-    """Extract BoxOp operations with verbatim box name and replace with barriers.
-
-    Args:
-        circuit: The Qiskit circuit to process
-        verbatim_box_name: The label name used to identify verbatim BoxOp operations
-
-    Returns:
-        A tuple of (modified_circuit, verbatim_boxes) where:
-        - modified_circuit: Circuit with BoxOps replaced by named barriers
-        - verbatim_boxes: List of (box_circuit, qubit_indices) tuples
-    """
-    modified_circuit = QuantumCircuit(circuit.num_qubits, circuit.num_clbits)
-    modified_circuit.global_phase = circuit.global_phase
-
-    verbatim_boxes = []
-
-    for instruction in circuit.data:
-        operation = instruction.operation
-
-        qubit_indices = [circuit.find_bit(q).index for q in instruction.qubits]
-
-        if isinstance(operation, BoxOp) and getattr(operation, "label", None) == verbatim_box_name:
-            box_circuit = operation.blocks[0]
-            verbatim_boxes.append((box_circuit, qubit_indices))
-            barrier = Barrier(len(instruction.qubits), label=verbatim_box_name)
-            modified_circuit.append(barrier, qubit_indices)
-        else:
-            clbit_indices = [circuit.find_bit(c).index for c in instruction.clbits]
-            modified_circuit.append(operation, qubit_indices, clbit_indices)
-
-    return modified_circuit, verbatim_boxes
-
-
-def _restore_verbatim_boxes(
-    transpiled_circuit: QuantumCircuit,
-    verbatim_boxes: list[tuple[QuantumCircuit, list[int]]],
-    verbatim_box_name: str,
-) -> QuantumCircuit:
-    """Restore verbatim boxes by replacing named barriers with box contents.
-
-    Args:
-        transpiled_circuit: The transpiled circuit with named barriers
-        verbatim_boxes: List of (box_circuit, original_qubit_indices) tuples
-        verbatim_box_name: The label name used to identify verbatim barriers
-
-    Returns:
-        Circuit with verbatim box contents restored
-
-    Raises:
-        ValueError: If barrier count doesn't match verbatim box count
-        ValueError: If qubit mapping fails
-    """
-    reconstructed_circuit = transpiled_circuit.copy_empty_like()
-
-    verbatim_box_iter = iter(verbatim_boxes)
-    barrier_count = 0
-
-    for instruction in transpiled_circuit.data:
-        operation = instruction.operation
-
-        if (
-            isinstance(operation, Barrier)
-            and getattr(operation, "label", None) == verbatim_box_name
-        ):
-            barrier_count += 1
-
-            try:
-                box_circuit, _ = next(verbatim_box_iter)
-            except StopIteration as err:
-                raise ValueError(
-                    f"Compiler error while processing verbatim boxes. Illegal barriers with label '{verbatim_box_name}'"
-                ) from err
-
-            for box_instruction in box_circuit.data:
-                qubit_indices = [box_circuit.find_bit(q).index for q in box_instruction.qubits]
-                clbit_indices = [box_circuit.find_bit(q).index for q in box_instruction.clbits]
-                reconstructed_circuit.append(
-                    box_instruction.operation, qubit_indices, clbit_indices
-                )
-        else:
-            qubit_indices = [transpiled_circuit.find_bit(q).index for q in instruction.qubits]
-            clbit_indices = [transpiled_circuit.find_bit(q).index for q in instruction.clbits]
-            reconstructed_circuit.append(operation, qubit_indices, clbit_indices)
-
-    remaining_boxes = list(verbatim_box_iter)
-    if remaining_boxes:
-        raise ValueError(
-            f"Compiler error while processing verbatim boxes. Expected {barrier_count} "
-            f"verbatim boxes, but found {len(verbatim_boxes)}."
-        )
-
-    return reconstructed_circuit
+_T = TypeVar("_T")
 
 
 @dataclass(frozen=True)
 class _CompilationContext:
-    """Result of :func:`_compile` containing compiled circuits and resolved state.
-
-    Attributes:
-        circuits: The compiled Qiskit QuantumCircuits.
-        target: The resolved transpiler target, if any.
-        qubit_labels: Physical qubit indices on the target device.
-        verbatim: Whether verbatim mode was requested.
-        basis_gates: The basis gate set used for compilation.
-        angle_restrictions: Per-gate angle constraints from the device.
-        pass_manager: The custom PassManager used, if any.
-    """
+    """Internal result from _compile containing compiled circuits and resolved state."""
 
     circuits: list[QuantumCircuit]
     target: Target | None
@@ -158,8 +58,8 @@ def _default_target(circuits: Iterable[QuantumCircuit]) -> Target:
 
 
 def _compile(
-    circuits: QuantumCircuit | Iterable[QuantumCircuit],
-    *,
+    circuits: QuantumCircuit | Iterable[QuantumCircuit] = None,
+    *args,
     qubit_labels: Sequence[int] | None = None,
     target: Target | None = None,
     verbatim: bool | None = None,
@@ -177,63 +77,35 @@ def _compile(
     routing_method: str | None = None,
     seed_transpiler: int | None = None,
 ) -> _CompilationContext:
-    """Compile Qiskit circuits for execution on a Braket device.
-
-    This is the compilation pipeline used by :func:`to_braket`. It handles
-    verbatim box extraction/restoration, transpilation via Qiskit's pass infrastructure,
-    and device-specific gate substitutions.
-
-    Args:
-        circuits: One or more Qiskit QuantumCircuits to compile.
-        qubit_labels: Physical qubit indices on the target device. If not supplied,
-            contiguous indices are assumed.
-        target: A Qiskit transpiler target describing device constraints.
-        verbatim: If ``True``, skip transpilation (pass circuits through unchanged).
-        basis_gates: Set of gate names supported by the target device.
-        coupling_map: Qubit connectivity as a list of ``[control, target]`` pairs.
-        angle_restrictions: Per-gate angle constraints from the device.
-        optimization_level: Transpiler optimization level (0-3). Default: 0.
-        callback: Callback function passed to the transpiler.
-        num_processes: Number of parallel processes for transpilation.
-        pass_manager: A custom Qiskit PassManager. Mutually exclusive with other
-            transpilation options.
-        braket_device: A Braket Device to derive target and qubit labels from.
-        connectivity: Deprecated alias for ``coupling_map``.
-        verbatim_box_name: Label identifying verbatim BoxOp nodes.
-        layout_method: Layout method for the transpiler.
-        routing_method: Routing method for the transpiler.
-        seed_transpiler: Seed for reproducible transpilation.
-
-    Returns:
-        A :class:`_CompilationContext` containing the compiled circuits and resolved
-        compilation state.
-
-    Raises:
-        ValueError: If mutually exclusive options are specified together.
-        TypeError: If inputs are not QuantumCircuits.
-    """
     if isinstance(circuits, QuantumCircuit):
         circuits = [circuits]
     circuits = list(circuits)
 
+    if len(args) > 4:
+        raise ValueError(f"Unknown arguments passed: {args[4:]}")
+    padded = args + (None,) * max(0, 4 - len(args))
+    basis_gates = _check_positional(padded[0], basis_gates, "basis_gates")
+    verbatim = _check_positional(padded[1], verbatim, "verbatim")
+    connectivity = _check_positional(padded[2], connectivity, "connectivity")
+    angle_restrictions = _check_positional(padded[3], angle_restrictions, "angle_restrictions")
     _validate_arguments(
         circuits, target, basis_gates, coupling_map, connectivity, pass_manager, braket_device
     )
     coupling_map = coupling_map or connectivity
 
-    has_barriers_named_verbatim = False
-    has_verbatim_boxes = False
+    has_verbatim_boxes = any(
+        isinstance(instr.operation, BoxOp)
+        and getattr(instr.operation, "label", None) == verbatim_box_name
+        for circ in circuits
+        for instr in circ.data
+    )
 
-    for circ in circuits:
-        for instr in circ.data:
-            label = getattr(instr.operation, "label", None)
-            if label == verbatim_box_name:
-                if isinstance(instr.operation, Barrier):
-                    has_barriers_named_verbatim = True
-                elif isinstance(instr.operation, BoxOp):
-                    has_verbatim_boxes = True
-
-    if has_barriers_named_verbatim:
+    if any(
+        isinstance(instr.operation, Barrier)
+        and getattr(instr.operation, "label", None) == verbatim_box_name
+        for circ in circuits
+        for instr in circ.data
+    ):
         raise ValueError(
             "Cannot have a Barrier labeled with the same label used for verbatim boxes"
         )
@@ -243,15 +115,6 @@ def _compile(
             "Custom pass_manager is not supported with verbatim boxes. "
             "Verbatim boxes require controlled transpilation to preserve gate ordering."
         )
-
-    all_verbatim_boxes = []
-    if has_verbatim_boxes:
-        extracted_circuits = []
-        for circ in circuits:
-            modified_circ, verbatim_boxes = _extract_verbatim_boxes(circ, verbatim_box_name)
-            extracted_circuits.append(modified_circ)
-            all_verbatim_boxes.append(verbatim_boxes)
-        circuits = extracted_circuits
 
     if braket_device:
         if qubit_labels:
@@ -294,28 +157,39 @@ def _compile(
                 )
             )
         ):
-            circuits = transpile(
-                circuits,
-                basis_gates=basis_gates,
+            pm = generate_preset_pass_manager(
+                # generate_preset_pass_manager does not accept None unlike transpile().
+                # If user explicitly passes None, default to 2 to match Qiskit's transpile() behavior.
+                # When not passed, the signature default of 0 is used (no optimization).
+                optimization_level=optimization_level if optimization_level is not None else 2,
+                basis_gates=list(basis_gates) if basis_gates else None,
                 coupling_map=coupling_map,
-                optimization_level=optimization_level,
                 target=target,
-                callback=callback,
-                num_processes=num_processes,
                 layout_method=effective_layout_method,
                 routing_method=effective_routing_method,
                 seed_transpiler=seed_transpiler,
             )
+            if has_verbatim_boxes:
+                pm.pre_init = PassManager([ExtractVerbatimBoxes(verbatim_box_name)])
+                pm.post_optimization = PassManager([RestoreVerbatimBoxes(verbatim_box_name)])
+            circuits = pm.run(circuits, callback=callback, num_processes=num_processes)
+        elif has_verbatim_boxes:
+            # No transpilation needed but still need to extract/restore verbatim boxes
+            verbatim_pm = PassManager([
+                ExtractVerbatimBoxes(verbatim_box_name),
+                RestoreVerbatimBoxes(verbatim_box_name),
+            ])
+            circuits = verbatim_pm.run(circuits)
+    elif has_verbatim_boxes:
+        # verbatim=True: unpack BoxOps without transpilation
+        verbatim_pm = PassManager([
+            ExtractVerbatimBoxes(verbatim_box_name),
+            RestoreVerbatimBoxes(verbatim_box_name),
+        ])
+        circuits = verbatim_pm.run(circuits)
+
     if isinstance(target, _SubstitutedTarget):
         circuits = target._substitute(circuits)
-
-    if has_verbatim_boxes:
-        circuits = [
-            _restore_verbatim_boxes(circ, verbatim_boxes, verbatim_box_name)
-            if len(verbatim_boxes) > 0
-            else circ
-            for circ, verbatim_boxes in zip(circuits, all_verbatim_boxes, strict=False)
-        ]
 
     return _CompilationContext(
         circuits=circuits,
@@ -326,6 +200,19 @@ def _compile(
         angle_restrictions=angle_restrictions,
         pass_manager=pass_manager,
     )
+
+
+def _check_positional(pos: _T, kw: _T, name: str) -> _T:
+    if pos is None:
+        return kw
+    if kw is not None:
+        raise TypeError(f"Multiple values for {name}: {pos, kw}")
+    warnings.warn(
+        f"Passing {name} as a positional argument is deprecated.",
+        DeprecationWarning,
+        stacklevel=1,
+    )
+    return pos
 
 
 def _validate_arguments(

--- a/qiskit_braket_provider/providers/passes/__init__.py
+++ b/qiskit_braket_provider/providers/passes/__init__.py
@@ -1,0 +1,8 @@
+"""Qiskit transpiler passes for the Braket provider."""
+
+from qiskit_braket_provider.providers.passes.verbatim_passes import (
+    ExtractVerbatimBoxes,
+    RestoreVerbatimBoxes,
+)
+
+__all__ = ["ExtractVerbatimBoxes", "RestoreVerbatimBoxes"]

--- a/qiskit_braket_provider/providers/passes/__init__.py
+++ b/qiskit_braket_provider/providers/passes/__init__.py
@@ -1,8 +1,4 @@
 """Qiskit transpiler passes for the Braket provider."""
 
-from qiskit_braket_provider.providers.passes.verbatim_passes import (
-    ExtractVerbatimBoxes,
-    RestoreVerbatimBoxes,
-)
-
-__all__ = ["ExtractVerbatimBoxes", "RestoreVerbatimBoxes"]
+from .verbatim_passes import ExtractVerbatimBoxes as ExtractVerbatimBoxes
+from .verbatim_passes import RestoreVerbatimBoxes as RestoreVerbatimBoxes

--- a/qiskit_braket_provider/providers/passes/verbatim_passes.py
+++ b/qiskit_braket_provider/providers/passes/verbatim_passes.py
@@ -1,24 +1,4 @@
-"""Transpiler passes for preserving Braket verbatim boxes through compilation.
-
-Braket verbatim boxes (``#pragma braket verbatim``) mark circuit regions that
-must reach hardware unmodified. In Qiskit these are represented as
-:class:`~qiskit.circuit.BoxOp` nodes with a ``"verbatim"`` label.
-
-Since the Qiskit transpiler has no notion of verbatim semantics, these two
-passes bracket the transpilation pipeline:
-
-- :class:`ExtractVerbatimBoxes` (pre-transpilation): swaps each verbatim
-  ``BoxOp`` for a labeled :class:`~qiskit.circuit.Barrier` that the
-  transpiler will leave untouched, and stashes the original circuits in
-  ``property_set["verbatim_boxes"]``.
-
-- :class:`RestoreVerbatimBoxes` (post-transpilation): replaces the labeled
-  barriers with the stashed gate sequences.
-
-Both passes must share a ``property_set``, which happens automatically when
-they live in the same :class:`~qiskit.transpiler.PassManager` or
-:class:`~qiskit.transpiler.StagedPassManager`.
-"""
+"""Transpiler passes for preserving verbatim boxes through compilation."""
 
 from qiskit.circuit import Barrier, BoxOp, QuantumCircuit
 from qiskit.converters import circuit_to_dag
@@ -132,15 +112,13 @@ class RestoreVerbatimBoxes(TransformationPass):
                 )
             box_circuit, clbit_indices = verbatim_boxes.pop(label)
             if clbit_indices:
-                # The barrier only has qubits; build a replacement DAG that
-                # includes the box's clbits so we can substitute correctly.
                 box_dag = circuit_to_dag(box_circuit)
-                # Wire mapping: barrier qubits → box qubits, dag clbits → box clbits
-                qubit_map = dict(zip(node.qargs, box_dag.qubits, strict=True))
+                # Build a replacement DAG that includes the box's clbits.
+                qubit_map = dict(zip(box_dag.qubits, node.qargs, strict=True))
                 clbit_map = dict(
                     zip(
-                        [dag.clbits[i] for i in clbit_indices],
                         box_dag.clbits,
+                        [dag.clbits[i] for i in clbit_indices],
                         strict=True,
                     )
                 )
@@ -151,8 +129,8 @@ class RestoreVerbatimBoxes(TransformationPass):
 
         if verbatim_boxes:
             raise RuntimeError(
-                f"Internal error: verbatim boxes lost during transpilation: "
-                f"{list(verbatim_boxes.keys())}. "
-                f"This is a bug in the verbatim pass pipeline."
+                f"Internal error: stashed verbatim boxes were not restored "
+                f"(no matching barriers found): {list(verbatim_boxes.keys())}. "
+                f"Their barriers may have been removed during transpilation."
             )
         return dag

--- a/qiskit_braket_provider/providers/passes/verbatim_passes.py
+++ b/qiskit_braket_provider/providers/passes/verbatim_passes.py
@@ -92,8 +92,8 @@ class RestoreVerbatimBoxes(TransformationPass):
         """Splice stashed gate sequences back in place of labeled barriers.
 
         Raises:
-            RuntimeError: If the number of labeled barriers does not match
-                the number of stashed verbatim boxes.
+            RuntimeError: If a labeled barrier has no matching stashed box.
+            RuntimeError: If stashed boxes remain unconsumed after processing.
         """
         verbatim_boxes = self.property_set.get("verbatim_boxes", {})
         if not verbatim_boxes:
@@ -111,8 +111,8 @@ class RestoreVerbatimBoxes(TransformationPass):
                     f"This is a bug in the verbatim pass pipeline."
                 )
             box_circuit, clbit_indices = verbatim_boxes.pop(label)
+            box_dag = circuit_to_dag(box_circuit)
             if clbit_indices:
-                box_dag = circuit_to_dag(box_circuit)
                 # Build a replacement DAG that includes the box's clbits.
                 qubit_map = dict(zip(box_dag.qubits, node.qargs, strict=True))
                 clbit_map = dict(
@@ -124,7 +124,6 @@ class RestoreVerbatimBoxes(TransformationPass):
                 )
                 dag.substitute_node_with_dag(node, box_dag, wires={**qubit_map, **clbit_map})
             else:
-                box_dag = circuit_to_dag(box_circuit)
                 dag.substitute_node_with_dag(node, box_dag)
 
         if verbatim_boxes:

--- a/qiskit_braket_provider/providers/passes/verbatim_passes.py
+++ b/qiskit_braket_provider/providers/passes/verbatim_passes.py
@@ -1,0 +1,158 @@
+"""Transpiler passes for preserving Braket verbatim boxes through compilation.
+
+Braket verbatim boxes (``#pragma braket verbatim``) mark circuit regions that
+must reach hardware unmodified. In Qiskit these are represented as
+:class:`~qiskit.circuit.BoxOp` nodes with a ``"verbatim"`` label.
+
+Since the Qiskit transpiler has no notion of verbatim semantics, these two
+passes bracket the transpilation pipeline:
+
+- :class:`ExtractVerbatimBoxes` (pre-transpilation): swaps each verbatim
+  ``BoxOp`` for a labeled :class:`~qiskit.circuit.Barrier` that the
+  transpiler will leave untouched, and stashes the original circuits in
+  ``property_set["verbatim_boxes"]``.
+
+- :class:`RestoreVerbatimBoxes` (post-transpilation): replaces the labeled
+  barriers with the stashed gate sequences.
+
+Both passes must share a ``property_set``, which happens automatically when
+they live in the same :class:`~qiskit.transpiler.PassManager` or
+:class:`~qiskit.transpiler.StagedPassManager`.
+"""
+
+from qiskit.circuit import Barrier, BoxOp, QuantumCircuit
+from qiskit.converters import circuit_to_dag
+from qiskit.dagcircuit import DAGCircuit
+from qiskit.transpiler.basepasses import TransformationPass
+
+from qiskit_braket_provider.providers.gate_mappings import _BRAKET_VERBATIM_BOX_NAME
+
+
+def _indexed_label(base: str, index: int) -> str:
+    return f"{base}__{index}"
+
+
+def _is_verbatim_label(label: str | None, base: str) -> bool:
+    """Check if a label is a verbatim barrier label (base or indexed)."""
+    if label is None:
+        return False
+    return label == base or (label.startswith(f"{base}__") and label[len(base) + 2 :].isdigit())
+
+
+class ExtractVerbatimBoxes(TransformationPass):
+    """Swap verbatim ``BoxOp`` nodes for labeled barriers before transpilation.
+
+    The original box circuits are stashed in ``property_set["verbatim_boxes"]``
+    as a dict mapping indexed labels to ``QuantumCircuit`` instances for
+    :class:`RestoreVerbatimBoxes` to restore afterwards.
+
+    Args:
+        verbatim_box_name: Label used to identify verbatim ``BoxOp`` nodes.
+    """
+
+    def __init__(self, verbatim_box_name: str = _BRAKET_VERBATIM_BOX_NAME):
+        super().__init__()
+        self._verbatim_box_name = verbatim_box_name
+
+    def run(self, dag: DAGCircuit) -> DAGCircuit:
+        """Replace matching ``BoxOp`` nodes with labeled barriers.
+
+        Raises:
+            ValueError: If the DAG already contains a barrier whose label
+                matches ``verbatim_box_name``.
+        """
+        for node in dag.topological_op_nodes():
+            if isinstance(node.op, Barrier) and _is_verbatim_label(
+                getattr(node.op, "label", None), self._verbatim_box_name
+            ):
+                raise ValueError(
+                    f"Circuit contains a Barrier with label '{node.op.label}' "
+                    "which conflicts with the verbatim box label"
+                )
+
+        verbatim_boxes = {}
+        index = 0
+        for node in dag.topological_op_nodes():
+            if not isinstance(node.op, BoxOp):
+                continue
+            if getattr(node.op, "label", None) != self._verbatim_box_name:
+                continue
+            label = _indexed_label(self._verbatim_box_name, index)
+            verbatim_boxes[label] = (node.op.blocks[0], [dag.find_bit(c).index for c in node.cargs])
+            barrier = Barrier(len(node.qargs), label=label)
+            if node.cargs:
+                # BoxOp has clbits — substitute_node requires matching width,
+                # so replace with a sub-DAG containing only the barrier on qubits.
+                qc = QuantumCircuit(len(node.qargs), len(node.cargs))
+                qc.append(barrier, list(range(len(node.qargs))))
+                dag.substitute_node_with_dag(node, circuit_to_dag(qc))
+            else:
+                dag.substitute_node(node, barrier)
+            index += 1
+
+        self.property_set["verbatim_boxes"] = verbatim_boxes
+        return dag
+
+
+class RestoreVerbatimBoxes(TransformationPass):
+    """Replace labeled barriers with the original verbatim gate sequences.
+
+    Reads ``property_set["verbatim_boxes"]`` populated by
+    :class:`ExtractVerbatimBoxes`.
+
+    Args:
+        verbatim_box_name: Label used to identify placeholder barriers.
+    """
+
+    def __init__(self, verbatim_box_name: str = _BRAKET_VERBATIM_BOX_NAME):
+        super().__init__()
+        self._verbatim_box_name = verbatim_box_name
+
+    def run(self, dag: DAGCircuit) -> DAGCircuit:
+        """Splice stashed gate sequences back in place of labeled barriers.
+
+        Raises:
+            RuntimeError: If the number of labeled barriers does not match
+                the number of stashed verbatim boxes.
+        """
+        verbatim_boxes = self.property_set.get("verbatim_boxes", {})
+        if not verbatim_boxes:
+            return dag
+
+        for node in dag.topological_op_nodes():
+            if not isinstance(node.op, Barrier):
+                continue
+            label = getattr(node.op, "label", None)
+            if not _is_verbatim_label(label, self._verbatim_box_name):
+                continue
+            if label not in verbatim_boxes:
+                raise RuntimeError(
+                    f"Internal error: verbatim barrier '{label}' has no matching box. "
+                    f"This is a bug in the verbatim pass pipeline."
+                )
+            box_circuit, clbit_indices = verbatim_boxes.pop(label)
+            if clbit_indices:
+                # The barrier only has qubits; build a replacement DAG that
+                # includes the box's clbits so we can substitute correctly.
+                box_dag = circuit_to_dag(box_circuit)
+                # Wire mapping: barrier qubits → box qubits, dag clbits → box clbits
+                qubit_map = dict(zip(node.qargs, box_dag.qubits, strict=True))
+                clbit_map = dict(
+                    zip(
+                        [dag.clbits[i] for i in clbit_indices],
+                        box_dag.clbits,
+                        strict=True,
+                    )
+                )
+                dag.substitute_node_with_dag(node, box_dag, wires={**qubit_map, **clbit_map})
+            else:
+                box_dag = circuit_to_dag(box_circuit)
+                dag.substitute_node_with_dag(node, box_dag)
+
+        if verbatim_boxes:
+            raise RuntimeError(
+                f"Internal error: verbatim boxes lost during transpilation: "
+                f"{list(verbatim_boxes.keys())}. "
+                f"This is a bug in the verbatim pass pipeline."
+            )
+        return dag

--- a/test/unit_tests/test_adapter.py
+++ b/test/unit_tests/test_adapter.py
@@ -85,7 +85,7 @@ _BRAKET_SUPPORTED_NOISE_INSTANCES = {
 
 
 def check_to_braket_unitary_correct(
-    qiskit_circuit: QuantumCircuit, optimization_level: int | None = None
+    qiskit_circuit: QuantumCircuit, optimization_level: int = 0
 ) -> bool:
     """Checks if endianness-reversed Qiskit circuit matrix matches Braket counterpart"""
     result = to_braket(qiskit_circuit, optimization_level=optimization_level)

--- a/test/unit_tests/test_adapter.py
+++ b/test/unit_tests/test_adapter.py
@@ -950,14 +950,16 @@ class TestAdapter(TestCase):
         with pytest.raises(ValueError, match=r"Please rename your parameters."):
             to_braket(qiskit_circuit)
 
-    @patch("qiskit_braket_provider.providers.compilation.transpile")
-    def test_invalid_ctrl_state(self, mock_transpile: MagicMock):
+    @patch("qiskit_braket_provider.providers.compilation.generate_preset_pass_manager")
+    def test_invalid_ctrl_state(self, mock_gen_pm: MagicMock):
         """Tests that control states other than all 1s are rejected."""
         qiskit_circuit = QuantumCircuit(2)
         qiskit_circuit.h(0)
         qiskit_circuit.cx(0, 1, ctrl_state=0)
 
-        mock_transpile.return_value = [qiskit_circuit]
+        mock_pm = MagicMock()
+        mock_pm.run.return_value = [qiskit_circuit]
+        mock_gen_pm.return_value = mock_pm
         with pytest.raises(ValueError):
             to_braket(qiskit_circuit)
 

--- a/test/unit_tests/test_adapter_to_braket_verbatim.py
+++ b/test/unit_tests/test_adapter_to_braket_verbatim.py
@@ -9,10 +9,12 @@ from qiskit.transpiler.passes import Optimize1qGates
 from braket.circuits import Circuit
 from braket.ir.openqasm import Program
 from qiskit_braket_provider.providers.adapter import (
-    _extract_verbatim_boxes,
-    _restore_verbatim_boxes,
     to_braket,
     to_qiskit,
+)
+from qiskit_braket_provider.providers.passes import (
+    ExtractVerbatimBoxes,
+    RestoreVerbatimBoxes,
 )
 
 VERBATIM_LABEL = "verbatim"
@@ -124,16 +126,21 @@ def test_verbatim_box_extraction(
     main = QuantumCircuit(NUM_QUBITS)
     main.append(BoxOp(inner, label=VERBATIM_LABEL), QUBIT_PAIR)
 
-    modified, boxes = _extract_verbatim_boxes(main, VERBATIM_LABEL)
+    pm = PassManager([ExtractVerbatimBoxes(VERBATIM_LABEL)])
+    modified = pm.run(main)
 
     assert len(modified.data) == 1
     assert isinstance(modified.data[0].operation, Barrier)
-    assert modified.data[0].operation.label == VERBATIM_LABEL
+    assert modified.data[0].operation.label.startswith(VERBATIM_LABEL)
 
-    assert len(boxes) == 1
-    box_circuit, qubit_indices = boxes[0]
+    verbatim_boxes = pm.property_set["verbatim_boxes"]
+    assert len(verbatim_boxes) == 1
+    box_circuit, _clbits = next(iter(verbatim_boxes.values()))
     assert [d.operation.name for d in box_circuit.data] == expected_gate_names
-    assert qubit_indices == expected_qubits
+
+    # Verify the barrier is on the expected qubits
+    barrier_qubits = [modified.find_bit(q).index for q in modified.data[0].qubits]
+    assert barrier_qubits == expected_qubits
 
 
 def test_multiple_verbatim_boxes_extraction(h_circuit: QuantumCircuit, cx_circuit: QuantumCircuit):
@@ -142,44 +149,55 @@ def test_multiple_verbatim_boxes_extraction(h_circuit: QuantumCircuit, cx_circui
     main.x(1)
     main.append(BoxOp(cx_circuit, label=VERBATIM_LABEL), QUBIT_PAIR)
 
-    modified, boxes = _extract_verbatim_boxes(main, VERBATIM_LABEL)
+    pm = PassManager([ExtractVerbatimBoxes(VERBATIM_LABEL)])
+    modified = pm.run(main)
 
     barriers = [i for i in modified.data if isinstance(i.operation, Barrier)]
     assert len(barriers) == 2
-    assert all(b.operation.label == VERBATIM_LABEL for b in barriers)
+    assert all(b.operation.label.startswith(VERBATIM_LABEL) for b in barriers)
     assert len([i for i in modified.data if i.operation.name == "x"]) == 1
 
-    assert len(boxes) == 2
-    assert boxes[0][0].data[0].operation.name == "h"
-    assert boxes[1][0].data[0].operation.name == "cx"
+    # Verify barrier qubit indices
+    for barrier_instr in barriers:
+        barrier_qubits = [modified.find_bit(q).index for q in barrier_instr.qubits]
+        assert barrier_qubits == QUBIT_PAIR
+
+    verbatim_boxes = pm.property_set["verbatim_boxes"]
+    assert len(verbatim_boxes) == 2
+    box_circuits = [circ for circ, _clbits in verbatim_boxes.values()]
+    assert box_circuits[0].data[0].operation.name == "h"
+    assert box_circuits[1].data[0].operation.name == "cx"
 
 
 def test_circuit_without_verbatim_boxes():
     main = _make_box_circuit(NUM_QUBITS, [("h", [0]), ("cx", [0, 1])])
-    modified, boxes = _extract_verbatim_boxes(main, VERBATIM_LABEL)
+    pm = PassManager([ExtractVerbatimBoxes(VERBATIM_LABEL)])
+    modified = pm.run(main)
 
     assert len(modified.data) == 2
     assert [d.operation.name for d in modified.data] == ["h", "cx"]
-    assert len(boxes) == 0
+    assert pm.property_set["verbatim_boxes"] == {}
 
 
 def test_non_verbatim_boxop_not_extracted(h_circuit: QuantumCircuit):
     main = QuantumCircuit(NUM_QUBITS)
     main.append(BoxOp(h_circuit, label="other_label"), QUBIT_PAIR)
 
-    modified, boxes = _extract_verbatim_boxes(main, VERBATIM_LABEL)
+    pm = PassManager([ExtractVerbatimBoxes(VERBATIM_LABEL)])
+    modified = pm.run(main)
 
-    assert len(boxes) == 0
+    assert pm.property_set["verbatim_boxes"] == {}
     assert len(modified.data) == 1
     assert isinstance(modified.data[0].operation, BoxOp)
     assert modified.data[0].operation.label == "other_label"
 
 
 def test_single_verbatim_box_restoration(h_cx_circuit: QuantumCircuit):
-    transpiled = QuantumCircuit(NUM_QUBITS)
-    transpiled.append(Barrier(NUM_QUBITS, label=VERBATIM_LABEL), QUBIT_PAIR)
+    main = QuantumCircuit(NUM_QUBITS)
+    main.append(BoxOp(h_cx_circuit, label=VERBATIM_LABEL), QUBIT_PAIR)
 
-    restored = _restore_verbatim_boxes(transpiled, [(h_cx_circuit, QUBIT_PAIR)], VERBATIM_LABEL)
+    pm = PassManager([ExtractVerbatimBoxes(VERBATIM_LABEL), RestoreVerbatimBoxes(VERBATIM_LABEL)])
+    restored = pm.run(main)
 
     assert len(restored.data) == 2
     assert restored.data[0].operation.name == "h"
@@ -190,36 +208,41 @@ def test_single_verbatim_box_restoration(h_cx_circuit: QuantumCircuit):
 
 
 def test_multiple_verbatim_boxes_restoration(h_circuit: QuantumCircuit, cx_circuit: QuantumCircuit):
-    transpiled = QuantumCircuit(NUM_QUBITS)
-    transpiled.append(Barrier(NUM_QUBITS, label=VERBATIM_LABEL), QUBIT_PAIR)
-    transpiled.x(1)
-    transpiled.append(Barrier(NUM_QUBITS, label=VERBATIM_LABEL), QUBIT_PAIR)
+    main = QuantumCircuit(NUM_QUBITS)
+    main.append(BoxOp(h_circuit, label=VERBATIM_LABEL), QUBIT_PAIR)
+    main.x(1)
+    main.append(BoxOp(cx_circuit, label=VERBATIM_LABEL), QUBIT_PAIR)
 
-    restored = _restore_verbatim_boxes(
-        transpiled, [(h_circuit, QUBIT_PAIR), (cx_circuit, QUBIT_PAIR)], VERBATIM_LABEL
-    )
+    pm = PassManager([ExtractVerbatimBoxes(VERBATIM_LABEL), RestoreVerbatimBoxes(VERBATIM_LABEL)])
+    restored = pm.run(main)
 
     gate_names = [i.operation.name for i in restored.data]
     assert gate_names == ["h", "x", "cx"]
 
+    # Verify qubit indices
+    assert restored.find_bit(restored.data[0].qubits[0]).index == 0  # h on q0
+    assert restored.find_bit(restored.data[1].qubits[0]).index == 1  # x on q1
+    assert restored.find_bit(restored.data[2].qubits[0]).index == 0  # cx control q0
+    assert restored.find_bit(restored.data[2].qubits[1]).index == 1  # cx target q1
 
-@pytest.mark.parametrize(
-    "num_barriers, num_boxes, error_match",
-    [
-        (2, 1, "Compiler error while processing verbatim boxes.*Illegal barriers"),
-        (1, 2, "Compiler error while processing verbatim boxes.*Expected"),
-    ],
-    ids=["too_many_barriers", "too_few_barriers"],
-)
-def test_barrier_box_count_mismatch(num_barriers: int, num_boxes: int, error_match: str):
-    transpiled = QuantumCircuit(NUM_QUBITS)
-    for _ in range(num_barriers):
-        transpiled.append(Barrier(NUM_QUBITS, label=VERBATIM_LABEL), QUBIT_PAIR)
 
-    boxes = [(_make_box_circuit(NUM_QUBITS, [("h", [0])]), QUBIT_PAIR) for _ in range(num_boxes)]
+def test_extract_raises_on_barrier_labeled_verbatim():
+    qc = QuantumCircuit(NUM_QUBITS)
+    qc.append(Barrier(NUM_QUBITS, label=VERBATIM_LABEL), QUBIT_PAIR)
 
-    with pytest.raises(ValueError, match=error_match):
-        _restore_verbatim_boxes(transpiled, boxes, VERBATIM_LABEL)
+    pm = PassManager([ExtractVerbatimBoxes(VERBATIM_LABEL)])
+    with pytest.raises(ValueError, match="conflicts with the verbatim box label"):
+        pm.run(qc)
+
+
+def test_restore_raises_on_missing_box():
+    """Test that ExtractVerbatimBoxes raises on conflicting barrier labels."""
+    qc = QuantumCircuit(NUM_QUBITS)
+    qc.append(Barrier(NUM_QUBITS, label="verbatim__0"), QUBIT_PAIR)
+
+    pm = PassManager([ExtractVerbatimBoxes(VERBATIM_LABEL)])
+    with pytest.raises(ValueError, match="conflicts with the verbatim box label"):
+        pm.run(qc)
 
 
 def test_to_braket_with_single_verbatim_box(h_cx_circuit: QuantumCircuit):

--- a/test/unit_tests/test_adapter_to_braket_verbatim.py
+++ b/test/unit_tests/test_adapter_to_braket_verbatim.py
@@ -767,3 +767,29 @@ def test_verbatim_with_if_else_on_unsupported_backend_raises_clean_error():
 
     with pytest.raises(TranspilerError, match="control-flow"):
         to_braket(qc, target=target)
+
+
+def test_verbatim_box_preserves_reversed_qubit_order():
+    """Verbatim box on reversed qubits preserves outer qubit indices."""
+    body = QuantumCircuit(NUM_QUBITS)
+    body.cx(0, 1)
+
+    qc = QuantumCircuit(NUM_QUBITS)
+    qc.append(BoxOp(body, label=VERBATIM_LABEL), [qc.qubits[1], qc.qubits[0]])
+
+    out = _compile(qc, basis_gates={"cx"}).circuits[0]
+    cx = next(i for i in out.data if i.operation.name == "cx")
+    assert [out.find_bit(q).index for q in cx.qubits] == [1, 0]
+
+
+def test_verbatim_box_preserves_non_contiguous_qubit_order():
+    """Verbatim box on non-contiguous qubits preserves outer qubit indices."""
+    body = QuantumCircuit(2)
+    body.cx(0, 1)
+
+    qc = QuantumCircuit(3)
+    qc.append(BoxOp(body, label=VERBATIM_LABEL), [qc.qubits[2], qc.qubits[0]])
+
+    out = _compile(qc, basis_gates={"cx"}).circuits[0]
+    cx = next(i for i in out.data if i.operation.name == "cx")
+    assert [out.find_bit(q).index for q in cx.qubits] == [2, 0]

--- a/test/unit_tests/test_adapter_to_braket_verbatim.py
+++ b/test/unit_tests/test_adapter_to_braket_verbatim.py
@@ -3,6 +3,7 @@
 import pytest
 from qiskit import QuantumCircuit
 from qiskit.circuit import Barrier, BoxOp
+from qiskit.converters import circuit_to_dag, dag_to_circuit
 from qiskit.transpiler import PassManager
 from qiskit.transpiler.passes import Optimize1qGates
 
@@ -12,10 +13,12 @@ from qiskit_braket_provider.providers.adapter import (
     to_braket,
     to_qiskit,
 )
+from qiskit_braket_provider.providers.compilation import _compile
 from qiskit_braket_provider.providers.passes import (
     ExtractVerbatimBoxes,
     RestoreVerbatimBoxes,
 )
+from qiskit_braket_provider.providers.passes.verbatim_passes import _indexed_label
 
 VERBATIM_LABEL = "verbatim"
 NUM_QUBITS = 2
@@ -138,7 +141,6 @@ def test_verbatim_box_extraction(
     box_circuit, _clbits = next(iter(verbatim_boxes.values()))
     assert [d.operation.name for d in box_circuit.data] == expected_gate_names
 
-    # Verify the barrier is on the expected qubits
     barrier_qubits = [modified.find_bit(q).index for q in modified.data[0].qubits]
     assert barrier_qubits == expected_qubits
 
@@ -157,7 +159,6 @@ def test_multiple_verbatim_boxes_extraction(h_circuit: QuantumCircuit, cx_circui
     assert all(b.operation.label.startswith(VERBATIM_LABEL) for b in barriers)
     assert len([i for i in modified.data if i.operation.name == "x"]) == 1
 
-    # Verify barrier qubit indices
     for barrier_instr in barriers:
         barrier_qubits = [modified.find_bit(q).index for q in barrier_instr.qubits]
         assert barrier_qubits == QUBIT_PAIR
@@ -193,11 +194,16 @@ def test_non_verbatim_boxop_not_extracted(h_circuit: QuantumCircuit):
 
 
 def test_single_verbatim_box_restoration(h_cx_circuit: QuantumCircuit):
-    main = QuantumCircuit(NUM_QUBITS)
-    main.append(BoxOp(h_cx_circuit, label=VERBATIM_LABEL), QUBIT_PAIR)
+    """RestoreVerbatimBoxes replaces a labeled barrier with stashed box contents."""
+    label = _indexed_label(VERBATIM_LABEL, 0)
+    transpiled = QuantumCircuit(NUM_QUBITS)
+    transpiled.append(Barrier(NUM_QUBITS, label=label), QUBIT_PAIR)
 
-    pm = PassManager([ExtractVerbatimBoxes(VERBATIM_LABEL), RestoreVerbatimBoxes(VERBATIM_LABEL)])
-    restored = pm.run(main)
+    restore_pass = RestoreVerbatimBoxes(VERBATIM_LABEL)
+    restore_pass.property_set["verbatim_boxes"] = {label: (h_cx_circuit, [])}
+
+    dag = circuit_to_dag(transpiled)
+    restored = dag_to_circuit(restore_pass.run(dag))
 
     assert len(restored.data) == 2
     assert restored.data[0].operation.name == "h"
@@ -208,18 +214,26 @@ def test_single_verbatim_box_restoration(h_cx_circuit: QuantumCircuit):
 
 
 def test_multiple_verbatim_boxes_restoration(h_circuit: QuantumCircuit, cx_circuit: QuantumCircuit):
-    main = QuantumCircuit(NUM_QUBITS)
-    main.append(BoxOp(h_circuit, label=VERBATIM_LABEL), QUBIT_PAIR)
-    main.x(1)
-    main.append(BoxOp(cx_circuit, label=VERBATIM_LABEL), QUBIT_PAIR)
+    """RestoreVerbatimBoxes replaces multiple labeled barriers with stashed box contents."""
+    label_0 = _indexed_label(VERBATIM_LABEL, 0)
+    label_1 = _indexed_label(VERBATIM_LABEL, 1)
+    transpiled = QuantumCircuit(NUM_QUBITS)
+    transpiled.append(Barrier(NUM_QUBITS, label=label_0), QUBIT_PAIR)
+    transpiled.x(1)
+    transpiled.append(Barrier(NUM_QUBITS, label=label_1), QUBIT_PAIR)
 
-    pm = PassManager([ExtractVerbatimBoxes(VERBATIM_LABEL), RestoreVerbatimBoxes(VERBATIM_LABEL)])
-    restored = pm.run(main)
+    restore_pass = RestoreVerbatimBoxes(VERBATIM_LABEL)
+    restore_pass.property_set["verbatim_boxes"] = {
+        label_0: (h_circuit, []),
+        label_1: (cx_circuit, []),
+    }
+
+    dag = circuit_to_dag(transpiled)
+    restored = dag_to_circuit(restore_pass.run(dag))
 
     gate_names = [i.operation.name for i in restored.data]
     assert gate_names == ["h", "x", "cx"]
 
-    # Verify qubit indices
     assert restored.find_bit(restored.data[0].qubits[0]).index == 0  # h on q0
     assert restored.find_bit(restored.data[1].qubits[0]).index == 1  # x on q1
     assert restored.find_bit(restored.data[2].qubits[0]).index == 0  # cx control q0
@@ -235,7 +249,7 @@ def test_extract_raises_on_barrier_labeled_verbatim():
         pm.run(qc)
 
 
-def test_restore_raises_on_missing_box():
+def test_extract_raises_on_conflicting_barrier_label():
     """Test that ExtractVerbatimBoxes raises on conflicting barrier labels."""
     qc = QuantumCircuit(NUM_QUBITS)
     qc.append(Barrier(NUM_QUBITS, label="verbatim__0"), QUBIT_PAIR)
@@ -542,6 +556,23 @@ def test_to_braket_handles_verbatim_box_with_clbits():
     assert "b[0] = measure $0;" in source
 
 
+def test_to_braket_verbatim_box_with_clbits_on_subset_of_qubits():
+    """Verbatim BoxOp on a qubit subset of a larger circuit with measurements."""
+    body = QuantumCircuit(2, 2)
+    body.x(0)
+    body.measure(0, 0)
+    body.measure(1, 1)
+
+    qc = QuantumCircuit(3, 2)
+    qc.append(BoxOp(body, label=VERBATIM_LABEL), [qc.qubits[0], qc.qubits[1]], qc.clbits)
+
+    bc = to_braket(qc, verbatim=True)
+
+    source = bc.to_ir(ir_type="OPENQASM").source
+    assert "bit[2] b;" in source
+    assert "x $0;" in source
+
+
 def test_to_braket_round_trip_preserves_verbatim_box_with_measurement():
     """QASM → Qiskit → Braket QASM preserves verbatim gates and non-identity clbit mapping."""
     src = """
@@ -567,36 +598,30 @@ def test_to_braket_round_trip_preserves_verbatim_box_with_measurement():
 
 def test_verbatim_boxes_without_transpilation_needed():
     """Cover the elif path: verbatim boxes present but no transpilation triggers."""
-    from qiskit_braket_provider.providers.compilation import _compile
 
     body = QuantumCircuit(NUM_QUBITS)
     body.h(0)
 
     qc = QuantumCircuit(NUM_QUBITS)
     qc.append(BoxOp(body, label=VERBATIM_LABEL), QUBIT_PAIR)
-
-    # Provide basis_gates that include all the circuit's gates so no
-    # transpilation is triggered, but verbatim boxes still need handling.
-    # The circuit only has a "box" gate at top level (the BoxOp).
     result = _compile(qc, basis_gates={"h", "cx", "box"})
     assert result.circuits[0].data[0].operation.name == "h"
 
 
 def test_restore_without_extract_is_noop():
-    """RestoreVerbatimBoxes with empty property_set returns dag unchanged (line 120)."""
+    """RestoreVerbatimBoxes with empty property_set returns dag unchanged."""
     qc = QuantumCircuit(NUM_QUBITS)
     qc.h(0)
 
     pm = PassManager([RestoreVerbatimBoxes(VERBATIM_LABEL)])
     result = pm.run(qc)
+    assert len(result.data) == 1
     assert result.data[0].operation.name == "h"
+    assert [result.find_bit(q).index for q in result.data[0].qubits] == [0]
 
 
 def test_restore_raises_on_mismatched_barrier_label():
-    """RestoreVerbatimBoxes raises when a verbatim barrier has no matching box (line 127-129)."""
-    from qiskit.converters import circuit_to_dag
-
-    from qiskit_braket_provider.providers.passes.verbatim_passes import _indexed_label
+    """RestoreVerbatimBoxes raises when a verbatim barrier has no matching box."""
 
     qc = QuantumCircuit(NUM_QUBITS)
     label = _indexed_label(VERBATIM_LABEL, 0)
@@ -615,12 +640,8 @@ def test_restore_raises_on_mismatched_barrier_label():
 
 
 def test_restore_raises_on_leftover_boxes():
-    """RestoreVerbatimBoxes raises when boxes remain after processing (line 153)."""
-    from qiskit.converters import circuit_to_dag
+    """RestoreVerbatimBoxes raises when boxes remain after processing."""
 
-    from qiskit_braket_provider.providers.passes.verbatim_passes import _indexed_label
-
-    # Circuit with no verbatim barriers
     qc = QuantumCircuit(NUM_QUBITS)
     qc.h(0)
 
@@ -632,7 +653,7 @@ def test_restore_raises_on_leftover_boxes():
     restore_pass.property_set["verbatim_boxes"] = {label: (body, [])}
 
     dag = circuit_to_dag(qc)
-    with pytest.raises(RuntimeError, match="verbatim boxes lost during transpilation"):
+    with pytest.raises(RuntimeError, match="stashed verbatim boxes were not restored"):
         restore_pass.run(dag)
 
 

--- a/test/unit_tests/test_adapter_to_braket_verbatim.py
+++ b/test/unit_tests/test_adapter_to_braket_verbatim.py
@@ -3,8 +3,10 @@
 import pytest
 from qiskit import QuantumCircuit
 from qiskit.circuit import Barrier, BoxOp
+from qiskit.circuit.library import CXGate, HGate, Measure, XGate
 from qiskit.converters import circuit_to_dag, dag_to_circuit
-from qiskit.transpiler import PassManager
+from qiskit.transpiler import PassManager, Target
+from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.passes import Optimize1qGates
 
 from braket.circuits import Circuit
@@ -544,7 +546,7 @@ def test_to_braket_handles_verbatim_box_with_clbits():
     """to_braket on a verbatim BoxOp carrying clbits succeeds."""
     body = QuantumCircuit(1, 1)
     body.h(0)
-    body.measure(0, 0)  # gives the body a clbit, which propagates to the BoxOp
+    body.measure(0, 0)
 
     qc = QuantumCircuit(1, 1)
     qc.append(BoxOp(body, label=VERBATIM_LABEL), qc.qubits, qc.clbits)
@@ -552,8 +554,10 @@ def test_to_braket_handles_verbatim_box_with_clbits():
     bc = to_braket(qc, verbatim=True)
 
     source = bc.to_ir(ir_type="OPENQASM").source
-    assert "bit[1] b;" in source
-    assert "b[0] = measure $0;" in source
+    expected = (
+        "OPENQASM 3.0;\nbit[1] b;\n#pragma braket verbatim\nbox{\nh $0;\n}\nb[0] = measure $0;"
+    )
+    assert source == expected
 
 
 def test_to_braket_verbatim_box_with_clbits_on_subset_of_qubits():
@@ -569,8 +573,11 @@ def test_to_braket_verbatim_box_with_clbits_on_subset_of_qubits():
     bc = to_braket(qc, verbatim=True)
 
     source = bc.to_ir(ir_type="OPENQASM").source
-    assert "bit[2] b;" in source
-    assert "x $0;" in source
+    expected = (
+        "OPENQASM 3.0;\nbit[2] b;\n#pragma braket verbatim\nbox{\nx $0;\n}\n"
+        "b[0] = measure $0;\nb[1] = measure $1;"
+    )
+    assert source == expected
 
 
 def test_verbatim_box_with_clbits_through_transpilation():
@@ -583,12 +590,11 @@ def test_verbatim_box_with_clbits_through_transpilation():
     qc.x(0)
     qc.append(BoxOp(body, label=VERBATIM_LABEL), [qc.qubits[1]], qc.clbits)
 
-    # Provide basis_gates to trigger transpilation path (not verbatim=True)
     bc = to_braket(qc, basis_gates=["x", "h", "cx", "measure"])
 
     source = bc.to_ir(ir_type="OPENQASM").source
-    assert "h q[1];" in source
-    assert "b[0] = measure q[1];" in source
+    expected = "OPENQASM 3.0;\nbit[1] b;\nqubit[2] q;\nx q[0];\nh q[1];\nb[0] = measure q[1];"
+    assert source == expected
 
 
 def test_verbatim_box_with_clbits_on_subset_through_transpilation():
@@ -604,9 +610,10 @@ def test_verbatim_box_with_clbits_on_subset_through_transpilation():
     bc = to_braket(qc, basis_gates=["x", "h", "cx", "measure"])
 
     source = bc.to_ir(ir_type="OPENQASM").source
-    assert "bit[2] b;" in source
-    assert "x q[0];" in source
-    assert "b[0] = measure q[0];" in source
+    expected = (
+        "OPENQASM 3.0;\nbit[2] b;\nqubit[2] q;\nx q[0];\nb[0] = measure q[0];\nb[1] = measure q[1];"
+    )
+    assert source == expected
 
 
 def test_to_braket_round_trip_preserves_verbatim_box_with_measurement():
@@ -625,11 +632,11 @@ def test_to_braket_round_trip_preserves_verbatim_box_with_measurement():
     qc = to_qiskit(src)
     bc = to_braket(qc, verbatim=True)
     out = bc.to_ir(ir_type="OPENQASM").source
-    assert "#pragma braket verbatim" in out
-    assert "h $0;" in out
-    assert "cnot $0, $1;" in out
-    assert "b[0] = measure $1;" in out
-    assert "b[1] = measure $0;" in out
+    expected = (
+        "OPENQASM 3.0;\nbit[2] b;\n#pragma braket verbatim\nbox{\n"
+        "h $0;\ncnot $0, $1;\n}\nb[0] = measure $1;\nb[1] = measure $0;"
+    )
+    assert out == expected
 
 
 def test_verbatim_boxes_without_transpilation_needed():
@@ -694,7 +701,7 @@ def test_restore_raises_on_leftover_boxes():
 
 
 def test_extract_restore_with_non_verbatim_barrier():
-    """A non-verbatim labeled barrier is preserved through extract/restore."""
+    """A non-verbatim barrier is preserved through extract/restore."""
     body = QuantumCircuit(NUM_QUBITS)
     body.h(0)
 
@@ -709,3 +716,54 @@ def test_extract_restore_with_non_verbatim_barrier():
     assert result.data[0].operation.name == "barrier"
     assert result.data[0].operation.label is None
     assert result.data[1].operation.name == "h"
+
+
+def test_verbatim_with_target_runs_contains_instruction():
+    """ContainsInstruction pass runs when verbatim boxes are present with a target."""
+    target = Target(num_qubits=2)
+    target.add_instruction(HGate(), {(i,): None for i in range(2)})
+    target.add_instruction(CXGate(), {(0, 1): None})
+    target.add_instruction(Measure(), {(i,): None for i in range(2)})
+
+    body = QuantumCircuit(2)
+    body.h(0)
+    body.cx(0, 1)
+
+    qc = QuantumCircuit(2)
+    qc.append(BoxOp(body, label=VERBATIM_LABEL), [0, 1])
+
+    pass_names = []
+
+    def cb(**kwargs):
+        p = kwargs.get("pass_")
+        if p:
+            pass_names.append(type(p).__name__)
+
+    _compile(qc, target=target, callback=cb)
+    assert "ContainsInstruction" in pass_names
+
+
+def test_verbatim_with_if_else_on_unsupported_backend_raises_clean_error():
+    """Verbatim box + if_else on a backend without control-flow gives a clear error."""
+    target = Target(num_qubits=3)
+    target.add_instruction(HGate(), {(i,): None for i in range(3)})
+    target.add_instruction(XGate(), {(i,): None for i in range(3)})
+    target.add_instruction(CXGate(), {(0, 1): None, (1, 2): None})
+    target.add_instruction(Measure(), {(i,): None for i in range(3)})
+
+    qc = to_qiskit("""
+    OPENQASM 3.0;
+    bit[1] c;
+    #pragma braket verbatim
+    box {
+        h $0;
+        cnot $0, $1;
+    }
+    c[0] = measure $0;
+    if (c[0] == 1) {
+        x $2;
+    }
+    """)
+
+    with pytest.raises(TranspilerError, match="control-flow"):
+        to_braket(qc, target=target)

--- a/test/unit_tests/test_adapter_to_braket_verbatim.py
+++ b/test/unit_tests/test_adapter_to_braket_verbatim.py
@@ -573,6 +573,42 @@ def test_to_braket_verbatim_box_with_clbits_on_subset_of_qubits():
     assert "x $0;" in source
 
 
+def test_verbatim_box_with_clbits_through_transpilation():
+    """Verbatim BoxOp with clbits goes through the pass pipeline when transpiling."""
+    body = QuantumCircuit(1, 1)
+    body.h(0)
+    body.measure(0, 0)
+
+    qc = QuantumCircuit(2, 1)
+    qc.x(0)
+    qc.append(BoxOp(body, label=VERBATIM_LABEL), [qc.qubits[1]], qc.clbits)
+
+    # Provide basis_gates to trigger transpilation path (not verbatim=True)
+    bc = to_braket(qc, basis_gates=["x", "h", "cx", "measure"])
+
+    source = bc.to_ir(ir_type="OPENQASM").source
+    assert "h q[1];" in source
+    assert "b[0] = measure q[1];" in source
+
+
+def test_verbatim_box_with_clbits_on_subset_through_transpilation():
+    """Verbatim BoxOp with clbits on qubit subset goes through pass pipeline."""
+    body = QuantumCircuit(2, 2)
+    body.x(0)
+    body.measure(0, 0)
+    body.measure(1, 1)
+
+    qc = QuantumCircuit(3, 2)
+    qc.append(BoxOp(body, label=VERBATIM_LABEL), [qc.qubits[0], qc.qubits[1]], qc.clbits)
+
+    bc = to_braket(qc, basis_gates=["x", "h", "cx", "measure"])
+
+    source = bc.to_ir(ir_type="OPENQASM").source
+    assert "bit[2] b;" in source
+    assert "x q[0];" in source
+    assert "b[0] = measure q[0];" in source
+
+
 def test_to_braket_round_trip_preserves_verbatim_box_with_measurement():
     """QASM → Qiskit → Braket QASM preserves verbatim gates and non-identity clbit mapping."""
     src = """

--- a/test/unit_tests/test_adapter_to_braket_verbatim.py
+++ b/test/unit_tests/test_adapter_to_braket_verbatim.py
@@ -563,3 +563,92 @@ def test_to_braket_round_trip_preserves_verbatim_box_with_measurement():
     assert "cnot $0, $1;" in out
     assert "b[0] = measure $1;" in out
     assert "b[1] = measure $0;" in out
+
+
+def test_verbatim_boxes_without_transpilation_needed():
+    """Cover the elif path: verbatim boxes present but no transpilation triggers."""
+    from qiskit_braket_provider.providers.compilation import _compile
+
+    body = QuantumCircuit(NUM_QUBITS)
+    body.h(0)
+
+    qc = QuantumCircuit(NUM_QUBITS)
+    qc.append(BoxOp(body, label=VERBATIM_LABEL), QUBIT_PAIR)
+
+    # Provide basis_gates that include all the circuit's gates so no
+    # transpilation is triggered, but verbatim boxes still need handling.
+    # The circuit only has a "box" gate at top level (the BoxOp).
+    result = _compile(qc, basis_gates={"h", "cx", "box"})
+    assert result.circuits[0].data[0].operation.name == "h"
+
+
+def test_restore_without_extract_is_noop():
+    """RestoreVerbatimBoxes with empty property_set returns dag unchanged (line 120)."""
+    qc = QuantumCircuit(NUM_QUBITS)
+    qc.h(0)
+
+    pm = PassManager([RestoreVerbatimBoxes(VERBATIM_LABEL)])
+    result = pm.run(qc)
+    assert result.data[0].operation.name == "h"
+
+
+def test_restore_raises_on_mismatched_barrier_label():
+    """RestoreVerbatimBoxes raises when a verbatim barrier has no matching box (line 127-129)."""
+    from qiskit.converters import circuit_to_dag
+
+    from qiskit_braket_provider.providers.passes.verbatim_passes import _indexed_label
+
+    qc = QuantumCircuit(NUM_QUBITS)
+    label = _indexed_label(VERBATIM_LABEL, 0)
+    qc.append(Barrier(NUM_QUBITS, label=label), QUBIT_PAIR)
+
+    restore_pass = RestoreVerbatimBoxes(VERBATIM_LABEL)
+    # Set verbatim_boxes with a different label than what's in the circuit
+    different_label = _indexed_label(VERBATIM_LABEL, 99)
+    body = QuantumCircuit(NUM_QUBITS)
+    body.h(0)
+    restore_pass.property_set["verbatim_boxes"] = {different_label: (body, [])}
+
+    dag = circuit_to_dag(qc)
+    with pytest.raises(RuntimeError, match="has no matching box"):
+        restore_pass.run(dag)
+
+
+def test_restore_raises_on_leftover_boxes():
+    """RestoreVerbatimBoxes raises when boxes remain after processing (line 153)."""
+    from qiskit.converters import circuit_to_dag
+
+    from qiskit_braket_provider.providers.passes.verbatim_passes import _indexed_label
+
+    # Circuit with no verbatim barriers
+    qc = QuantumCircuit(NUM_QUBITS)
+    qc.h(0)
+
+    restore_pass = RestoreVerbatimBoxes(VERBATIM_LABEL)
+    # Set verbatim_boxes that will never be consumed
+    label = _indexed_label(VERBATIM_LABEL, 0)
+    body = QuantumCircuit(NUM_QUBITS)
+    body.h(0)
+    restore_pass.property_set["verbatim_boxes"] = {label: (body, [])}
+
+    dag = circuit_to_dag(qc)
+    with pytest.raises(RuntimeError, match="verbatim boxes lost during transpilation"):
+        restore_pass.run(dag)
+
+
+def test_extract_restore_with_non_verbatim_barrier():
+    """A non-verbatim labeled barrier is preserved through extract/restore."""
+    body = QuantumCircuit(NUM_QUBITS)
+    body.h(0)
+
+    qc = QuantumCircuit(NUM_QUBITS)
+    qc.append(Barrier(NUM_QUBITS), QUBIT_PAIR)
+    qc.append(BoxOp(body, label=VERBATIM_LABEL), QUBIT_PAIR)
+
+    pm = PassManager([ExtractVerbatimBoxes(VERBATIM_LABEL), RestoreVerbatimBoxes(VERBATIM_LABEL)])
+    result = pm.run(qc)
+
+    # The unlabeled barrier is preserved, and the verbatim box is unpacked
+    assert result.data[0].operation.name == "barrier"
+    assert result.data[0].operation.label is None
+    assert result.data[1].operation.name == "h"


### PR DESCRIPTION
 ## Description:
  
  Replaces _extract_verbatim_boxes and _restore_verbatim_boxes with proper Qiskit TransformationPass subclasses (ExtractVerbatimBoxes and
  RestoreVerbatimBoxes) in a new passes/ module.
  
## Changes:
  
  - Added qiskit_braket_provider/providers/passes/ with ExtractVerbatimBoxes and RestoreVerbatimBoxes
  - _compile now integrates the passes into the PassManager pipeline (pre_init / post_optimization) instead of manual pre/post-processing
  - Handles BoxOps with classical bits (aligned with #350)
  - Removed standalone _extract_verbatim_boxes / _restore_verbatim_boxes from compilation.py
  - Updated tests to exercise the pass-based API
  -  Fixes a correctness bug where _restore_verbatim_boxes on main discarded outer qubit indices, causing verbatim box contents to be placed on [0, 1, ..., k-1] regardless of where the user appended the BoxOp; the new pass-based approach preserves the original qubit mapping, with regression tests for reversed and non-contiguous qubit orderings.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md) doc
- [ ] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md#pr-title-format)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/README.md) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
