### PR TITLE
fix: correctly write measures across multiple bit registers in to_qiskit

### DIFF
--- a/qiskit_braket_provider/providers/qasm_context.py
+++ b/qiskit_braket_provider/providers/qasm_context.py
@@ -26,7 +26,7 @@ from qiskit.circuit import (
 from sympy import Add, Expr, Mul, Pow, Symbol
 
 from braket.default_simulator.openqasm._helpers.arrays import convert_range_def_to_range
-from braket.default_simulator.openqasm._helpers.casting import cast_to
+from braket.default_simulator.openqasm._helpers.casting import cast_to, get_identifier_name
 from braket.default_simulator.openqasm._helpers.functions import (
     evaluate_binary_expression,
     evaluate_unary_expression,
@@ -227,20 +227,40 @@ class _QiskitProgramContext(AbstractProgramContext):
 
     def add_measure(
         self,
-        target: tuple[int],
+        target: tuple[int, ...],
         classical_targets: Sequence[int] | None = None,
         *,
-        classical_destination: Identifier | IndexedIdentifier | None = None,  # noqa: ARG002
+        classical_destination: Identifier | IndexedIdentifier | None = None,
     ) -> None:
-        active = self._active_circuit
+        if classical_destination is None:
+            self._ensure_qubit_capacity(target)
+            self._add_measure_into_loose_clbits(target)
+            return
+        name = get_identifier_name(classical_destination)
+        if name not in self._clbit_offset:
+            raise ValueError(f"Classical bit register {name!r} is not declared")
         self._ensure_qubit_capacity(target)
-        # this is to cover the edge case where a user measures a qubit without assigning it to a classical register
+        self._add_measure_into_register(target, classical_targets, self._clbit_offset[name])
+
+    def _add_measure_into_loose_clbits(self, target: tuple[int, ...]) -> None:
+        """Measure without a classical destination, synthesizing loose clbits to receive the results."""
+        active = self._active_circuit
         if active.num_clbits < len(target):
-            num_missing_clbits = len(target) - active.num_clbits
-            active.add_bits([Clbit() for _ in range(num_missing_clbits)])
+            active.add_bits([Clbit() for _ in range(len(target) - active.num_clbits)])
         for idx, qubit in enumerate(target):
-            index = classical_targets[idx] if classical_targets else idx
-            active.measure(qubit, index)
+            active.measure(qubit, idx)
+
+    def _add_measure_into_register(
+        self,
+        target: tuple[int, ...],
+        classical_targets: Sequence[int] | None,
+        offset: int,
+    ) -> None:
+        """Measure into a declared bit register at the given flat-clbit offset."""
+        active = self._active_circuit
+        for idx, qubit in enumerate(target):
+            local_index = classical_targets[idx] if classical_targets else idx
+            active.measure(qubit, offset + local_index)
 
     def add_verbatim_marker(self, marker: VerbatimBoxDelimiter) -> None:
         """Handle verbatim box start/end markers.

--- a/test/unit_tests/test_adapter_dynamic_circuits.py
+++ b/test/unit_tests/test_adapter_dynamic_circuits.py
@@ -35,6 +35,15 @@ def _get_if_else_ops(circuit: QuantumCircuit) -> list[CircuitInstruction]:
     return [instr for instr in circuit.data if isinstance(instr.operation, IfElseOp)]
 
 
+def _measure_clbit_indices(circuit: QuantumCircuit) -> list[int]:
+    """Return the flat clbit index each measure in the given circuit writes to, in order."""
+    return [
+        circuit.clbits.index(instr.clbits[0])
+        for instr in circuit.data
+        if instr.operation.name == "measure"
+    ]
+
+
 def _get_ops_with_qubits(
     circuit: QuantumCircuit,
 ) -> list[tuple[str, list[int]]]:
@@ -1327,3 +1336,177 @@ def test_control_flow_body_global_phase_behavior(
 
     assert qc.global_phase == pytest.approx(expected_parent)
     assert body.global_phase == pytest.approx(expected_body)
+
+
+@pytest.mark.parametrize(
+    "qasm",
+    [
+        """
+OPENQASM 3;
+c[0] = measure $1;
+""",
+        """
+OPENQASM 3;
+c[1] = measure $1;
+""",
+        """
+OPENQASM 3;
+bit[1] z;
+h $0;
+z[0] = measure $0;
+if (z[0] == 0) {
+    c[1] = measure $0;
+}
+""",
+        """
+OPENQASM 3;
+#pragma braket verbatim
+box {
+    rx(0.1) $0;
+    c[1] = measure $0;
+}
+""",
+        """
+OPENQASM 3;
+bit[1] z;
+h $0;
+z[0] = measure $0;
+if (z[0] == 0) {
+    if (z[0] == 0) {
+        c[1] = measure $0;
+    }
+}
+""",
+        """
+OPENQASM 3;
+bit[1] z;
+h $0;
+z[0] = measure $0;
+#pragma braket verbatim
+box {
+    rx(0.1) $0;
+}
+if (z[0] == 0) {
+    c[1] = measure $0;
+}
+""",
+    ],
+    ids=["idx-0", "idx-1", "if-body", "verbatim-box", "nested-if", "if-after-verbatim"],
+)
+def test_measure_assignment_to_undeclared_register_raises(qasm: str):
+    with pytest.raises(ValueError, match=r"Classical bit register 'c' is not declared"):
+        to_qiskit(qasm)
+
+
+@pytest.mark.parametrize(
+    ("qasm", "expected_clbit_indices"),
+    [
+        (
+            """
+OPENQASM 3;
+qubit[2] q;
+bit[2] a;
+bit[2] b;
+a[0] = measure q[0];
+b[1] = measure q[1];
+""",
+            [0, 3],
+        ),
+        (
+            """
+OPENQASM 3;
+qubit[3] q;
+bit[1] a;
+bit[2] b;
+bit[1] c;
+b[0] = measure q[0];
+b[1] = measure q[1];
+""",
+            [1, 2],
+        ),
+        (
+            """
+OPENQASM 3;
+qubit[2] q;
+bit[1] a;
+bit[3] b;
+a[0] = measure q[0];
+b[2] = measure q[1];
+""",
+            [0, 3],
+        ),
+        (
+            """
+OPENQASM 3;
+qubit[2] q;
+bit[1] a;
+bit[1] b;
+bit[2] c;
+c[1] = measure q[0];
+""",
+            [3],
+        ),
+    ],
+    ids=["two-registers", "three-registers-middle", "mixed-sizes", "three-registers-last"],
+)
+def test_indexed_measure_routes_to_correct_register(qasm: str, expected_clbit_indices: list[int]):
+    qc = to_qiskit(qasm)
+    assert _measure_clbit_indices(qc) == expected_clbit_indices
+
+
+def test_whole_register_measure_routes_to_correct_register_with_multiple_bit_registers():
+    qasm = """
+OPENQASM 3;
+qubit[2] q;
+bit[2] a;
+bit[2] c;
+c = measure q;
+"""
+    qc = to_qiskit(qasm)
+    assert _measure_clbit_indices(qc) == [2, 3]  # c starts at flat 2
+
+
+def test_indexed_measure_inside_if_body_routes_to_correct_register():
+    qasm = """
+OPENQASM 3;
+qubit[2] q;
+bit[2] a;
+bit[2] b;
+h q[0];
+a[0] = measure q[0];
+if (a[0] == 1) {
+    b[1] = measure q[1];
+}
+"""
+    qc = to_qiskit(qasm)
+    body = _get_if_else_ops(qc)[0].operation.params[0]
+    assert _measure_clbit_indices(body) == [3]  # b[1]
+
+
+def test_indexed_measure_routes_correctly_for_register_declared_inside_if_body():
+    qasm = """
+OPENQASM 3;
+qubit[2] q;
+bit[2] c;
+c[0] = measure q[0];
+if (c[0] == 1) {
+    bit[2] d;
+    d[1] = measure q[1];
+}
+"""
+    qc = to_qiskit(qasm)
+    assert qc.num_clbits == 4  # d's clbits propagate back to the parent
+    body = _get_if_else_ops(qc)[0].operation.params[0]
+    assert _measure_clbit_indices(body) == [3]  # d[1]: d starts at flat 2
+
+
+def test_bare_measure_without_classical_destination_writes_into_loose_clbits():
+    qasm = """
+OPENQASM 3;
+qubit[3] q;
+measure q;
+"""
+    qc = to_qiskit(qasm)
+    assert qc.cregs == []  # no classical register was declared
+    assert qc.num_clbits == 3  # one loose clbit per measured qubit
+    assert _measure_clbit_indices(qc) == [0, 1, 2]


### PR DESCRIPTION
  Description of changes:
    Fixes two bugs in _QiskitProgramContext.add_measure. Both stem from add_measure writing to the raw OpenQASM-local clbit index instead of translating via _clbit_offset (which _resolve_clbit_index already does for if-conditions).
  
  1. Measures into a non-first bit register silently wrote to the wrong register:
  ```
  qubit[2] q; 
bit[2] a; 
bit[2] b;
  b[1] = measure q[1];   # main: flat 1 (a[1]); fixed: flat 3 (b[1])
```
  
  2. Measures into an undeclared register raised inconsistent errors:
  ```
  c[0] = measure $1;     # main: ValueError "No scope found for variable c"
  c[1] = measure $1;     # main: CircuitError "Index 1 out of range for size 1." (misleading)
```
  
  Fixed: both raise `ValueError("Classical bit register 'c' is not declared")`.
  
  Why one PR: same function, same root cause, same patch.
  
  Testing done:
  
  14 new tests in test_adapter_dynamic_circuits.py: undeclared-register raise across 6 scopes; multi-register routing
  across 4 layouts; whole-register, inside-if-body, body-local-declared-register, and bare-measure routing. Full unit-test
  suite: 333 passing.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md#pr-title-format)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/README.md) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
