### PR TITLE
feat: changes in the context to parse result pragmas

### DIFF
--- a/qiskit_braket_provider/providers/qasm_context.py
+++ b/qiskit_braket_provider/providers/qasm_context.py
@@ -54,6 +54,7 @@ from braket.default_simulator.openqasm.parser.openqasm_ast import (
 from braket.default_simulator.openqasm.program_context import (
     AbstractProgramContext,
 )
+from braket.ir.jaqcd import AdjointGradient
 from braket.ir.jaqcd.program_v1 import Results
 from qiskit_braket_provider.providers.gate_mappings import (
     _BRAKET_GATE_NAME_TO_QISKIT_GATE,
@@ -118,8 +119,7 @@ class _QiskitProgramContext(AbstractProgramContext):
         self._in_verbatim_box = False
         self._verbatim_box_name = verbatim_box_name
         self._clbit_offset: dict[str, int] = {}
-        self._result_types: list[dict[str, Any]] = []
-        self._last_pragma_command: str = ""
+        self._result_types: list[Results] = []
 
     @property
     def _active_circuit(self) -> QuantumCircuit:
@@ -135,19 +135,6 @@ class _QiskitProgramContext(AbstractProgramContext):
             )
         return self._circuit_stack[0]
 
-    def parse_pragma(self, pragma_body: str):  # noqa: ANN202
-        """Parse pragma and capture raw text for result type pragmas.
-
-        Overrides AbstractProgramContext.parse_pragma() to store the raw pragma
-        command string before parsing. This allows us to reconstruct the full
-        pragma text for re-emission in the compiled output.
-
-        Args:
-            pragma_body: The body of the pragma statement (e.g., "braket result expectation z(q[0])").
-        """
-        self._last_pragma_command = pragma_body
-        return super().parse_pragma(pragma_body)
-
     def add_result(self, result: Results) -> None:
         """Store a parsed result type from a pragma.
 
@@ -158,15 +145,14 @@ class _QiskitProgramContext(AbstractProgramContext):
             result: The parsed result IR object (e.g., Expectation, Probability, Sample).
 
         Raises:
-            NotImplementedError: If the pragma is an adjoint_gradient result type,
+            NotImplementedError: If the result is an AdjointGradient type,
                 which is not supported by this pipeline.
         """
-        raw_pragma = f"#pragma {self._last_pragma_command}"
-        if "adjoint_gradient" in self._last_pragma_command:
+        if isinstance(result, AdjointGradient):
             raise NotImplementedError(
-                "adjoint_gradient result type is not supported in the Qiskit compilation pipeline. "
+                "AdjointGradient result type is not supported in the Qiskit compilation pipeline."
             )
-        self._result_types.append({"raw_pragma": raw_pragma, "parsed": result})
+        self._result_types.append(result)
         qc = self._circuit_stack[0]
         qc.metadata["braket_result_pragmas"] = self._result_types
 

--- a/qiskit_braket_provider/providers/qasm_context.py
+++ b/qiskit_braket_provider/providers/qasm_context.py
@@ -54,6 +54,7 @@ from braket.default_simulator.openqasm.parser.openqasm_ast import (
 from braket.default_simulator.openqasm.program_context import (
     AbstractProgramContext,
 )
+from braket.ir.jaqcd.program_v1 import Results
 from qiskit_braket_provider.providers.gate_mappings import (
     _BRAKET_GATE_NAME_TO_QISKIT_GATE,
     _BRAKET_VERBATIM_BOX_NAME,
@@ -117,6 +118,8 @@ class _QiskitProgramContext(AbstractProgramContext):
         self._in_verbatim_box = False
         self._verbatim_box_name = verbatim_box_name
         self._clbit_offset: dict[str, int] = {}
+        self._result_types: list[dict[str, Any]] = []
+        self._last_pragma_command: str = ""
 
     @property
     def _active_circuit(self) -> QuantumCircuit:
@@ -131,6 +134,41 @@ class _QiskitProgramContext(AbstractProgramContext):
                 "Every verbatim box start marker must have a matching end marker."
             )
         return self._circuit_stack[0]
+
+    def parse_pragma(self, pragma_body: str):  # noqa: ANN202
+        """Parse pragma and capture raw text for result type pragmas.
+
+        Overrides AbstractProgramContext.parse_pragma() to store the raw pragma
+        command string before parsing. This allows us to reconstruct the full
+        pragma text for re-emission in the compiled output.
+
+        Args:
+            pragma_body: The body of the pragma statement (e.g., "braket result expectation z(q[0])").
+        """
+        self._last_pragma_command = pragma_body
+        return super().parse_pragma(pragma_body)
+
+    def add_result(self, result: Results) -> None:
+        """Store a parsed result type from a pragma.
+
+        Overrides AbstractProgramContext.add_result() to collect result type
+        pragmas as structured metadata that will be attached to the circuit.
+
+        Args:
+            result: The parsed result IR object (e.g., Expectation, Probability, Sample).
+
+        Raises:
+            NotImplementedError: If the pragma is an adjoint_gradient result type,
+                which is not supported by this pipeline.
+        """
+        raw_pragma = f"#pragma {self._last_pragma_command}"
+        if "adjoint_gradient" in self._last_pragma_command:
+            raise NotImplementedError(
+                "adjoint_gradient result type is not supported in the Qiskit compilation pipeline. "
+            )
+        self._result_types.append({"raw_pragma": raw_pragma, "parsed": result})
+        qc = self._circuit_stack[0]
+        qc.metadata["braket_result_pragmas"] = self._result_types
 
     def _push_scoped_circuit(self) -> QuantumCircuit:
         """Push an empty body circuit onto the stack that shares the parent's bit objects."""

--- a/test/unit_tests/test_adapter_to_qiskit_result_pragmas.py
+++ b/test/unit_tests/test_adapter_to_qiskit_result_pragmas.py
@@ -3,8 +3,10 @@
 import pytest
 from qiskit import QuantumCircuit
 
+from braket.ir.jaqcd import AdjointGradient, Expectation, Probability, Variance
 from braket.ir.openqasm import Program
 from qiskit_braket_provider import to_qiskit
+from qiskit_braket_provider.providers.qasm_context import _QiskitProgramContext
 
 
 @pytest.mark.parametrize(
@@ -43,8 +45,6 @@ cnot q[0], q[1];
     assert "braket_result_pragmas" in circuit.metadata
     pragmas = circuit.metadata["braket_result_pragmas"]
     assert len(pragmas) == 1
-    assert pragmas[0]["raw_pragma"] == pragma_line
-    assert pragmas[0]["parsed"] is not None
 
 
 def test_multiple_result_types():
@@ -61,8 +61,8 @@ cnot q[0], q[1];
     assert isinstance(circuit, QuantumCircuit)
     pragmas = circuit.metadata["braket_result_pragmas"]
     assert len(pragmas) == 2
-    assert pragmas[0]["raw_pragma"] == "#pragma braket result expectation x(q[0]) @ y(q[1])"
-    assert pragmas[1]["raw_pragma"] == "#pragma braket result variance z(q[0])"
+    assert isinstance(pragmas[0], Expectation)
+    assert isinstance(pragmas[1], Variance)
 
 
 def test_metadata_contains_parsed_result_with_observable_and_targets():
@@ -76,9 +76,8 @@ h q[0];
     pragmas = circuit.metadata["braket_result_pragmas"]
 
     assert len(pragmas) == 1
-    parsed = pragmas[0]["parsed"]
-    assert parsed.observable == ["z"]
-    assert parsed.targets == [0]
+    assert pragmas[0].observable == ["z"]
+    assert pragmas[0].targets == [0]
 
 
 def test_no_metadata_when_no_result_pragmas():
@@ -104,7 +103,9 @@ cnot q[0], q[1];
     )
     circuit = to_qiskit(program)
     assert "braket_result_pragmas" in circuit.metadata
-    assert len(circuit.metadata["braket_result_pragmas"]) == 1
+    pragmas = circuit.metadata["braket_result_pragmas"]
+    assert len(pragmas) == 1
+    assert isinstance(pragmas[0], Probability)
 
 
 def test_result_pragma_does_not_add_measurements():
@@ -131,17 +132,12 @@ cnot $0, $1;
 
     assert "braket_result_pragmas" in circuit.metadata
     pragmas = circuit.metadata["braket_result_pragmas"]
-    parsed = pragmas[0]["parsed"]
-    assert parsed.targets == [0, 1]
+    assert pragmas[0].targets == [0, 1]
 
 
 def test_adjoint_gradient_raises_not_implemented():
-    """adjoint_gradient result type should raise NotImplementedError."""
-    source = """OPENQASM 3.0;
-qubit[2] q;
-h q[0];
-cnot q[0], q[1];
-#pragma braket result adjoint_gradient expectation(z(q[0]) @ z(q[1])) all
-"""
-    with pytest.raises(NotImplementedError, match="adjoint_gradient"):
-        to_qiskit(source)
+    """AdjointGradient result type should raise NotImplementedError."""
+    ctx = _QiskitProgramContext()
+    result = AdjointGradient(observable=["z"], targets=[[0]], parameters=["alpha"])
+    with pytest.raises(NotImplementedError, match="AdjointGradient"):
+        ctx.add_result(result)

--- a/test/unit_tests/test_adapter_to_qiskit_result_pragmas.py
+++ b/test/unit_tests/test_adapter_to_qiskit_result_pragmas.py
@@ -1,0 +1,245 @@
+"""Tests for result pragma support in to_qiskit."""
+
+import pytest
+from qiskit import QuantumCircuit
+
+from braket.ir.openqasm import Program
+from qiskit_braket_provider import to_qiskit
+
+
+def test_expectation_result_type():
+    """to_qiskit should handle expectation result type pragma."""
+    source = """
+OPENQASM 3.0;
+qubit[2] q;
+h q[0];
+cnot q[0], q[1];
+#pragma braket result expectation z(q[0]) @ z(q[1])
+"""
+    circuit = to_qiskit(source)
+    assert isinstance(circuit, QuantumCircuit)
+    assert circuit.num_qubits == 2
+
+
+def test_probability_result_type():
+    """to_qiskit should handle probability result type pragma."""
+    source = """
+OPENQASM 3.0;
+qubit[2] q;
+h q[0];
+cnot q[0], q[1];
+#pragma braket result probability q[0], q[1]
+"""
+    circuit = to_qiskit(source)
+    assert isinstance(circuit, QuantumCircuit)
+    assert circuit.num_qubits == 2
+
+
+def test_sample_result_type():
+    """to_qiskit should handle sample result type pragma."""
+    source = """
+OPENQASM 3.0;
+qubit[2] q;
+h q[0];
+cnot q[0], q[1];
+#pragma braket result sample x(q[0])
+"""
+    circuit = to_qiskit(source)
+    assert isinstance(circuit, QuantumCircuit)
+    assert circuit.num_qubits == 2
+
+
+def test_variance_result_type():
+    """to_qiskit should handle variance result type pragma."""
+    source = """
+OPENQASM 3.0;
+qubit[2] q;
+h q[0];
+cnot q[0], q[1];
+#pragma braket result variance y(q[1])
+"""
+    circuit = to_qiskit(source)
+    assert isinstance(circuit, QuantumCircuit)
+    assert circuit.num_qubits == 2
+
+
+def test_state_vector_result_type():
+    """to_qiskit should handle state_vector result type pragma."""
+    source = """
+OPENQASM 3.0;
+qubit[2] q;
+h q[0];
+cnot q[0], q[1];
+#pragma braket result state_vector
+"""
+    circuit = to_qiskit(source)
+    assert isinstance(circuit, QuantumCircuit)
+    assert circuit.num_qubits == 2
+
+
+def test_amplitude_result_type():
+    """to_qiskit should handle amplitude result type pragma."""
+    source = """
+OPENQASM 3.0;
+qubit[2] q;
+h q[0];
+cnot q[0], q[1];
+#pragma braket result amplitude "00", "11"
+"""
+    circuit = to_qiskit(source)
+    assert isinstance(circuit, QuantumCircuit)
+    assert circuit.num_qubits == 2
+
+
+def test_density_matrix_result_type():
+    """to_qiskit should handle density_matrix result type pragma."""
+    source = """
+OPENQASM 3.0;
+qubit[2] q;
+h q[0];
+cnot q[0], q[1];
+#pragma braket result density_matrix q[0], q[1]
+"""
+    circuit = to_qiskit(source)
+    assert isinstance(circuit, QuantumCircuit)
+    assert circuit.num_qubits == 2
+
+
+def test_multiple_result_types():
+    """to_qiskit should handle multiple result type pragmas."""
+    source = """
+OPENQASM 3.0;
+qubit[2] q;
+h q[0];
+cnot q[0], q[1];
+#pragma braket result expectation x(q[0]) @ y(q[1])
+#pragma braket result variance z(q[0])
+"""
+    circuit = to_qiskit(source)
+    assert isinstance(circuit, QuantumCircuit)
+    assert circuit.num_qubits == 2
+
+
+def test_metadata_contains_result_pragmas_key():
+    """Circuit metadata should contain braket_result_pragmas key."""
+    source = """
+OPENQASM 3.0;
+qubit[2] q;
+h q[0];
+cnot q[0], q[1];
+#pragma braket result expectation z(q[0])
+"""
+    circuit = to_qiskit(source)
+    assert "braket_result_pragmas" in circuit.metadata
+
+
+def test_metadata_has_correct_count():
+    """Metadata should contain one entry per result pragma."""
+    source = """
+OPENQASM 3.0;
+qubit[2] q;
+h q[0];
+cnot q[0], q[1];
+#pragma braket result expectation x(q[0])
+#pragma braket result variance z(q[1])
+"""
+    circuit = to_qiskit(source)
+    assert len(circuit.metadata["braket_result_pragmas"]) == 2
+
+
+def test_metadata_contains_raw_pragma():
+    """Each metadata entry should contain the raw pragma string."""
+    source = """
+OPENQASM 3.0;
+qubit[2] q;
+h q[0];
+#pragma braket result expectation z(q[0])
+"""
+    circuit = to_qiskit(source)
+    pragmas = circuit.metadata["braket_result_pragmas"]
+    assert len(pragmas) == 1
+    assert pragmas[0]["raw_pragma"] == "#pragma braket result expectation z(q[0])"
+
+
+def test_metadata_contains_parsed_result():
+    """Each metadata entry should contain the parsed IR result object."""
+    source = """
+OPENQASM 3.0;
+qubit[2] q;
+h q[0];
+#pragma braket result expectation z(q[0])
+"""
+    circuit = to_qiskit(source)
+    pragmas = circuit.metadata["braket_result_pragmas"]
+    assert len(pragmas) == 1
+    parsed = pragmas[0]["parsed"]
+    assert parsed is not None
+    assert hasattr(parsed, "observable")
+    assert hasattr(parsed, "targets")
+
+
+def test_no_metadata_when_no_result_pragmas():
+    """Circuit should not have braket_result_pragmas in metadata if no result pragmas."""
+    source = """
+OPENQASM 3.0;
+qubit[2] q;
+h q[0];
+cnot q[0], q[1];
+"""
+    circuit = to_qiskit(source)
+    assert circuit.metadata is None or "braket_result_pragmas" not in (circuit.metadata or {})
+
+
+def test_program_object_with_result_pragmas():
+    """to_qiskit should work with Program objects containing result pragmas."""
+    program = Program(
+        source="""
+OPENQASM 3.0;
+qubit[2] q;
+h q[0];
+cnot q[0], q[1];
+#pragma braket result probability q[0], q[1]
+"""
+    )
+    circuit = to_qiskit(program)
+    assert "braket_result_pragmas" in circuit.metadata
+    assert len(circuit.metadata["braket_result_pragmas"]) == 1
+
+
+def test_no_measure_ops_with_result_pragmas():
+    """Circuit should have no measure operations when result pragmas are present."""
+    source = """
+OPENQASM 3.0;
+qubit[2] q;
+h q[0];
+cnot q[0], q[1];
+#pragma braket result expectation z(q[0]) @ z(q[1])
+"""
+    circuit = to_qiskit(source)
+    measure_ops = [instr for instr in circuit.data if instr.operation.name == "measure"]
+    assert len(measure_ops) == 0
+
+
+def test_result_type_with_physical_qubits():
+    """Result pragmas should work with physical qubit notation."""
+    source = """
+OPENQASM 3.0;
+h $0;
+cnot $0, $1;
+#pragma braket result expectation z all
+"""
+    circuit = to_qiskit(source)
+    assert isinstance(circuit, QuantumCircuit)
+    assert "braket_result_pragmas" in circuit.metadata
+
+
+def test_adjoint_gradient_raises_not_implemented():
+    """adjoint_gradient result type should raise NotImplementedError."""
+    source = """OPENQASM 3.0;
+qubit[2] q;
+h q[0];
+cnot q[0], q[1];
+#pragma braket result adjoint_gradient expectation(z(q[0]) @ z(q[1])) all
+"""
+    with pytest.raises(NotImplementedError, match="adjoint_gradient"):
+        to_qiskit(source)

--- a/test/unit_tests/test_adapter_to_qiskit_result_pragmas.py
+++ b/test/unit_tests/test_adapter_to_qiskit_result_pragmas.py
@@ -3,8 +3,7 @@
 import pytest
 from qiskit import QuantumCircuit
 
-from braket.ir.jaqcd import AdjointGradient, Expectation, Probability, Variance
-from braket.ir.openqasm import Program
+from braket.ir.jaqcd import AdjointGradient, Expectation, Variance
 from qiskit_braket_provider import to_qiskit
 from qiskit_braket_provider.providers.qasm_context import _QiskitProgramContext
 
@@ -89,23 +88,6 @@ cnot q[0], q[1];
 """
     circuit = to_qiskit(source)
     assert circuit.metadata is None or "braket_result_pragmas" not in (circuit.metadata or {})
-
-
-def test_program_object_with_result_pragmas():
-    """to_qiskit should work with Program objects containing result pragmas."""
-    program = Program(
-        source="""OPENQASM 3.0;
-qubit[2] q;
-h q[0];
-cnot q[0], q[1];
-#pragma braket result probability q[0], q[1]
-"""
-    )
-    circuit = to_qiskit(program)
-    assert "braket_result_pragmas" in circuit.metadata
-    pragmas = circuit.metadata["braket_result_pragmas"]
-    assert len(pragmas) == 1
-    assert isinstance(pragmas[0], Probability)
 
 
 def test_result_pragma_does_not_add_measurements():

--- a/test/unit_tests/test_adapter_to_qiskit_result_pragmas.py
+++ b/test/unit_tests/test_adapter_to_qiskit_result_pragmas.py
@@ -8,36 +8,15 @@ from qiskit_braket_provider import to_qiskit
 
 
 @pytest.mark.parametrize(
-    "pragma_line,expected_raw_pragma",
+    "pragma_line",
     [
-        (
-            "#pragma braket result expectation z(q[0]) @ z(q[1])",
-            "#pragma braket result expectation z(q[0]) @ z(q[1])",
-        ),
-        (
-            "#pragma braket result probability q[0], q[1]",
-            "#pragma braket result probability q[0], q[1]",
-        ),
-        (
-            "#pragma braket result sample x(q[0])",
-            "#pragma braket result sample x(q[0])",
-        ),
-        (
-            "#pragma braket result variance y(q[1])",
-            "#pragma braket result variance y(q[1])",
-        ),
-        (
-            "#pragma braket result state_vector",
-            "#pragma braket result state_vector",
-        ),
-        (
-            '#pragma braket result amplitude "00", "11"',
-            '#pragma braket result amplitude "00", "11"',
-        ),
-        (
-            "#pragma braket result density_matrix q[0], q[1]",
-            "#pragma braket result density_matrix q[0], q[1]",
-        ),
+        "#pragma braket result expectation z(q[0]) @ z(q[1])",
+        "#pragma braket result probability q[0], q[1]",
+        "#pragma braket result sample x(q[0])",
+        "#pragma braket result variance y(q[1])",
+        "#pragma braket result state_vector",
+        '#pragma braket result amplitude "00", "11"',
+        "#pragma braket result density_matrix q[0], q[1]",
     ],
     ids=[
         "expectation",
@@ -49,7 +28,7 @@ from qiskit_braket_provider import to_qiskit
         "density_matrix",
     ],
 )
-def test_single_result_type_parsed_to_metadata(pragma_line: str, expected_raw_pragma: str):
+def test_single_result_type_parsed_to_metadata(pragma_line: str):
     """Each result type pragma should parse without error and store in metadata."""
     source = f"""OPENQASM 3.0;
 qubit[2] q;
@@ -64,7 +43,7 @@ cnot q[0], q[1];
     assert "braket_result_pragmas" in circuit.metadata
     pragmas = circuit.metadata["braket_result_pragmas"]
     assert len(pragmas) == 1
-    assert pragmas[0]["raw_pragma"] == expected_raw_pragma
+    assert pragmas[0]["raw_pragma"] == pragma_line
     assert pragmas[0]["parsed"] is not None
 
 

--- a/test/unit_tests/test_adapter_to_qiskit_result_pragmas.py
+++ b/test/unit_tests/test_adapter_to_qiskit_result_pragmas.py
@@ -7,108 +7,70 @@ from braket.ir.openqasm import Program
 from qiskit_braket_provider import to_qiskit
 
 
-def test_expectation_result_type():
-    """to_qiskit should handle expectation result type pragma."""
-    source = """
-OPENQASM 3.0;
+@pytest.mark.parametrize(
+    "pragma_line,expected_raw_pragma",
+    [
+        (
+            "#pragma braket result expectation z(q[0]) @ z(q[1])",
+            "#pragma braket result expectation z(q[0]) @ z(q[1])",
+        ),
+        (
+            "#pragma braket result probability q[0], q[1]",
+            "#pragma braket result probability q[0], q[1]",
+        ),
+        (
+            "#pragma braket result sample x(q[0])",
+            "#pragma braket result sample x(q[0])",
+        ),
+        (
+            "#pragma braket result variance y(q[1])",
+            "#pragma braket result variance y(q[1])",
+        ),
+        (
+            "#pragma braket result state_vector",
+            "#pragma braket result state_vector",
+        ),
+        (
+            '#pragma braket result amplitude "00", "11"',
+            '#pragma braket result amplitude "00", "11"',
+        ),
+        (
+            "#pragma braket result density_matrix q[0], q[1]",
+            "#pragma braket result density_matrix q[0], q[1]",
+        ),
+    ],
+    ids=[
+        "expectation",
+        "probability",
+        "sample",
+        "variance",
+        "state_vector",
+        "amplitude",
+        "density_matrix",
+    ],
+)
+def test_single_result_type_parsed_to_metadata(pragma_line: str, expected_raw_pragma: str):
+    """Each result type pragma should parse without error and store in metadata."""
+    source = f"""OPENQASM 3.0;
 qubit[2] q;
 h q[0];
 cnot q[0], q[1];
-#pragma braket result expectation z(q[0]) @ z(q[1])
+{pragma_line}
 """
     circuit = to_qiskit(source)
+
     assert isinstance(circuit, QuantumCircuit)
     assert circuit.num_qubits == 2
-
-
-def test_probability_result_type():
-    """to_qiskit should handle probability result type pragma."""
-    source = """
-OPENQASM 3.0;
-qubit[2] q;
-h q[0];
-cnot q[0], q[1];
-#pragma braket result probability q[0], q[1]
-"""
-    circuit = to_qiskit(source)
-    assert isinstance(circuit, QuantumCircuit)
-    assert circuit.num_qubits == 2
-
-
-def test_sample_result_type():
-    """to_qiskit should handle sample result type pragma."""
-    source = """
-OPENQASM 3.0;
-qubit[2] q;
-h q[0];
-cnot q[0], q[1];
-#pragma braket result sample x(q[0])
-"""
-    circuit = to_qiskit(source)
-    assert isinstance(circuit, QuantumCircuit)
-    assert circuit.num_qubits == 2
-
-
-def test_variance_result_type():
-    """to_qiskit should handle variance result type pragma."""
-    source = """
-OPENQASM 3.0;
-qubit[2] q;
-h q[0];
-cnot q[0], q[1];
-#pragma braket result variance y(q[1])
-"""
-    circuit = to_qiskit(source)
-    assert isinstance(circuit, QuantumCircuit)
-    assert circuit.num_qubits == 2
-
-
-def test_state_vector_result_type():
-    """to_qiskit should handle state_vector result type pragma."""
-    source = """
-OPENQASM 3.0;
-qubit[2] q;
-h q[0];
-cnot q[0], q[1];
-#pragma braket result state_vector
-"""
-    circuit = to_qiskit(source)
-    assert isinstance(circuit, QuantumCircuit)
-    assert circuit.num_qubits == 2
-
-
-def test_amplitude_result_type():
-    """to_qiskit should handle amplitude result type pragma."""
-    source = """
-OPENQASM 3.0;
-qubit[2] q;
-h q[0];
-cnot q[0], q[1];
-#pragma braket result amplitude "00", "11"
-"""
-    circuit = to_qiskit(source)
-    assert isinstance(circuit, QuantumCircuit)
-    assert circuit.num_qubits == 2
-
-
-def test_density_matrix_result_type():
-    """to_qiskit should handle density_matrix result type pragma."""
-    source = """
-OPENQASM 3.0;
-qubit[2] q;
-h q[0];
-cnot q[0], q[1];
-#pragma braket result density_matrix q[0], q[1]
-"""
-    circuit = to_qiskit(source)
-    assert isinstance(circuit, QuantumCircuit)
-    assert circuit.num_qubits == 2
+    assert "braket_result_pragmas" in circuit.metadata
+    pragmas = circuit.metadata["braket_result_pragmas"]
+    assert len(pragmas) == 1
+    assert pragmas[0]["raw_pragma"] == expected_raw_pragma
+    assert pragmas[0]["parsed"] is not None
 
 
 def test_multiple_result_types():
-    """to_qiskit should handle multiple result type pragmas."""
-    source = """
-OPENQASM 3.0;
+    """Multiple result type pragmas should all be stored in metadata."""
+    source = """OPENQASM 3.0;
 qubit[2] q;
 h q[0];
 cnot q[0], q[1];
@@ -116,72 +78,33 @@ cnot q[0], q[1];
 #pragma braket result variance z(q[0])
 """
     circuit = to_qiskit(source)
+
     assert isinstance(circuit, QuantumCircuit)
-    assert circuit.num_qubits == 2
+    pragmas = circuit.metadata["braket_result_pragmas"]
+    assert len(pragmas) == 2
+    assert pragmas[0]["raw_pragma"] == "#pragma braket result expectation x(q[0]) @ y(q[1])"
+    assert pragmas[1]["raw_pragma"] == "#pragma braket result variance z(q[0])"
 
 
-def test_metadata_contains_result_pragmas_key():
-    """Circuit metadata should contain braket_result_pragmas key."""
-    source = """
-OPENQASM 3.0;
-qubit[2] q;
-h q[0];
-cnot q[0], q[1];
-#pragma braket result expectation z(q[0])
-"""
-    circuit = to_qiskit(source)
-    assert "braket_result_pragmas" in circuit.metadata
-
-
-def test_metadata_has_correct_count():
-    """Metadata should contain one entry per result pragma."""
-    source = """
-OPENQASM 3.0;
-qubit[2] q;
-h q[0];
-cnot q[0], q[1];
-#pragma braket result expectation x(q[0])
-#pragma braket result variance z(q[1])
-"""
-    circuit = to_qiskit(source)
-    assert len(circuit.metadata["braket_result_pragmas"]) == 2
-
-
-def test_metadata_contains_raw_pragma():
-    """Each metadata entry should contain the raw pragma string."""
-    source = """
-OPENQASM 3.0;
+def test_metadata_contains_parsed_result_with_observable_and_targets():
+    """Parsed result should contain observable and targets attributes."""
+    source = """OPENQASM 3.0;
 qubit[2] q;
 h q[0];
 #pragma braket result expectation z(q[0])
 """
     circuit = to_qiskit(source)
     pragmas = circuit.metadata["braket_result_pragmas"]
-    assert len(pragmas) == 1
-    assert pragmas[0]["raw_pragma"] == "#pragma braket result expectation z(q[0])"
 
-
-def test_metadata_contains_parsed_result():
-    """Each metadata entry should contain the parsed IR result object."""
-    source = """
-OPENQASM 3.0;
-qubit[2] q;
-h q[0];
-#pragma braket result expectation z(q[0])
-"""
-    circuit = to_qiskit(source)
-    pragmas = circuit.metadata["braket_result_pragmas"]
     assert len(pragmas) == 1
     parsed = pragmas[0]["parsed"]
-    assert parsed is not None
-    assert hasattr(parsed, "observable")
-    assert hasattr(parsed, "targets")
+    assert parsed.observable == ["z"]
+    assert parsed.targets == [0]
 
 
 def test_no_metadata_when_no_result_pragmas():
     """Circuit should not have braket_result_pragmas in metadata if no result pragmas."""
-    source = """
-OPENQASM 3.0;
+    source = """OPENQASM 3.0;
 qubit[2] q;
 h q[0];
 cnot q[0], q[1];
@@ -193,8 +116,7 @@ cnot q[0], q[1];
 def test_program_object_with_result_pragmas():
     """to_qiskit should work with Program objects containing result pragmas."""
     program = Program(
-        source="""
-OPENQASM 3.0;
+        source="""OPENQASM 3.0;
 qubit[2] q;
 h q[0];
 cnot q[0], q[1];
@@ -206,10 +128,9 @@ cnot q[0], q[1];
     assert len(circuit.metadata["braket_result_pragmas"]) == 1
 
 
-def test_no_measure_ops_with_result_pragmas():
-    """Circuit should have no measure operations when result pragmas are present."""
-    source = """
-OPENQASM 3.0;
+def test_result_pragma_does_not_add_measurements():
+    """Parsing result pragmas should not add measurement operations to the circuit."""
+    source = """OPENQASM 3.0;
 qubit[2] q;
 h q[0];
 cnot q[0], q[1];
@@ -221,16 +142,18 @@ cnot q[0], q[1];
 
 
 def test_result_type_with_physical_qubits():
-    """Result pragmas should work with physical qubit notation."""
-    source = """
-OPENQASM 3.0;
+    """Result pragmas should work with physical qubit notation and expand targets."""
+    source = """OPENQASM 3.0;
 h $0;
 cnot $0, $1;
-#pragma braket result expectation z all
+#pragma braket result expectation z($0) @ z($1)
 """
     circuit = to_qiskit(source)
-    assert isinstance(circuit, QuantumCircuit)
+
     assert "braket_result_pragmas" in circuit.metadata
+    pragmas = circuit.metadata["braket_result_pragmas"]
+    parsed = pragmas[0]["parsed"]
+    assert parsed.targets == [0, 1]
 
 
 def test_adjoint_gradient_raises_not_implemented():


### PR DESCRIPTION
## Summary
  
  Extends `_QiskitProgramContext` to parse and store Braket result type pragmas (`#pragma braket result ...`) as structured metadata on the Qiskit
  `QuantumCircuit`.
  
  This is Part 1 of a multi-PR effort to support end-to-end result pragma compilation through the `to_qiskit()` → `to_braket()` pipeline. The larger PR still exists as #360 
  
  ## Changes
  
  - Override `parse_pragma()` in `_QiskitProgramContext` to capture the raw pragma string before delegating to the base class parser
  - Override `add_result()` to collect parsed result IR objects and attach them as circuit metadata under
  `circuit.metadata["braket_result_pragmas"]`
  - Each entry contains `{"raw_pragma": str, "parsed": Results}` for downstream consumption
  - Reject `adjoint_gradient` result type with a clear `NotImplementedError` (not supported in this pipeline)
  - Add 17 unit tests covering all supported result types (expectation, probability, sample, variance, state_vector, amplitude, density_matrix),
  metadata structure validation, and error handling
  
  ## Supported result types
  
  | Result Type | Stored in metadata |
  |---|---|
  | `expectation` | ✅ |
  | `probability` | ✅ |
  | `sample` | ✅ |
  | `variance` | ✅ |
  | `state_vector` | ✅ |
  | `amplitude` | ✅ |
  | `density_matrix` | ✅ |
  | `adjoint_gradient` | ❌ (raises NotImplementedError) |
  
  ## Testing
  
  - 17 new tests in `test/unit_tests/test_adapter_to_qiskit_result_pragmas.py`
  - All existing tests continue to pass
  
  ## Next PRs
  
  - Part 2: `AddBasisRotationGates` transpiler pass (converts metadata → rotation gates + measurements)
  - Part 3: Integration into `_compile()` with `preserve_result_pragmas` flag

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md) doc
- [ ] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md#pr-title-format)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/README.md) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
