### PR TITLE
fix: preserve OpenQASM 3 barriers in to_qiskit

### DIFF
--- a/qiskit_braket_provider/providers/qasm_context.py
+++ b/qiskit_braket_provider/providers/qasm_context.py
@@ -136,6 +136,7 @@ class _QiskitProgramContext(AbstractProgramContext):
             )
         top = self._circuit_stack[0]
         self._finalize_verbatim_boxes(top)
+        self._finalize_if_else_bodies(top)
         self._resolve_bare_barriers(top)
         return top
 
@@ -333,6 +334,19 @@ class _QiskitProgramContext(AbstractProgramContext):
                     BoxOp(op.body, label=op.label), tuple(outer.qubits), instr.clbits
                 )
 
+    def _finalize_if_else_bodies(self, outer: QuantumCircuit) -> None:
+        """Grow every top-level IfElseOp body (and its qargs) to cover all of outer's qubits,
+        then resolve any bare-barrier placeholders inside the widened bodies. Nested
+        IfElseOps inside another IfElseOp body are not handled."""
+        for i, instr in enumerate(outer.data):
+            op = instr.operation
+            if isinstance(op, IfElseOp):
+                for body in op.blocks:
+                    body.add_bits([q for q in outer.qubits if q not in body.qubits])
+                    self._resolve_bare_barriers(body)
+                new_op = op.replace_blocks(op.blocks)
+                outer.data[i] = CircuitInstruction(new_op, tuple(outer.qubits), instr.clbits)
+
     def add_verbatim_marker(self, marker: VerbatimBoxDelimiter) -> None:
         """Handle verbatim box start/end markers.
 
@@ -438,9 +452,6 @@ class _QiskitProgramContext(AbstractProgramContext):
         self._extend_bits(main, false_body)
         self._extend_bits(true_body, main)
         self._extend_bits(false_body, main)
-
-        self._resolve_bare_barriers(true_body)
-        self._resolve_bare_barriers(false_body)
 
         if_else_op = IfElseOp(resolved_condition, true_body, actual_false)
         main.append(if_else_op, main.qubits, main.clbits)

--- a/qiskit_braket_provider/providers/qasm_context.py
+++ b/qiskit_braket_provider/providers/qasm_context.py
@@ -318,9 +318,7 @@ class _QiskitProgramContext(AbstractProgramContext):
             op = instr.operation
             # Zero-width Barrier is the global-barrier placeholder from add_barrier.
             if isinstance(op, Barrier) and op.num_qubits == 0:
-                circ.data[i] = CircuitInstruction(
-                    Barrier(circ.num_qubits), tuple(circ.qubits), ()
-                )
+                circ.data[i] = CircuitInstruction(Barrier(circ.num_qubits), tuple(circ.qubits), ())
             for block in getattr(op, "blocks", ()) or ():
                 if isinstance(block, QuantumCircuit):
                     self._resolve_global_barriers(block)

--- a/qiskit_braket_provider/providers/qasm_context.py
+++ b/qiskit_braket_provider/providers/qasm_context.py
@@ -135,10 +135,7 @@ class _QiskitProgramContext(AbstractProgramContext):
                 "Every verbatim box start marker must have a matching end marker."
             )
         top = self._circuit_stack[0]
-        self._finalize_verbatim_boxes(top)
-        self._finalize_if_else_bodies(top)
-        self._resolve_bare_barriers(top)
-        return top
+        return self._finalize_scoped_bodies(top)
 
     def add_result(self, result: Results) -> None:
         """Store a parsed result type from a pragma.
@@ -301,42 +298,38 @@ class _QiskitProgramContext(AbstractProgramContext):
             return
         if active.num_qubits == 0:
             raise ValueError("Cannot add bare barrier to empty circuit")
-        # Bare-barrier placeholder; resolved to top-level qubits by _resolve_bare_barriers.
+        # Bare-barrier placeholder; resolved to top-level qubits by _finalize_scoped_bodies.
         active.append(Barrier(0), (), ())
 
-    def _resolve_bare_barriers(self, circ: QuantumCircuit) -> None:
-        """Rewrite bare-barrier placeholders in circ to cover circ's qubits.
-        Nested control-flow bodies resolve their own placeholders at their
-        own scope-close, so this pass is single-scope."""
-        for i, instr in enumerate(circ.data):
+    def _finalize_scoped_bodies(
+        self,
+        circ: QuantumCircuit,
+        top_qubits: tuple[Qubit, ...] | None = None,
+    ) -> QuantumCircuit:
+        """Rebuild circ: resolve bare-barrier placeholders and widen every scoped
+        body (verbatim BoxOp, IfElseOp, ForLoopOp, WhileLoopOp) to top_qubits,
+        recursing into nested scoped ops."""
+        if top_qubits is None:
+            top_qubits = tuple(circ.qubits)
+        new = circ.copy_empty_like()
+        for q in top_qubits:
+            if q not in new.qubits:
+                new.add_bits([q])
+        for instr in circ.data:
             op = instr.operation
             if isinstance(op, Barrier) and op.num_qubits == 0:
-                circ.data[i] = CircuitInstruction(Barrier(circ.num_qubits), tuple(circ.qubits), ())
-
-    def _finalize_verbatim_boxes(self, outer: QuantumCircuit) -> None:
-        """Grow every verbatim BoxOp body (and its qargs) to cover all of outer's qubits,
-        then resolve any bare-barrier placeholders inside the widened body."""
-        for i, instr in enumerate(outer.data):
-            op = instr.operation
+                new.append(Barrier(len(top_qubits)), top_qubits, ())
+                continue
             if isinstance(op, BoxOp) and op.label == self._verbatim_box_name:
-                op.body.add_bits([q for q in outer.qubits if q not in op.body.qubits])
-                self._resolve_bare_barriers(op.body)
-                outer.data[i] = CircuitInstruction(
-                    BoxOp(op.body, label=op.label), tuple(outer.qubits), instr.clbits
-                )
-
-    def _finalize_if_else_bodies(self, outer: QuantumCircuit) -> None:
-        """Grow every top-level IfElseOp body (and its qargs) to cover all of outer's qubits,
-        then resolve any bare-barrier placeholders inside the widened bodies. Nested
-        IfElseOps inside another IfElseOp body are not handled."""
-        for i, instr in enumerate(outer.data):
-            op = instr.operation
-            if isinstance(op, IfElseOp):
-                for body in op.blocks:
-                    body.add_bits([q for q in outer.qubits if q not in body.qubits])
-                    self._resolve_bare_barriers(body)
-                new_op = op.replace_blocks(op.blocks)
-                outer.data[i] = CircuitInstruction(new_op, tuple(outer.qubits), instr.clbits)
+                bodies = [op.body]
+            elif isinstance(op, (IfElseOp, ForLoopOp, WhileLoopOp)):
+                bodies = list(op.blocks)
+            else:
+                new.append(op, instr.qubits, instr.clbits)
+                continue
+            new_bodies = [self._finalize_scoped_bodies(b, top_qubits) for b in bodies]
+            new.append(op.replace_blocks(new_bodies), tuple(top_qubits), instr.clbits)
+        return new
 
     def add_verbatim_marker(self, marker: VerbatimBoxDelimiter) -> None:
         """Handle verbatim box start/end markers.

--- a/qiskit_braket_provider/providers/qasm_context.py
+++ b/qiskit_braket_provider/providers/qasm_context.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from qiskit import QuantumCircuit
 from qiskit.circuit import (
+    Barrier,
     BoxOp,
     CircuitInstruction,
     Clbit,
@@ -130,7 +131,9 @@ class _QiskitProgramContext(AbstractProgramContext):
                 "Unclosed verbatim box at end of program. "
                 "Every verbatim box start marker must have a matching end marker."
             )
-        return self._circuit_stack[0]
+        top = self._circuit_stack[0]
+        self._resolve_global_barriers(top)
+        return top
 
     def _push_scoped_circuit(self) -> QuantumCircuit:
         """Push an empty body circuit onto the stack that shares the parent's bit objects."""
@@ -261,6 +264,42 @@ class _QiskitProgramContext(AbstractProgramContext):
         for idx, qubit in enumerate(target):
             local_index = classical_targets[idx] if classical_targets else idx
             active.measure(qubit, offset + local_index)
+
+    def add_barrier(self, target: list[int] | None = None) -> None:
+        """Add a barrier instruction to the active circuit.
+
+        Args:
+            target: Qubit indices for the barrier. If None or empty, the
+                barrier applies to all qubits in the enclosing scope
+                (including qubits added later within the same scope).
+
+        Raises:
+            ValueError: If target is None or empty and the enclosing scope
+                has no qubits at the time the barrier is added.
+        """
+        active = self._active_circuit
+        if target:
+            self._ensure_qubit_capacity(target)
+            active.barrier(target)
+            return
+        if active.num_qubits == 0:
+            raise ValueError("Cannot add global barrier to empty circuit")
+        # Global-barrier placeholder; _resolve_global_barriers rewrites it at scope-close.
+        active.append(Barrier(0), (), ())
+
+    def _resolve_global_barriers(self, circ: QuantumCircuit) -> None:
+        """Rewrite empty-target global-barrier placeholders to cover every qubit
+        of their enclosing scope, recursing into any nested control-flow bodies."""
+        for i, instr in enumerate(circ.data):
+            op = instr.operation
+            # Zero-width Barrier is the global-barrier placeholder from add_barrier.
+            if isinstance(op, Barrier) and op.num_qubits == 0:
+                circ.data[i] = CircuitInstruction(
+                    Barrier(circ.num_qubits), tuple(circ.qubits), ()
+                )
+            for block in getattr(op, "blocks", ()) or ():
+                if isinstance(block, QuantumCircuit):
+                    self._resolve_global_barriers(block)
 
     def add_verbatim_marker(self, marker: VerbatimBoxDelimiter) -> None:
         """Handle verbatim box start/end markers.

--- a/qiskit_braket_provider/providers/qasm_context.py
+++ b/qiskit_braket_provider/providers/qasm_context.py
@@ -292,17 +292,8 @@ class _QiskitProgramContext(AbstractProgramContext):
             active.measure(qubit, offset + local_index)
 
     def add_barrier(self, target: list[int] | None = None) -> None:
-        """Add a barrier instruction to the active circuit.
-
-        Args:
-            target: Qubit indices for the barrier. If None or empty, the
-                barrier applies to all qubits in the enclosing scope
-                (including qubits added later within the same scope).
-
-        Raises:
-            ValueError: If target is None or empty and the enclosing scope
-                has no qubits at the time the barrier is added.
-        """
+        """Emit a barrier. Bare (empty target) barriers late-bind to cover
+        the top-level circuit's qubits."""
         active = self._active_circuit
         if target:
             self._ensure_qubit_capacity(target)
@@ -310,7 +301,7 @@ class _QiskitProgramContext(AbstractProgramContext):
             return
         if active.num_qubits == 0:
             raise ValueError("Cannot add bare barrier to empty circuit")
-        # Bare-barrier placeholder; _resolve_bare_barriers rewrites it at scope-close.
+        # Bare-barrier placeholder; resolved to top-level qubits by _resolve_bare_barriers.
         active.append(Barrier(0), (), ())
 
     def _resolve_bare_barriers(self, circ: QuantumCircuit) -> None:

--- a/qiskit_braket_provider/providers/qasm_context.py
+++ b/qiskit_braket_provider/providers/qasm_context.py
@@ -135,6 +135,7 @@ class _QiskitProgramContext(AbstractProgramContext):
                 "Every verbatim box start marker must have a matching end marker."
             )
         top = self._circuit_stack[0]
+        self._expand_verbatim_bodies(top)
         self._resolve_global_barriers(top)
         return top
 
@@ -322,6 +323,16 @@ class _QiskitProgramContext(AbstractProgramContext):
             for block in getattr(op, "blocks", ()) or ():
                 if isinstance(block, QuantumCircuit):
                     self._resolve_global_barriers(block)
+
+    def _expand_verbatim_bodies(self, outer: QuantumCircuit) -> None:
+        """Grow every verbatim BoxOp body (and its qargs) to cover all of outer's qubits."""
+        for i, instr in enumerate(outer.data):
+            op = instr.operation
+            if isinstance(op, BoxOp) and op.label == self._verbatim_box_name:
+                op.body.add_bits([q for q in outer.qubits if q not in op.body.qubits])
+                outer.data[i] = CircuitInstruction(
+                    BoxOp(op.body, label=op.label), tuple(outer.qubits), instr.clbits
+                )
 
     def add_verbatim_marker(self, marker: VerbatimBoxDelimiter) -> None:
         """Handle verbatim box start/end markers.

--- a/qiskit_braket_provider/providers/qasm_context.py
+++ b/qiskit_braket_provider/providers/qasm_context.py
@@ -135,8 +135,8 @@ class _QiskitProgramContext(AbstractProgramContext):
                 "Every verbatim box start marker must have a matching end marker."
             )
         top = self._circuit_stack[0]
-        self._expand_verbatim_bodies(top)
-        self._resolve_global_barriers(top)
+        self._finalize_verbatim_boxes(top)
+        self._resolve_bare_barriers(top)
         return top
 
     def add_result(self, result: Results) -> None:
@@ -308,28 +308,27 @@ class _QiskitProgramContext(AbstractProgramContext):
             active.barrier(target)
             return
         if active.num_qubits == 0:
-            raise ValueError("Cannot add global barrier to empty circuit")
-        # Global-barrier placeholder; _resolve_global_barriers rewrites it at scope-close.
+            raise ValueError("Cannot add bare barrier to empty circuit")
+        # Bare-barrier placeholder; _resolve_bare_barriers rewrites it at scope-close.
         active.append(Barrier(0), (), ())
 
-    def _resolve_global_barriers(self, circ: QuantumCircuit) -> None:
-        """Rewrite empty-target global-barrier placeholders to cover every qubit
-        of their enclosing scope, recursing into any nested control-flow bodies."""
+    def _resolve_bare_barriers(self, circ: QuantumCircuit) -> None:
+        """Rewrite bare-barrier placeholders in circ to cover circ's qubits.
+        Nested control-flow bodies resolve their own placeholders at their
+        own scope-close, so this pass is single-scope."""
         for i, instr in enumerate(circ.data):
             op = instr.operation
-            # Zero-width Barrier is the global-barrier placeholder from add_barrier.
             if isinstance(op, Barrier) and op.num_qubits == 0:
                 circ.data[i] = CircuitInstruction(Barrier(circ.num_qubits), tuple(circ.qubits), ())
-            for block in getattr(op, "blocks", ()) or ():
-                if isinstance(block, QuantumCircuit):
-                    self._resolve_global_barriers(block)
 
-    def _expand_verbatim_bodies(self, outer: QuantumCircuit) -> None:
-        """Grow every verbatim BoxOp body (and its qargs) to cover all of outer's qubits."""
+    def _finalize_verbatim_boxes(self, outer: QuantumCircuit) -> None:
+        """Grow every verbatim BoxOp body (and its qargs) to cover all of outer's qubits,
+        then resolve any bare-barrier placeholders inside the widened body."""
         for i, instr in enumerate(outer.data):
             op = instr.operation
             if isinstance(op, BoxOp) and op.label == self._verbatim_box_name:
                 op.body.add_bits([q for q in outer.qubits if q not in op.body.qubits])
+                self._resolve_bare_barriers(op.body)
                 outer.data[i] = CircuitInstruction(
                     BoxOp(op.body, label=op.label), tuple(outer.qubits), instr.clbits
                 )
@@ -439,6 +438,9 @@ class _QiskitProgramContext(AbstractProgramContext):
         self._extend_bits(main, false_body)
         self._extend_bits(true_body, main)
         self._extend_bits(false_body, main)
+
+        self._resolve_bare_barriers(true_body)
+        self._resolve_bare_barriers(false_body)
 
         if_else_op = IfElseOp(resolved_condition, true_body, actual_false)
         main.append(if_else_op, main.qubits, main.clbits)

--- a/test/unit_tests/test_adapter.py
+++ b/test/unit_tests/test_adapter.py
@@ -1737,7 +1737,7 @@ class TestFromBraket(TestCase):
         self.assertEqual(ops, [("h", [0]), ("barrier", [0, 1, 2]), ("h", [2])])
 
     def test_openqasm_bare_barrier_before_any_qubit_raises(self):
-        """SDK parity: bare barrier before any qubit exists in the enclosing scope raises."""
+        """Bare barrier before any qubit exists in the enclosing scope raises."""
         qasm = (
             "OPENQASM 3.0;\n"
             "barrier;\n"
@@ -1745,29 +1745,6 @@ class TestFromBraket(TestCase):
         )
         with self.assertRaisesRegex(ValueError, "Cannot add global barrier to empty circuit"):
             to_qiskit(qasm, add_measurements=False)
-
-    def test_openqasm_bare_barrier_in_empty_verbatim_box_raises(self):
-        """SDK parity: bare barrier inside a box with no inherited or local qubits raises."""
-        qasm = (
-            "OPENQASM 3.0;\n"
-            "#pragma braket verbatim\n"
-            "box {\n"
-            "    barrier;\n"
-            "}\n"
-        )
-        with self.assertRaisesRegex(ValueError, "Cannot add global barrier to empty circuit"):
-            to_qiskit(qasm, add_measurements=False)
-
-    def test_openqasm_bare_barrier_after_first_gate_does_not_raise(self):
-        """Empty-circuit check does not fire once at least one qubit exists in scope."""
-        qasm = (
-            "OPENQASM 3.0;\n"
-            "h $0;\n"
-            "barrier;\n"
-        )
-        qc = to_qiskit(qasm, add_measurements=False)
-        ops = [(i.operation.name, [qc.find_bit(q).index for q in i.qubits]) for i in qc.data]
-        self.assertEqual(ops, [("h", [0]), ("barrier", [0])])
 
     def test_openqasm_bare_barrier_inside_verbatim_box_covers_inherited_and_late_added_qubits(
         self,
@@ -1793,39 +1770,6 @@ class TestFromBraket(TestCase):
             body_ops,
             [("h", [0]), ("barrier", [0, 1, 2, 3, 4, 5]), ("h", [5])],
         )
-
-    def test_openqasm_barrier_scoping_around_verbatim_box(self):
-        """OpenQASM path: barriers land in the scope they were written in."""
-        qasm = (
-            "OPENQASM 3.0;\n"
-            "h $0;\n"
-            "barrier $0;\n"
-            "#pragma braket verbatim\n"
-            "box {\n"
-            "    h $0;\n"
-            "    barrier $0, $1;\n"
-            "    cnot $0, $1;\n"
-            "}\n"
-            "barrier $1;\n"
-            "h $1;\n"
-        )
-        qc = to_qiskit(qasm, add_measurements=False)
-        ops = [(i.operation.name, [qc.find_bit(q).index for q in i.qubits]) for i in qc.data]
-        self.assertEqual(
-            ops,
-            [
-                ("h", [0]),
-                ("barrier", [0]),
-                ("box", [0, 1]),
-                ("barrier", [1]),
-                ("h", [1]),
-            ],
-        )
-        body = qc.data[2].operation.body
-        body_ops = [
-            (i.operation.name, [body.find_bit(q).index for q in i.qubits]) for i in body.data
-        ]
-        self.assertEqual(body_ops, [("h", [0]), ("barrier", [0, 1]), ("cx", [0, 1])])
 
     def test_openqasm_bare_barrier_inside_if_body_late_binds_to_if_body_qubits(self):
         """Bare barrier inside an if-body late-binds via resolve recursing into IfElseOp.blocks."""

--- a/test/unit_tests/test_adapter.py
+++ b/test/unit_tests/test_adapter.py
@@ -1729,7 +1729,7 @@ class TestFromBraket(TestCase):
     def test_openqasm_bare_barrier_before_any_qubit_raises(self):
         """Bare barrier before any qubit exists in the enclosing scope raises."""
         qasm = "OPENQASM 3.0;\nbarrier;\nh $0;\n"
-        with self.assertRaisesRegex(ValueError, "Cannot add global barrier to empty circuit"):
+        with self.assertRaisesRegex(ValueError, "Cannot add bare barrier to empty circuit"):
             to_qiskit(qasm, add_measurements=False)
 
     def test_openqasm_bare_barrier_inside_verbatim_box_covers_all_top_level_qubits(

--- a/test/unit_tests/test_adapter.py
+++ b/test/unit_tests/test_adapter.py
@@ -63,6 +63,15 @@ from test.unit_tests.mocks import (
 
 _EPS = 1e-10  # global variable used to chop very small numbers to zero
 
+
+def _innermost_scoped_body(circ):
+    """Descend into the first scoped op recursively; return the innermost body."""
+    for instr in circ.data:
+        blocks = getattr(instr.operation, "blocks", ()) or ()
+        if blocks and isinstance(blocks[0], QuantumCircuit):
+            return _innermost_scoped_body(blocks[0])
+    return circ
+
 qiskit_ionq_gates: list[QiskitGate] = [
     ionq_gates.GPIGate(Parameter("φ")),
     ionq_gates.GPI2Gate(Parameter("φ")),
@@ -1768,176 +1777,70 @@ class TestFromBraket(TestCase):
             [("h", [0]), ("barrier", [0, 1, 2, 3, 4, 5, 6]), ("h", [5])],
         )
 
-    def test_openqasm_bare_barrier_inside_if_body_late_binds_to_if_body_qubits(self):
-        """Bare barrier inside an if-body late-binds via resolve recursing into IfElseOp.blocks."""
-        qasm = (
-            "OPENQASM 3.0;\n"
-            "bit[1] c;\n"
-            "qubit[2] q;\n"
-            "h q[0];\n"
+
+@pytest.mark.parametrize(
+    "qasm,expected",
+    [
+        pytest.param(
+            "OPENQASM 3.0;\nbit[1] c;\nqubit[2] q;\nh q[0];\n"
             "c[0] = measure q[0];\n"
-            "if (c[0]) {\n"
-            "    h q[1];\n"
-            "    barrier;\n"
-            "}\n"
-        )
-        qc = to_qiskit(qasm, add_measurements=False)
-        if_else = qc.data[-1].operation
-        self.assertEqual(if_else.name, "if_else")
-        true_body = if_else.blocks[0]
-        body_ops = [
-            (i.operation.name, [true_body.find_bit(q).index for q in i.qubits])
-            for i in true_body.data
-        ]
-        self.assertEqual(body_ops, [("h", [1]), ("barrier", [0, 1])])
-
-    def test_openqasm_bare_barrier_in_if_body_covers_qubit_added_later_in_same_body(self):
-        """Bare barrier inside an if-body late-binds to qubits added later within the body."""
-        qasm = (
-            "OPENQASM 3.0;\n"
-            "bit[1] c;\n"
-            "qubit[1] q;\n"
-            "h q[0];\n"
+            "if (c[0]) { h q[1]; barrier; }\n",
+            [("h", [1]), ("barrier", [0, 1])],
+            id="qubit-used-inside-if-before-barrier",
+        ),
+        pytest.param(
+            "OPENQASM 3.0;\nbit[1] c;\nqubit[1] q;\nh q[0];\n"
             "c[0] = measure q[0];\n"
-            "if (c[0]) {\n"
-            "    barrier;\n"
-            "    h $3;\n"
-            "}\n"
-        )
-        qc = to_qiskit(qasm, add_measurements=False)
-        true_body = qc.data[-1].operation.blocks[0]
-        body_ops = [
-            (i.operation.name, [true_body.find_bit(q).index for q in i.qubits])
-            for i in true_body.data
-        ]
-        self.assertEqual(body_ops, [("barrier", [0, 1, 2, 3]), ("h", [3])])
-
-    def test_openqasm_bare_barrier_in_if_body_covers_qubit_added_after_if(self):
-        """Bare barrier inside an if-body late-binds to top-level qubits, including
-        qubits added at the outer scope after the if closes."""
-        qasm = (
-            "OPENQASM 3.0;\n"
-            "bit[1] c;\n"
-            "qubit[1] q;\n"
-            "h q[0];\n"
+            "if (c[0]) { barrier; h $3; }\n",
+            [("barrier", [0, 1, 2, 3]), ("h", [3])],
+            id="qubit-added-inside-if-after-barrier",
+        ),
+        pytest.param(
+            "OPENQASM 3.0;\nbit[1] c;\nqubit[1] q;\nh q[0];\n"
             "c[0] = measure q[0];\n"
-            "if (c[0]) {\n"
-            "    barrier;\n"
-            "}\n"
-            "h $4;\n"
-        )
-        qc = to_qiskit(qasm, add_measurements=False)
-        if_else = next(i for i in qc.data if i.operation.name == "if_else").operation
-        true_body = if_else.blocks[0]
-        body_ops = [
-            (i.operation.name, [true_body.find_bit(q).index for q in i.qubits])
-            for i in true_body.data
-        ]
-        self.assertEqual(body_ops, [("barrier", [0, 1, 2, 3, 4])])
+            "if (c[0]) { barrier; }\n"
+            "h $4;\n",
+            [("barrier", [0, 1, 2, 3, 4])],
+            id="qubit-added-outside-if-after-it-closes",
+        ),
+    ],
+)
+def test_openqasm_bare_barrier_in_if_body_late_binds_to_top_level_qubits(qasm, expected):
+    """Bare barrier inside an if body covers all top-level qubits at circuit
+    finalization, regardless of where the extra qubits are introduced."""
+    qc = to_qiskit(qasm, add_measurements=False)
+    body = _innermost_scoped_body(qc)
+    body_ops = [
+        (i.operation.name, [body.find_bit(q).index for q in i.qubits]) for i in body.data
+    ]
+    assert body_ops == expected
 
-    def test_openqasm_bare_barrier_inside_for_loop_covers_top_level_qubits(self):
-        """Bare barrier inside a for-loop body late-binds to top-level qubits,
-        including qubits added at the outer scope after the loop closes."""
-        qasm = (
-            "OPENQASM 3.0;\n"
-            "qubit[3] q;\n"
-            "for uint i in [0:2] {\n"
-            "    h q[0];\n"
-            "    barrier;\n"
-            "    cnot q[0], q[1];\n"
-            "}\n"
-            "h $5;\n"
-        )
-        qc = to_qiskit(qasm, add_measurements=False)
-        for_loop = next(i for i in qc.data if i.operation.name == "for_loop").operation
-        body = for_loop.blocks[0]
-        body_ops = [
-            (i.operation.name, [body.find_bit(q).index for q in i.qubits]) for i in body.data
-        ]
-        self.assertEqual(
-            body_ops, [("h", [0]), ("barrier", [0, 1, 2, 3, 4, 5]), ("cx", [0, 1])]
-        )
 
-    def test_openqasm_bare_barrier_inside_while_loop_covers_top_level_qubits(self):
-        """Bare barrier inside a while-loop body late-binds to top-level qubits,
-        including qubits added at the outer scope after the loop closes."""
-        qasm = (
-            "OPENQASM 3.0;\n"
-            "qubit[2] q;\n"
-            "bit[1] c;\n"
-            "c[0] = measure q[0];\n"
-            "while (c[0] == 1) {\n"
-            "    h q[0];\n"
-            "    barrier;\n"
-            "    c[0] = measure q[0];\n"
-            "}\n"
-            "h $5;\n"
-        )
-        qc = to_qiskit(qasm, add_measurements=False)
-        while_loop = next(i for i in qc.data if i.operation.name == "while_loop").operation
-        body = while_loop.blocks[0]
-        body_ops = [
-            (i.operation.name, [body.find_bit(q).index for q in i.qubits]) for i in body.data
-        ]
-        self.assertEqual(
-            body_ops,
-            [("h", [0]), ("barrier", [0, 1, 2, 3, 4, 5]), ("measure", [0])],
-        )
-
-    def test_openqasm_bare_barrier_in_nested_for_loop_covers_top_level_qubits(self):
-        """Bare barrier inside a for-in-for body late-binds to top-level qubits."""
-        qasm = (
-            "OPENQASM 3.0;\n"
-            "qubit[2] q;\n"
-            "for uint i in [0:1] {\n"
-            "    for uint j in [0:1] {\n"
-            "        h q[0];\n"
-            "        barrier;\n"
-            "        cnot q[0], q[1];\n"
-            "    }\n"
-            "}\n"
-            "h $5;\n"
-        )
-        qc = to_qiskit(qasm, add_measurements=False)
-        outer_for = next(i for i in qc.data if i.operation.name == "for_loop").operation
-        inner_for = outer_for.blocks[0].data[0].operation
-        body = inner_for.blocks[0]
-        body_ops = [
-            (i.operation.name, [body.find_bit(q).index for q in i.qubits]) for i in body.data
-        ]
-        self.assertEqual(
-            body_ops,
-            [("h", [0]), ("barrier", [0, 1, 2, 3, 4, 5]), ("cx", [0, 1])],
-        )
-
-    def test_openqasm_bare_barrier_in_nested_if_body_covers_top_level_qubits(self):
-        """Bare barrier inside an if-in-if body late-binds to top-level qubits."""
-        qasm = (
-            "OPENQASM 3.0;\n"
-            "bit[1] c;\n"
-            "qubit[2] q;\n"
-            "h q[0];\n"
-            "c[0] = measure q[0];\n"
-            "if (c[0]) {\n"
-            "    if (c[0]) {\n"
-            "        h q[0];\n"
-            "        barrier;\n"
-            "        cnot q[0], q[1];\n"
-            "    }\n"
-            "}\n"
-            "h $5;\n"
-        )
-        qc = to_qiskit(qasm, add_measurements=False)
-        outer_if = next(i for i in qc.data if i.operation.name == "if_else").operation
-        inner_if = outer_if.blocks[0].data[0].operation
-        body = inner_if.blocks[0]
-        body_ops = [
-            (i.operation.name, [body.find_bit(q).index for q in i.qubits]) for i in body.data
-        ]
-        self.assertEqual(
-            body_ops,
-            [("h", [0]), ("barrier", [0, 1, 2, 3, 4, 5]), ("cx", [0, 1])],
-        )
+@pytest.mark.parametrize(
+    "wrapper",
+    [
+        pytest.param("for uint i in [0:1] {\nBODY\n}\n", id="for"),
+        pytest.param("while (c[0] == 1) {\nBODY\n}\n", id="while"),
+        pytest.param(
+            "for uint i in [0:1] {\nfor uint j in [0:1] {\nBODY\n}\n}\n", id="for-in-for"
+        ),
+        pytest.param("if (c[0]) {\nif (c[0]) {\nBODY\n}\n}\n", id="if-in-if"),
+        pytest.param("while (c[0] == 1) {\nif (c[0]) {\nBODY\n}\n}\n", id="if-in-while"),
+    ],
+)
+def test_openqasm_bare_barrier_in_scoped_body_covers_top_level_qubits(wrapper):
+    """Bare barrier inside a scoped body late-binds to all top-level qubits,
+    including qubits added at the outer scope after the scope closes."""
+    preamble = "OPENQASM 3.0;\nbit[1] c;\nqubit[2] q;\nh q[0];\nc[0] = measure q[0];\n"
+    body_stmt = "h q[0]; barrier; cnot q[0], q[1];"
+    trailing = "h $5;\n"
+    qasm = preamble + wrapper.replace("BODY", body_stmt) + trailing
+    qc = to_qiskit(qasm, add_measurements=False)
+    body = _innermost_scoped_body(qc)
+    body_ops = [
+        (i.operation.name, [body.find_bit(q).index for q in i.qubits]) for i in body.data
+    ]
+    assert body_ops == [("h", [0]), ("barrier", [0, 1, 2, 3, 4, 5]), ("cx", [0, 1])]
 
 
 class TestThereAndBackAgain(TestCase):

--- a/test/unit_tests/test_adapter.py
+++ b/test/unit_tests/test_adapter.py
@@ -1720,11 +1720,12 @@ class TestFromBraket(TestCase):
         self.assertEqual({0, 1}, barrier_indices[0])
         self.assertEqual({0}, barrier_indices[1])
 
-    def test_openqasm_bare_barrier_before_any_qubit_raises(self):
-        """Bare barrier before any qubit exists in the enclosing scope raises."""
-        qasm = "OPENQASM 3.0;\nbarrier;\nh $0;\n"
-        with self.assertRaisesRegex(ValueError, "Cannot add bare barrier to empty circuit"):
-            to_qiskit(qasm, add_measurements=False)
+
+def test_openqasm_bare_barrier_before_any_qubit_raises() -> None:
+    """Bare barrier before any qubit exists in the enclosing scope raises."""
+    qasm = "OPENQASM 3.0;\nbarrier;\nh $0;\n"
+    with pytest.raises(ValueError, match="Cannot add bare barrier to empty circuit"):
+        to_qiskit(qasm, add_measurements=False)
 
 
 @pytest.mark.parametrize(

--- a/test/unit_tests/test_adapter.py
+++ b/test/unit_tests/test_adapter.py
@@ -1725,42 +1725,6 @@ class TestFromBraket(TestCase):
         with self.assertRaisesRegex(ValueError, "Cannot add bare barrier to empty circuit"):
             to_qiskit(qasm, add_measurements=False)
 
-    def test_openqasm_bare_barrier_inside_verbatim_box_covers_all_top_level_qubits(
-        self,
-    ):
-        """Bare barrier inside a verbatim box covers every top-level qubit."""
-        qasm = (
-            "OPENQASM 3.0;\n"
-            "h $2;\n"
-            "#pragma braket verbatim\n"
-            "box {\n"
-            "    h $0;\n"
-            "    barrier;\n"
-            "    h $5;\n"
-            "}\n"
-            "h $6;\n"
-            "barrier;\n"
-        )
-        qc = to_qiskit(qasm, add_measurements=False)
-        ops = [(i.operation.name, [qc.find_bit(q).index for q in i.qubits]) for i in qc.data]
-        self.assertEqual(
-            ops,
-            [
-                ("h", [2]),
-                ("box", [0, 1, 2, 3, 4, 5, 6]),
-                ("h", [6]),
-                ("barrier", [0, 1, 2, 3, 4, 5, 6]),
-            ],
-        )
-        body = qc.data[1].operation.body
-        body_ops = [
-            (i.operation.name, [body.find_bit(q).index for q in i.qubits]) for i in body.data
-        ]
-        self.assertEqual(
-            body_ops,
-            [("h", [0]), ("barrier", [0, 1, 2, 3, 4, 5, 6]), ("h", [5])],
-        )
-
 
 @pytest.mark.parametrize(
     "qasm,expected_num_qubits,expected_ops",
@@ -1828,6 +1792,7 @@ def test_openqasm_bare_barrier_in_if_body_late_binds_to_top_level_qubits(qasm, e
 @pytest.mark.parametrize(
     "wrapper",
     [
+        pytest.param("#pragma braket verbatim\nbox {\nBODY\n}\n", id="verbatim-box"),
         pytest.param("for uint i in [0:1] {\nBODY\n}\n", id="for"),
         pytest.param("while (c[0] == 1) {\nBODY\n}\n", id="while"),
         pytest.param(

--- a/test/unit_tests/test_adapter.py
+++ b/test/unit_tests/test_adapter.py
@@ -1732,11 +1732,10 @@ class TestFromBraket(TestCase):
         with self.assertRaisesRegex(ValueError, "Cannot add global barrier to empty circuit"):
             to_qiskit(qasm, add_measurements=False)
 
-    def test_openqasm_bare_barrier_inside_verbatim_box_covers_inherited_and_late_added_qubits(
+    def test_openqasm_bare_barrier_inside_verbatim_box_covers_all_top_level_qubits(
         self,
     ):
-        """Body's bare barrier covers inherited + body-local qubits and stays frozen at
-        box close; a subsequent top-level bare barrier resolves independently."""
+        """Bare barrier inside a verbatim box covers every top-level qubit."""
         qasm = (
             "OPENQASM 3.0;\n"
             "h $2;\n"
@@ -1755,7 +1754,7 @@ class TestFromBraket(TestCase):
             ops,
             [
                 ("h", [2]),
-                ("box", [0, 1, 2, 3, 4, 5]),
+                ("box", [0, 1, 2, 3, 4, 5, 6]),
                 ("h", [6]),
                 ("barrier", [0, 1, 2, 3, 4, 5, 6]),
             ],
@@ -1766,8 +1765,28 @@ class TestFromBraket(TestCase):
         ]
         self.assertEqual(
             body_ops,
-            [("h", [0]), ("barrier", [0, 1, 2, 3, 4, 5]), ("h", [5])],
+            [("h", [0]), ("barrier", [0, 1, 2, 3, 4, 5, 6]), ("h", [5])],
         )
+
+    def test_openqasm_bare_barrier_in_verbatim_box_covers_qubit_added_after_box(self):
+        """Bare barrier inside a verbatim box picks up a qubit added outside the box."""
+        qasm = (
+            "OPENQASM 3.0;\n"
+            "#pragma braket verbatim\n"
+            "box {\n"
+            "    h $0;\n"
+            "    barrier;\n"
+            "    cnot $0, $1;\n"
+            "}\n"
+            "h $2;\n"
+        )
+        qc = to_qiskit(qasm, add_measurements=False)
+        box = next(i for i in qc.data if i.operation.name == "box").operation
+        body = box.body
+        body_ops = [
+            (i.operation.name, [body.find_bit(q).index for q in i.qubits]) for i in body.data
+        ]
+        self.assertEqual(body_ops, [("h", [0]), ("barrier", [0, 1, 2]), ("cx", [0, 1])])
 
     def test_openqasm_bare_barrier_inside_if_body_late_binds_to_if_body_qubits(self):
         """Bare barrier inside an if-body late-binds via resolve recursing into IfElseOp.blocks."""
@@ -1791,6 +1810,49 @@ class TestFromBraket(TestCase):
             for i in true_body.data
         ]
         self.assertEqual(body_ops, [("h", [1]), ("barrier", [0, 1])])
+
+    def test_openqasm_bare_barrier_in_if_body_covers_qubit_added_later_in_same_body(self):
+        """Bare barrier inside an if-body late-binds to qubits added later within the body."""
+        qasm = (
+            "OPENQASM 3.0;\n"
+            "bit[1] c;\n"
+            "qubit[1] q;\n"
+            "h q[0];\n"
+            "c[0] = measure q[0];\n"
+            "if (c[0]) {\n"
+            "    barrier;\n"
+            "    h $3;\n"
+            "}\n"
+        )
+        qc = to_qiskit(qasm, add_measurements=False)
+        true_body = qc.data[-1].operation.blocks[0]
+        body_ops = [
+            (i.operation.name, [true_body.find_bit(q).index for q in i.qubits])
+            for i in true_body.data
+        ]
+        self.assertEqual(body_ops, [("barrier", [0, 1, 2, 3]), ("h", [3])])
+
+    def test_openqasm_bare_barrier_in_if_body_does_not_cover_qubit_added_after_if(self):
+        """Bare barrier inside an if-body stays scope-local; a qubit added outside afterwards is excluded."""
+        qasm = (
+            "OPENQASM 3.0;\n"
+            "bit[1] c;\n"
+            "qubit[1] q;\n"
+            "h q[0];\n"
+            "c[0] = measure q[0];\n"
+            "if (c[0]) {\n"
+            "    barrier;\n"
+            "}\n"
+            "h $3;\n"
+        )
+        qc = to_qiskit(qasm, add_measurements=False)
+        if_else = next(i for i in qc.data if i.operation.name == "if_else").operation
+        true_body = if_else.blocks[0]
+        body_ops = [
+            (i.operation.name, [true_body.find_bit(q).index for q in i.qubits])
+            for i in true_body.data
+        ]
+        self.assertEqual(body_ops, [("barrier", [0])])
 
 
 class TestThereAndBackAgain(TestCase):

--- a/test/unit_tests/test_adapter.py
+++ b/test/unit_tests/test_adapter.py
@@ -64,13 +64,14 @@ from test.unit_tests.mocks import (
 _EPS = 1e-10  # global variable used to chop very small numbers to zero
 
 
-def _innermost_scoped_body(circ):
+def _innermost_scoped_body(circ: QuantumCircuit) -> QuantumCircuit:
     """Descend into the first scoped op recursively; return the innermost body."""
     for instr in circ.data:
         blocks = getattr(instr.operation, "blocks", ()) or ()
         if blocks and isinstance(blocks[0], QuantumCircuit):
             return _innermost_scoped_body(blocks[0])
     return circ
+
 
 qiskit_ionq_gates: list[QiskitGate] = [
     ionq_gates.GPIGate(Parameter("φ")),
@@ -1743,7 +1744,9 @@ class TestFromBraket(TestCase):
         ),
     ],
 )
-def test_openqasm_top_level_barrier(qasm, expected_num_qubits, expected_ops):
+def test_openqasm_top_level_barrier(
+    qasm: str, expected_num_qubits: int, expected_ops: list[tuple[str, list[int]]]
+) -> None:
     """Top-level barriers: explicit targets stay frozen, bare barriers cover every top-level qubit."""
     qc = to_qiskit(qasm, add_measurements=False)
     assert qc.num_qubits == expected_num_qubits
@@ -1778,14 +1781,14 @@ def test_openqasm_top_level_barrier(qasm, expected_num_qubits, expected_ops):
         ),
     ],
 )
-def test_openqasm_bare_barrier_in_if_body_late_binds_to_top_level_qubits(qasm, expected):
+def test_openqasm_bare_barrier_in_if_body_late_binds_to_top_level_qubits(
+    qasm: str, expected: list[tuple[str, list[int]]]
+) -> None:
     """Bare barrier inside an if body covers all top-level qubits at circuit
     finalization, regardless of where the extra qubits are introduced."""
     qc = to_qiskit(qasm, add_measurements=False)
     body = _innermost_scoped_body(qc)
-    body_ops = [
-        (i.operation.name, [body.find_bit(q).index for q in i.qubits]) for i in body.data
-    ]
+    body_ops = [(i.operation.name, [body.find_bit(q).index for q in i.qubits]) for i in body.data]
     assert body_ops == expected
 
 
@@ -1795,14 +1798,12 @@ def test_openqasm_bare_barrier_in_if_body_late_binds_to_top_level_qubits(qasm, e
         pytest.param("#pragma braket verbatim\nbox {\nBODY\n}\n", id="verbatim-box"),
         pytest.param("for uint i in [0:1] {\nBODY\n}\n", id="for"),
         pytest.param("while (c[0] == 1) {\nBODY\n}\n", id="while"),
-        pytest.param(
-            "for uint i in [0:1] {\nfor uint j in [0:1] {\nBODY\n}\n}\n", id="for-in-for"
-        ),
+        pytest.param("for uint i in [0:1] {\nfor uint j in [0:1] {\nBODY\n}\n}\n", id="for-in-for"),
         pytest.param("if (c[0]) {\nif (c[0]) {\nBODY\n}\n}\n", id="if-in-if"),
         pytest.param("while (c[0] == 1) {\nif (c[0]) {\nBODY\n}\n}\n", id="if-in-while"),
     ],
 )
-def test_openqasm_bare_barrier_in_scoped_body_covers_top_level_qubits(wrapper):
+def test_openqasm_bare_barrier_in_scoped_body_covers_top_level_qubits(wrapper: str) -> None:
     """Bare barrier inside a scoped body late-binds to all top-level qubits,
     including qubits added at the outer scope after the scope closes."""
     preamble = "OPENQASM 3.0;\nbit[1] c;\nqubit[2] q;\nh q[0];\nc[0] = measure q[0];\n"
@@ -1811,10 +1812,23 @@ def test_openqasm_bare_barrier_in_scoped_body_covers_top_level_qubits(wrapper):
     qasm = preamble + wrapper.replace("BODY", body_stmt) + trailing
     qc = to_qiskit(qasm, add_measurements=False)
     body = _innermost_scoped_body(qc)
-    body_ops = [
-        (i.operation.name, [body.find_bit(q).index for q in i.qubits]) for i in body.data
-    ]
+    body_ops = [(i.operation.name, [body.find_bit(q).index for q in i.qubits]) for i in body.data]
     assert body_ops == [("h", [0]), ("barrier", [0, 1, 2, 3, 4, 5]), ("cx", [0, 1])]
+
+
+def test_openqasm_explicit_target_barrier_in_scoped_body_stays_narrow() -> None:
+    """Explicit-target barriers inside a scoped body stay on their targets even when
+    the enclosing scope is widened to cover all top-level qubits."""
+    qasm = (
+        "OPENQASM 3.0;\nqubit[2] q;\n"
+        "for uint i in [0:1] { h q[0]; barrier q[0]; cnot q[0], q[1]; }\n"
+        "barrier;\n"
+        "h $5;\n"
+    )
+    qc = to_qiskit(qasm, add_measurements=False)
+    body = _innermost_scoped_body(qc)
+    body_ops = [(i.operation.name, [body.find_bit(q).index for q in i.qubits]) for i in body.data]
+    assert body_ops == [("h", [0]), ("barrier", [0]), ("cx", [0, 1])]
 
 
 class TestThereAndBackAgain(TestCase):

--- a/test/unit_tests/test_adapter.py
+++ b/test/unit_tests/test_adapter.py
@@ -1823,7 +1823,7 @@ class TestFromBraket(TestCase):
             "if (c[0]) {\n"
             "    barrier;\n"
             "}\n"
-            "h $3;\n"
+            "h $4;\n"
         )
         qc = to_qiskit(qasm, add_measurements=False)
         if_else = next(i for i in qc.data if i.operation.name == "if_else").operation

--- a/test/unit_tests/test_adapter.py
+++ b/test/unit_tests/test_adapter.py
@@ -1812,8 +1812,9 @@ class TestFromBraket(TestCase):
         ]
         self.assertEqual(body_ops, [("barrier", [0, 1, 2, 3]), ("h", [3])])
 
-    def test_openqasm_bare_barrier_in_if_body_does_not_cover_qubit_added_after_if(self):
-        """Bare barrier inside an if-body stays scope-local; a qubit added outside afterwards is excluded."""
+    def test_openqasm_bare_barrier_in_if_body_covers_qubit_added_after_if(self):
+        """Bare barrier inside an if-body late-binds to top-level qubits, including
+        qubits added at the outer scope after the if closes."""
         qasm = (
             "OPENQASM 3.0;\n"
             "bit[1] c;\n"
@@ -1832,7 +1833,7 @@ class TestFromBraket(TestCase):
             (i.operation.name, [true_body.find_bit(q).index for q in i.qubits])
             for i in true_body.data
         ]
-        self.assertEqual(body_ops, [("barrier", [0])])
+        self.assertEqual(body_ops, [("barrier", [0, 1, 2, 3, 4])])
 
 
 class TestThereAndBackAgain(TestCase):

--- a/test/unit_tests/test_adapter.py
+++ b/test/unit_tests/test_adapter.py
@@ -1768,26 +1768,6 @@ class TestFromBraket(TestCase):
             [("h", [0]), ("barrier", [0, 1, 2, 3, 4, 5, 6]), ("h", [5])],
         )
 
-    def test_openqasm_bare_barrier_in_verbatim_box_covers_qubit_added_after_box(self):
-        """Bare barrier inside a verbatim box picks up a qubit added outside the box."""
-        qasm = (
-            "OPENQASM 3.0;\n"
-            "#pragma braket verbatim\n"
-            "box {\n"
-            "    h $0;\n"
-            "    barrier;\n"
-            "    cnot $0, $1;\n"
-            "}\n"
-            "h $2;\n"
-        )
-        qc = to_qiskit(qasm, add_measurements=False)
-        box = next(i for i in qc.data if i.operation.name == "box").operation
-        body = box.body
-        body_ops = [
-            (i.operation.name, [body.find_bit(q).index for q in i.qubits]) for i in body.data
-        ]
-        self.assertEqual(body_ops, [("h", [0]), ("barrier", [0, 1, 2]), ("cx", [0, 1])])
-
     def test_openqasm_bare_barrier_inside_if_body_late_binds_to_if_body_qubits(self):
         """Bare barrier inside an if-body late-binds via resolve recursing into IfElseOp.blocks."""
         qasm = (

--- a/test/unit_tests/test_adapter.py
+++ b/test/unit_tests/test_adapter.py
@@ -1710,6 +1710,146 @@ class TestFromBraket(TestCase):
         self.assertEqual({0, 1}, barrier_indices[0])
         self.assertEqual({0}, barrier_indices[1])
 
+    def test_openqasm_barrier_grows_circuit_and_later_gates_extend_further(self):
+        """Explicit-target barrier's qubit list is frozen at emit time."""
+        qasm = (
+            "OPENQASM 3.0;\n"
+            "h $0;\n"
+            "barrier $0, $2;\n"
+            "h $4;\n"
+        )
+        qc = to_qiskit(qasm, add_measurements=False)
+        self.assertEqual(qc.num_qubits, 5)
+        ops = [(i.operation.name, [qc.find_bit(q).index for q in i.qubits]) for i in qc.data]
+        self.assertEqual(ops, [("h", [0]), ("barrier", [0, 2]), ("h", [4])])
+
+    def test_openqasm_bare_barrier_late_binds_to_all_qubits_in_scope(self):
+        """Bare barrier covers every qubit of the enclosing scope at scope-close."""
+        qasm = (
+            "OPENQASM 3.0;\n"
+            "h $0;\n"
+            "barrier;\n"
+            "h $2;\n"
+        )
+        qc = to_qiskit(qasm, add_measurements=False)
+        self.assertEqual(qc.num_qubits, 3)
+        ops = [(i.operation.name, [qc.find_bit(q).index for q in i.qubits]) for i in qc.data]
+        self.assertEqual(ops, [("h", [0]), ("barrier", [0, 1, 2]), ("h", [2])])
+
+    def test_openqasm_bare_barrier_before_any_qubit_raises(self):
+        """SDK parity: bare barrier before any qubit exists in the enclosing scope raises."""
+        qasm = (
+            "OPENQASM 3.0;\n"
+            "barrier;\n"
+            "h $0;\n"
+        )
+        with self.assertRaisesRegex(ValueError, "Cannot add global barrier to empty circuit"):
+            to_qiskit(qasm, add_measurements=False)
+
+    def test_openqasm_bare_barrier_in_empty_verbatim_box_raises(self):
+        """SDK parity: bare barrier inside a box with no inherited or local qubits raises."""
+        qasm = (
+            "OPENQASM 3.0;\n"
+            "#pragma braket verbatim\n"
+            "box {\n"
+            "    barrier;\n"
+            "}\n"
+        )
+        with self.assertRaisesRegex(ValueError, "Cannot add global barrier to empty circuit"):
+            to_qiskit(qasm, add_measurements=False)
+
+    def test_openqasm_bare_barrier_after_first_gate_does_not_raise(self):
+        """Empty-circuit check does not fire once at least one qubit exists in scope."""
+        qasm = (
+            "OPENQASM 3.0;\n"
+            "h $0;\n"
+            "barrier;\n"
+        )
+        qc = to_qiskit(qasm, add_measurements=False)
+        ops = [(i.operation.name, [qc.find_bit(q).index for q in i.qubits]) for i in qc.data]
+        self.assertEqual(ops, [("h", [0]), ("barrier", [0])])
+
+    def test_openqasm_bare_barrier_inside_verbatim_box_covers_inherited_and_late_added_qubits(
+        self,
+    ):
+        """Bare barrier in a verbatim box covers parent-inherited qubits and body-local
+        qubits added after the barrier."""
+        qasm = (
+            "OPENQASM 3.0;\n"
+            "h $2;\n"
+            "#pragma braket verbatim\n"
+            "box {\n"
+            "    h $0;\n"
+            "    barrier;\n"
+            "    h $5;\n"
+            "}\n"
+        )
+        qc = to_qiskit(qasm, add_measurements=False)
+        body = qc.data[1].operation.body
+        body_ops = [
+            (i.operation.name, [body.find_bit(q).index for q in i.qubits]) for i in body.data
+        ]
+        self.assertEqual(
+            body_ops,
+            [("h", [0]), ("barrier", [0, 1, 2, 3, 4, 5]), ("h", [5])],
+        )
+
+    def test_openqasm_barrier_scoping_around_verbatim_box(self):
+        """OpenQASM path: barriers land in the scope they were written in."""
+        qasm = (
+            "OPENQASM 3.0;\n"
+            "h $0;\n"
+            "barrier $0;\n"
+            "#pragma braket verbatim\n"
+            "box {\n"
+            "    h $0;\n"
+            "    barrier $0, $1;\n"
+            "    cnot $0, $1;\n"
+            "}\n"
+            "barrier $1;\n"
+            "h $1;\n"
+        )
+        qc = to_qiskit(qasm, add_measurements=False)
+        ops = [(i.operation.name, [qc.find_bit(q).index for q in i.qubits]) for i in qc.data]
+        self.assertEqual(
+            ops,
+            [
+                ("h", [0]),
+                ("barrier", [0]),
+                ("box", [0, 1]),
+                ("barrier", [1]),
+                ("h", [1]),
+            ],
+        )
+        body = qc.data[2].operation.body
+        body_ops = [
+            (i.operation.name, [body.find_bit(q).index for q in i.qubits]) for i in body.data
+        ]
+        self.assertEqual(body_ops, [("h", [0]), ("barrier", [0, 1]), ("cx", [0, 1])])
+
+    def test_openqasm_bare_barrier_inside_if_body_late_binds_to_if_body_qubits(self):
+        """Bare barrier inside an if-body late-binds via resolve recursing into IfElseOp.blocks."""
+        qasm = (
+            "OPENQASM 3.0;\n"
+            "bit[1] c;\n"
+            "qubit[2] q;\n"
+            "h q[0];\n"
+            "c[0] = measure q[0];\n"
+            "if (c[0]) {\n"
+            "    h q[1];\n"
+            "    barrier;\n"
+            "}\n"
+        )
+        qc = to_qiskit(qasm, add_measurements=False)
+        if_else = qc.data[-1].operation
+        self.assertEqual(if_else.name, "if_else")
+        true_body = if_else.blocks[0]
+        body_ops = [
+            (i.operation.name, [true_body.find_bit(q).index for q in i.qubits])
+            for i in true_body.data
+        ]
+        self.assertEqual(body_ops, [("h", [1]), ("barrier", [0, 1])])
+
 
 class TestThereAndBackAgain(TestCase):
     """testing whether or not to_braket and to_qiskit work together"""

--- a/test/unit_tests/test_adapter.py
+++ b/test/unit_tests/test_adapter.py
@@ -1712,12 +1712,7 @@ class TestFromBraket(TestCase):
 
     def test_openqasm_barrier_grows_circuit_and_later_gates_extend_further(self):
         """Explicit-target barrier's qubit list is frozen at emit time."""
-        qasm = (
-            "OPENQASM 3.0;\n"
-            "h $0;\n"
-            "barrier $0, $2;\n"
-            "h $4;\n"
-        )
+        qasm = "OPENQASM 3.0;\nh $0;\nbarrier $0, $2;\nh $4;\n"
         qc = to_qiskit(qasm, add_measurements=False)
         self.assertEqual(qc.num_qubits, 5)
         ops = [(i.operation.name, [qc.find_bit(q).index for q in i.qubits]) for i in qc.data]
@@ -1725,12 +1720,7 @@ class TestFromBraket(TestCase):
 
     def test_openqasm_bare_barrier_late_binds_to_all_qubits_in_scope(self):
         """Bare barrier covers every qubit of the enclosing scope at scope-close."""
-        qasm = (
-            "OPENQASM 3.0;\n"
-            "h $0;\n"
-            "barrier;\n"
-            "h $2;\n"
-        )
+        qasm = "OPENQASM 3.0;\nh $0;\nbarrier;\nh $2;\n"
         qc = to_qiskit(qasm, add_measurements=False)
         self.assertEqual(qc.num_qubits, 3)
         ops = [(i.operation.name, [qc.find_bit(q).index for q in i.qubits]) for i in qc.data]
@@ -1738,19 +1728,15 @@ class TestFromBraket(TestCase):
 
     def test_openqasm_bare_barrier_before_any_qubit_raises(self):
         """Bare barrier before any qubit exists in the enclosing scope raises."""
-        qasm = (
-            "OPENQASM 3.0;\n"
-            "barrier;\n"
-            "h $0;\n"
-        )
+        qasm = "OPENQASM 3.0;\nbarrier;\nh $0;\n"
         with self.assertRaisesRegex(ValueError, "Cannot add global barrier to empty circuit"):
             to_qiskit(qasm, add_measurements=False)
 
     def test_openqasm_bare_barrier_inside_verbatim_box_covers_inherited_and_late_added_qubits(
         self,
     ):
-        """Bare barrier in a verbatim box covers parent-inherited qubits and body-local
-        qubits added after the barrier."""
+        """Body's bare barrier covers inherited + body-local qubits and stays frozen at
+        box close; a subsequent top-level bare barrier resolves independently."""
         qasm = (
             "OPENQASM 3.0;\n"
             "h $2;\n"
@@ -1760,8 +1746,20 @@ class TestFromBraket(TestCase):
             "    barrier;\n"
             "    h $5;\n"
             "}\n"
+            "h $6;\n"
+            "barrier;\n"
         )
         qc = to_qiskit(qasm, add_measurements=False)
+        ops = [(i.operation.name, [qc.find_bit(q).index for q in i.qubits]) for i in qc.data]
+        self.assertEqual(
+            ops,
+            [
+                ("h", [2]),
+                ("box", [0, 1, 2, 3, 4, 5]),
+                ("h", [6]),
+                ("barrier", [0, 1, 2, 3, 4, 5, 6]),
+            ],
+        )
         body = qc.data[1].operation.body
         body_ops = [
             (i.operation.name, [body.find_bit(q).index for q in i.qubits]) for i in body.data

--- a/test/unit_tests/test_adapter.py
+++ b/test/unit_tests/test_adapter.py
@@ -1835,6 +1835,110 @@ class TestFromBraket(TestCase):
         ]
         self.assertEqual(body_ops, [("barrier", [0, 1, 2, 3, 4])])
 
+    def test_openqasm_bare_barrier_inside_for_loop_covers_top_level_qubits(self):
+        """Bare barrier inside a for-loop body late-binds to top-level qubits,
+        including qubits added at the outer scope after the loop closes."""
+        qasm = (
+            "OPENQASM 3.0;\n"
+            "qubit[3] q;\n"
+            "for uint i in [0:2] {\n"
+            "    h q[0];\n"
+            "    barrier;\n"
+            "    cnot q[0], q[1];\n"
+            "}\n"
+            "h $5;\n"
+        )
+        qc = to_qiskit(qasm, add_measurements=False)
+        for_loop = next(i for i in qc.data if i.operation.name == "for_loop").operation
+        body = for_loop.blocks[0]
+        body_ops = [
+            (i.operation.name, [body.find_bit(q).index for q in i.qubits]) for i in body.data
+        ]
+        self.assertEqual(
+            body_ops, [("h", [0]), ("barrier", [0, 1, 2, 3, 4, 5]), ("cx", [0, 1])]
+        )
+
+    def test_openqasm_bare_barrier_inside_while_loop_covers_top_level_qubits(self):
+        """Bare barrier inside a while-loop body late-binds to top-level qubits,
+        including qubits added at the outer scope after the loop closes."""
+        qasm = (
+            "OPENQASM 3.0;\n"
+            "qubit[2] q;\n"
+            "bit[1] c;\n"
+            "c[0] = measure q[0];\n"
+            "while (c[0] == 1) {\n"
+            "    h q[0];\n"
+            "    barrier;\n"
+            "    c[0] = measure q[0];\n"
+            "}\n"
+            "h $5;\n"
+        )
+        qc = to_qiskit(qasm, add_measurements=False)
+        while_loop = next(i for i in qc.data if i.operation.name == "while_loop").operation
+        body = while_loop.blocks[0]
+        body_ops = [
+            (i.operation.name, [body.find_bit(q).index for q in i.qubits]) for i in body.data
+        ]
+        self.assertEqual(
+            body_ops,
+            [("h", [0]), ("barrier", [0, 1, 2, 3, 4, 5]), ("measure", [0])],
+        )
+
+    def test_openqasm_bare_barrier_in_nested_for_loop_covers_top_level_qubits(self):
+        """Bare barrier inside a for-in-for body late-binds to top-level qubits."""
+        qasm = (
+            "OPENQASM 3.0;\n"
+            "qubit[2] q;\n"
+            "for uint i in [0:1] {\n"
+            "    for uint j in [0:1] {\n"
+            "        h q[0];\n"
+            "        barrier;\n"
+            "        cnot q[0], q[1];\n"
+            "    }\n"
+            "}\n"
+            "h $5;\n"
+        )
+        qc = to_qiskit(qasm, add_measurements=False)
+        outer_for = next(i for i in qc.data if i.operation.name == "for_loop").operation
+        inner_for = outer_for.blocks[0].data[0].operation
+        body = inner_for.blocks[0]
+        body_ops = [
+            (i.operation.name, [body.find_bit(q).index for q in i.qubits]) for i in body.data
+        ]
+        self.assertEqual(
+            body_ops,
+            [("h", [0]), ("barrier", [0, 1, 2, 3, 4, 5]), ("cx", [0, 1])],
+        )
+
+    def test_openqasm_bare_barrier_in_nested_if_body_covers_top_level_qubits(self):
+        """Bare barrier inside an if-in-if body late-binds to top-level qubits."""
+        qasm = (
+            "OPENQASM 3.0;\n"
+            "bit[1] c;\n"
+            "qubit[2] q;\n"
+            "h q[0];\n"
+            "c[0] = measure q[0];\n"
+            "if (c[0]) {\n"
+            "    if (c[0]) {\n"
+            "        h q[0];\n"
+            "        barrier;\n"
+            "        cnot q[0], q[1];\n"
+            "    }\n"
+            "}\n"
+            "h $5;\n"
+        )
+        qc = to_qiskit(qasm, add_measurements=False)
+        outer_if = next(i for i in qc.data if i.operation.name == "if_else").operation
+        inner_if = outer_if.blocks[0].data[0].operation
+        body = inner_if.blocks[0]
+        body_ops = [
+            (i.operation.name, [body.find_bit(q).index for q in i.qubits]) for i in body.data
+        ]
+        self.assertEqual(
+            body_ops,
+            [("h", [0]), ("barrier", [0, 1, 2, 3, 4, 5]), ("cx", [0, 1])],
+        )
+
 
 class TestThereAndBackAgain(TestCase):
     """testing whether or not to_braket and to_qiskit work together"""

--- a/test/unit_tests/test_adapter.py
+++ b/test/unit_tests/test_adapter.py
@@ -1719,22 +1719,6 @@ class TestFromBraket(TestCase):
         self.assertEqual({0, 1}, barrier_indices[0])
         self.assertEqual({0}, barrier_indices[1])
 
-    def test_openqasm_barrier_grows_circuit_and_later_gates_extend_further(self):
-        """Explicit-target barrier's qubit list is frozen at emit time."""
-        qasm = "OPENQASM 3.0;\nh $0;\nbarrier $0, $2;\nh $4;\n"
-        qc = to_qiskit(qasm, add_measurements=False)
-        self.assertEqual(qc.num_qubits, 5)
-        ops = [(i.operation.name, [qc.find_bit(q).index for q in i.qubits]) for i in qc.data]
-        self.assertEqual(ops, [("h", [0]), ("barrier", [0, 2]), ("h", [4])])
-
-    def test_openqasm_bare_barrier_late_binds_to_all_qubits_in_scope(self):
-        """Bare barrier covers every qubit of the enclosing scope at scope-close."""
-        qasm = "OPENQASM 3.0;\nh $0;\nbarrier;\nh $2;\n"
-        qc = to_qiskit(qasm, add_measurements=False)
-        self.assertEqual(qc.num_qubits, 3)
-        ops = [(i.operation.name, [qc.find_bit(q).index for q in i.qubits]) for i in qc.data]
-        self.assertEqual(ops, [("h", [0]), ("barrier", [0, 1, 2]), ("h", [2])])
-
     def test_openqasm_bare_barrier_before_any_qubit_raises(self):
         """Bare barrier before any qubit exists in the enclosing scope raises."""
         qasm = "OPENQASM 3.0;\nbarrier;\nh $0;\n"
@@ -1776,6 +1760,31 @@ class TestFromBraket(TestCase):
             body_ops,
             [("h", [0]), ("barrier", [0, 1, 2, 3, 4, 5, 6]), ("h", [5])],
         )
+
+
+@pytest.mark.parametrize(
+    "qasm,expected_num_qubits,expected_ops",
+    [
+        pytest.param(
+            "OPENQASM 3.0;\nh $0;\nbarrier $0, $2;\nh $4;\n",
+            5,
+            [("h", [0]), ("barrier", [0, 2]), ("h", [4])],
+            id="explicit-target-frozen-at-emit-time",
+        ),
+        pytest.param(
+            "OPENQASM 3.0;\nh $0;\nbarrier;\nh $2;\n",
+            3,
+            [("h", [0]), ("barrier", [0, 1, 2]), ("h", [2])],
+            id="bare-covers-all-top-level-qubits",
+        ),
+    ],
+)
+def test_openqasm_top_level_barrier(qasm, expected_num_qubits, expected_ops):
+    """Top-level barriers: explicit targets stay frozen, bare barriers cover every top-level qubit."""
+    qc = to_qiskit(qasm, add_measurements=False)
+    assert qc.num_qubits == expected_num_qubits
+    ops = [(i.operation.name, [qc.find_bit(q).index for q in i.qubits]) for i in qc.data]
+    assert ops == expected_ops
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
  *Description of changes:*
  
  Preserve OpenQASM 3 barriers in `to_qiskit(qasm_string)`. `_QiskitProgramContext` inherited a no-op `add_barrier` from `AbstractProgramContext`, so any `barrier` in the OpenQASM 3 input was silently dropped. Override it in `qasm_context.py`:
  
  * **Explicit-target barrier** (`barrier q[0], q[1];` / `barrier $0, $2;`): grow the active circuit via `_ensure_qubit_capacity` and emit `active.barrier(target)`.
  * **Bare `barrier;`**: append a `Barrier(0)` placeholder to the active scope, then resolve it at circuit finalization by
  `_finalize_scoped_bodies` — a single recursive pass that rebuilds the tree bottom-up, widens every scoped body (verbatim BoxOp, IfElseOp, ForLoopOp, WhileLoopOp) to the top-level circuit's qubit set, and rewrites placeholders to `Barrier(top.num_qubits)` on all top qubits. 
  * **Empty scope**: raise `ValueError("Cannot add bare barrier to empty circuit")` at emit time, mirroring the BDK's `Circuit.barrier()` behavior on an empty circuit ([amazon-braket-sdk-python#1203](https://github.com/amazon-braket/amazon-braket-sdk-python/pull/1203)).
  
  Bare barriers cover **all** top-level qubits regardless of where they appear syntactically, including qubits declared after the enclosing scope closes. Nested scoped ops (if-in-if, for-in-for, if-in-while, …) are handled by the same recursive pass.
  
  Reproducer from the ticket:
  ```
  qasm = "OPENQASM 3.0; qubit[2] q; h q[0]; barrier q[0], q[1]; cnot q[0], q[1];"
  [instr.operation.name for instr in to_qiskit(qasm, add_measurements=False).data]
  
  was `['h', 'cx']`, now `['h', 'barrier', 'cx']`.
  ```
  *Testing done:*
  Added tests in `test/unit_tests/test_adapter.py`, including parametrized coverage of bare barriers inside if bodies and inside for/while/nested scoped bodies.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md#pr-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/README.md) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
