### PR TITLE
fix: to_qiskit for IQM experimental operators (cc_prx, measure_ff)

### DIFF
--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -26,7 +26,7 @@ from qiskit.quantum_info import Pauli, SparsePauliOp
 from qiskit.transpiler import PassManager, Target
 from qiskit_ionq import add_equivalences
 
-from braket import experimental_capabilities as braket_expcaps  # noqa: F401
+from braket import experimental_capabilities as braket_expcaps
 from braket.aws import AwsDevice, AwsDeviceType  # noqa: F401
 from braket.circuits import Circuit, Instruction, compiler_directives, measure
 from braket.circuits import Observable as BraketObservable
@@ -582,6 +582,8 @@ def to_qiskit(
                 gate = _create_qiskit_kraus(operator.to_matrix())
             case braket_gates.Unitary():
                 gate = _create_qiskit_unitary(operator.to_matrix())
+            case braket_expcaps.iqm.classical_control.ExperimentalQuantumOperator():
+                gate = _create_qiskit_gate(operator._qasm_name, operator.parameters, parameter_map)
             case compiler_directives.StartVerbatimBox():
                 if verbatim_buffer is not None:
                     raise ValueError("Nested verbatim boxes are not supported")

--- a/test/unit_tests/test_braket_instructions.py
+++ b/test/unit_tests/test_braket_instructions.py
@@ -175,5 +175,14 @@ def test_direct_instantiation_of_abstract_base_raises() -> None:
         _CPhaseShift(0.5)
 
 
+def test_to_qiskit_supports_iqm_classical_control() -> None:
+    """Regression test for to_qiskit on cc_prx and measure_ff."""
+    qasm = "OPENQASM 3.0;\nqubit[2] q;\nmeasure_ff(0) q[0];\ncc_prx(0.5, 0.7, 0) q[1];\n"
+    with EnableExperimentalCapability():
+        qc = to_qiskit(Circuit.from_ir(qasm), add_measurements=False)
+    assert isinstance(qc.data[0].operation, MeasureFF)
+    assert isinstance(qc.data[1].operation, CCPRx)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
  *Description of changes:*
  `to_qiskit` raised `TypeError` on circuits containing `cc_prx` or `measure_ff`. The default branch looks up gates by `operator.name.lower()` ("ccprx" / "measureff"), which doesn't match the OpenQASM keys ("cc_prx" / "measure_ff") that `_BRAKET_GATE_NAME_TO_QISKIT_GATE` uses.
  
  Added a match case for `ExperimentalQuantumOperator` that dispatches via `operator._qasm_name`.

Example:
```python
from braket.circuits import Circuit
from braket.experimental_capabilities import EnableExperimentalCapability
from qiskit_braket_provider.providers.adapter import to_qiskit
  
QASMS = {
      "cc_prx":     "OPENQASM 3.0;\nqubit[1] q;\ncc_prx(0.5, 0.7, 0) q[0];\n",
      "measure_ff": "OPENQASM 3.0;\nqubit[1] q;\nmeasure_ff(0) q[0];\n",
}
  
with EnableExperimentalCapability():
    for name, qasm in QASMS.items():
        try:
            to_qiskit(Circuit.from_ir(qasm), add_measurements=False)
        except Exception as e:
            print(f"{name}: {type(e).__name__}: {e}")
  
  # cc_prx:     TypeError: Braket gate "ccprx" not supported in Qiskit
  # measure_ff: TypeError: Braket gate "measureff" not supported in Qiskit
```
  
  *Testing done:*
  Added regression test.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md#pr-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/README.md) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
