### PR TITLE
fix: errors due to new ruff version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from pygments.formatters import LatexFormatter
 
 project = "Qiskit-Braket provider"
-copyright = f"{datetime.datetime.now(tz=datetime.UTC).year}, Amazon.com"  # noqa: A001
+copyright = f"{datetime.datetime.now(tz=datetime.UTC).year}, Amazon.com"  # ruff:ignore[builtin-variable-shadowing]
 author = "Amazon Web Services"
 
 # The full version, including alpha/beta/rc tags

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,17 +39,17 @@ extend-select = [
     # "SLF",  # flake8-self (~41 errors)
     "SLOT",   # flake8-slots
     "TC",     # flake8-type-checking
-    "TID251", # flake8-tidy-imports
+    "banned-api", # flake8-tidy-imports
     # "TRY",  # tryceratops
     "UP",     # pyupgrade
     "YTT",    # flake8-2020
 ]
 extend-ignore = [
-    "N818",   # QiskitBraketException is public API
-    "TC001",  # imports used at runtime
-    "TC002",  # braket imports used at runtime in type annotations
-    "ANN002", # missing annotation on *args
-    "ANN003", # missing annotation on **kwargs
+    "error-suffix-on-exception-name",   # QiskitBraketException is public API
+    "typing-only-first-party-import",  # imports used at runtime
+    "typing-only-third-party-import",  # braket imports used at runtime in type annotations
+    "missing-type-args", # missing annotation on *args
+    "missing-type-kwargs", # missing annotation on **kwargs
 ]
 
 [tool.ruff.lint.isort]

--- a/qiskit_braket_provider/__init__.py
+++ b/qiskit_braket_provider/__init__.py
@@ -1,6 +1,6 @@
 """Qiskit-Braket provider."""
 
-from ._version import __version__  # noqa: F401
+from ._version import __version__  # ruff:ignore[unused-import]
 from .providers import (
     AmazonBraketTask as AmazonBraketTask,
 )

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -27,7 +27,7 @@ from qiskit.transpiler import PassManager, Target
 from qiskit_ionq import add_equivalences
 
 from braket import experimental_capabilities as braket_expcaps
-from braket.aws import AwsDevice, AwsDeviceType  # noqa: F401
+from braket.aws import AwsDevice, AwsDeviceType  # ruff:ignore[unused-import]
 from braket.circuits import Circuit, Instruction, compiler_directives, measure
 from braket.circuits import Observable as BraketObservable
 from braket.circuits import gates as braket_gates
@@ -38,16 +38,16 @@ from braket.devices import Device
 from braket.ir.openqasm import Program
 from braket.parametric import FreeParameter, FreeParameterExpression, Parameterizable
 from qiskit_braket_provider.providers.compilation import (
-    _CompilationContext,  # noqa: F401
+    _CompilationContext,  # ruff:ignore[unused-import]
     _compile,
-    _default_target,  # noqa: F401
+    _default_target,  # ruff:ignore[unused-import]
 )
 from qiskit_braket_provider.providers.gate_mappings import (
     _BRAKET_GATE_NAME_TO_QISKIT_GATE,
-    _BRAKET_SUPPORTED_NOISES,  # noqa: F401
-    _BRAKET_TO_QISKIT_NAMES,  # noqa: F401
+    _BRAKET_SUPPORTED_NOISES,  # ruff:ignore[unused-import]
+    _BRAKET_TO_QISKIT_NAMES,  # ruff:ignore[unused-import]
     _BRAKET_VERBATIM_BOX_NAME,
-    _CONTROLLED_GATES_BY_QUBIT_COUNT,  # noqa: F401
+    _CONTROLLED_GATES_BY_QUBIT_COUNT,  # ruff:ignore[unused-import]
     _EPS,
     _PAULI_MAP,
     _QISKIT_CONTROLLED_GATE_NAMES_TO_BRAKET_GATES,
@@ -58,14 +58,14 @@ from qiskit_braket_provider.providers.qasm_context import (
     _sympy_to_qiskit,
 )
 from qiskit_braket_provider.providers.target import (
-    _get_controlled_gateset,  # noqa: F401
-    _SubstitutedTarget,  # noqa: F401
-    aws_device_to_target,  # noqa: F401
-    gateset_from_properties,  # noqa: F401
-    local_simulator_to_target,  # noqa: F401
-    native_angle_restrictions,  # noqa: F401
-    native_gate_connectivity,  # noqa: F401
-    native_gate_set,  # noqa: F401
+    _get_controlled_gateset,  # ruff:ignore[unused-import]
+    _SubstitutedTarget,  # ruff:ignore[unused-import]
+    aws_device_to_target,  # ruff:ignore[unused-import]
+    gateset_from_properties,  # ruff:ignore[unused-import]
+    local_simulator_to_target,  # ruff:ignore[unused-import]
+    native_angle_restrictions,  # ruff:ignore[unused-import]
+    native_gate_connectivity,  # ruff:ignore[unused-import]
+    native_gate_set,  # ruff:ignore[unused-import]
 )
 
 add_equivalences()

--- a/qiskit_braket_provider/providers/braket_backend.py
+++ b/qiskit_braket_provider/providers/braket_backend.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 
 _TASK_ID_DIVIDER = ";"
 
-T = TypeVar("T", bound=Device, covariant=True)  # noqa: PLC0105
+T = TypeVar("T", bound=Device, covariant=True)  # ruff:ignore[type-name-incorrect-variance]
 
 
 def _emulator_supports_program_sets(emulator: Emulator) -> bool:

--- a/qiskit_braket_provider/providers/qasm_context.py
+++ b/qiskit_braket_provider/providers/qasm_context.py
@@ -185,7 +185,7 @@ class _QiskitProgramContext(AbstractProgramContext):
         self,
         name: str,
         symbol_type: ClassicalType | type,
-        value: Any = None,  # noqa: ANN401
+        value: Any = None,  # ruff:ignore[any-type]
         const: bool = False,
     ) -> None:
         """Override to add classical bits to the Qiskit circuit when declared.
@@ -218,7 +218,7 @@ class _QiskitProgramContext(AbstractProgramContext):
     def is_builtin_gate(self, name: str) -> bool:
         return name in _BRAKET_GATE_NAME_TO_QISKIT_GATE
 
-    def add_phase_instruction(self, target: int | list[int], phase_value: float) -> None:  # noqa: ARG002
+    def add_phase_instruction(self, target: int | list[int], phase_value: float) -> None:  # ruff:ignore[unused-method-argument]
         self._active_circuit.global_phase += phase_value
 
     def add_gate_instruction(
@@ -386,7 +386,7 @@ class _QiskitProgramContext(AbstractProgramContext):
             return True
         return super().is_mcm_dependent(expression)
 
-    def iter_classical_scopes(self, expression: Expression):  # noqa: ARG002
+    def iter_classical_scopes(self, expression: Expression):  # ruff:ignore[unused-method-argument]
         """Yield once since Qiskit circuit building doesn't do per-path branching."""
         yield
 
@@ -544,7 +544,7 @@ class _QiskitProgramContext(AbstractProgramContext):
         while_op = WhileLoopOp(resolved_condition, body)
         main.append(while_op, main.qubits, main.clbits)
 
-    def _evaluate_expression(self, expression: Expression | list[Expression]) -> Any:  # noqa: ANN401
+    def _evaluate_expression(self, expression: Expression | list[Expression]) -> Any:  # ruff:ignore[any-type]
         """Lightweight expression evaluator for loop conditions and ranges."""
         match expression:
             case (

--- a/test/unit_tests/test_adapter_to_qiskit_verbatim.py
+++ b/test/unit_tests/test_adapter_to_qiskit_verbatim.py
@@ -306,7 +306,7 @@ OPENQASM 3.0;
 box {
     h $0;
 """
-    with pytest.raises(Exception):  # noqa: B017
+    with pytest.raises(Exception):  # ruff:ignore[assert-raises-exception]
         to_qiskit(qasm)
 
 

--- a/test/unit_tests/test_braket_backend.py
+++ b/test/unit_tests/test_braket_backend.py
@@ -163,7 +163,7 @@ class TestBraketLocalBackend(TestCase):
         circuit = QuantumCircuit(1)
         circuit.h(0)
 
-        with self.assertRaises(Exception):  # noqa: B017
+        with self.assertRaises(Exception):  # ruff:ignore[assert-raises-exception]
             backend.run([circuit, circuit], shots=0)  # First run should pass
         braket_devices_run.assert_called()
 


### PR DESCRIPTION
  ## Summary
  
  Fixes linter failures caused by upgrading to ruff 0.15.22.
  
  ## Changes
  
  - Replace `# noqa: <CODE>` comments with `# ruff:ignore[<CODE>]` across all source and test files
  - Replace numeric rule codes with stable rule names in `pyproject.toml` (`extend-select` and `extend-ignore`)
  
  No functional changes.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md) doc
- [ ] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md#pr-title-format)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/README.md) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
