### PR TITLE
fix: resolve panic due to missing clbits on verbatim placeholder

### DIFF
--- a/qiskit_braket_provider/providers/compilation.py
+++ b/qiskit_braket_provider/providers/compilation.py
@@ -210,7 +210,9 @@ def _compile(
             )
         ):
             if has_verbatim_boxes and target and "barrier" not in target.operation_names:
-                target.add_instruction(VerbatimPlaceholder(1, 0), name="barrier")
+                target.add_instruction(
+                    VerbatimPlaceholder(1, 0, label="verbatim"), name="barrier"
+                )
             pm = generate_preset_pass_manager(
                 optimization_level=optimization_level,
                 basis_gates=list(basis_gates) if basis_gates else None,

--- a/qiskit_braket_provider/providers/compilation.py
+++ b/qiskit_braket_provider/providers/compilation.py
@@ -23,9 +23,6 @@ from qiskit_braket_provider.providers.passes import (
     ExtractVerbatimBoxes,
     RestoreVerbatimBoxes,
 )
-from qiskit_braket_provider.providers.passes.verbatim_passes import (
-    VerbatimPlaceholder,
-)
 from qiskit_braket_provider.providers.target import (
     _SubstitutedTarget,
     aws_device_to_target,
@@ -209,8 +206,6 @@ def _compile(
                 )
             )
         ):
-            if has_verbatim_boxes and target and "barrier" not in target.operation_names:
-                target.add_instruction(VerbatimPlaceholder(1, 0, label="verbatim"), name="barrier")
             pm = generate_preset_pass_manager(
                 optimization_level=optimization_level,
                 basis_gates=list(basis_gates) if basis_gates else None,

--- a/qiskit_braket_provider/providers/compilation.py
+++ b/qiskit_braket_provider/providers/compilation.py
@@ -210,9 +210,7 @@ def _compile(
             )
         ):
             if has_verbatim_boxes and target and "barrier" not in target.operation_names:
-                target.add_instruction(
-                    VerbatimPlaceholder(1, 0, label="verbatim"), name="barrier"
-                )
+                target.add_instruction(VerbatimPlaceholder(1, 0, label="verbatim"), name="barrier")
             pm = generate_preset_pass_manager(
                 optimization_level=optimization_level,
                 basis_gates=list(basis_gates) if basis_gates else None,

--- a/qiskit_braket_provider/providers/compilation.py
+++ b/qiskit_braket_provider/providers/compilation.py
@@ -209,13 +209,8 @@ def _compile(
                 )
             )
         ):
-            if has_verbatim_boxes and target:
-                # Register the VerbatimPlaceholder with the target so the
-                # transpiler treats it as a known directive. On the basis_gates
-                # path this isn't needed since VerbatimPlaceholder uses name
-                # 'barrier' which is auto-allowed.
-                if "barrier" not in target.operation_names:
-                    target.add_instruction(VerbatimPlaceholder(1, 0), name="barrier")
+            if has_verbatim_boxes and target and "barrier" not in target.operation_names:
+                target.add_instruction(VerbatimPlaceholder(1, 0), name="barrier")
             pm = generate_preset_pass_manager(
                 optimization_level=optimization_level,
                 basis_gates=list(basis_gates) if basis_gates else None,

--- a/qiskit_braket_provider/providers/compilation.py
+++ b/qiskit_braket_provider/providers/compilation.py
@@ -23,6 +23,9 @@ from qiskit_braket_provider.providers.passes import (
     ExtractVerbatimBoxes,
     RestoreVerbatimBoxes,
 )
+from qiskit_braket_provider.providers.passes.verbatim_passes import (
+    VerbatimPlaceholder,
+)
 from qiskit_braket_provider.providers.target import (
     _SubstitutedTarget,
     aws_device_to_target,
@@ -206,6 +209,13 @@ def _compile(
                 )
             )
         ):
+            if has_verbatim_boxes and target:
+                # Register the VerbatimPlaceholder with the target so the
+                # transpiler treats it as a known directive. On the basis_gates
+                # path this isn't needed since VerbatimPlaceholder uses name
+                # 'barrier' which is auto-allowed.
+                if "barrier" not in target.operation_names:
+                    target.add_instruction(VerbatimPlaceholder(1, 0), name="barrier")
             pm = generate_preset_pass_manager(
                 optimization_level=optimization_level,
                 basis_gates=list(basis_gates) if basis_gates else None,

--- a/qiskit_braket_provider/providers/passes/verbatim_passes.py
+++ b/qiskit_braket_provider/providers/passes/verbatim_passes.py
@@ -13,7 +13,7 @@ def _indexed_label(base: str, index: int) -> str:
 
 
 def _is_verbatim_label(label: str | None, base: str) -> bool:
-    """Check if a label is a verbatim barrier label (base or indexed)."""
+    """Check if a label is a verbatim placeholder label (base or indexed)."""
     if label is None:
         return False
     return label == base or (label.startswith(f"{base}__") and label[len(base) + 2 :].isdigit())
@@ -30,8 +30,7 @@ class VerbatimPlaceholder(Instruction):
     _directive = True
 
     def __init__(self, num_qubits: int, num_clbits: int, label: str):
-        super().__init__("barrier", num_qubits, num_clbits, [])
-        self.label = label
+        super().__init__("barrier", num_qubits, num_clbits, [], label=label)
 
 
 class ExtractVerbatimBoxes(TransformationPass):
@@ -89,7 +88,7 @@ class RestoreVerbatimBoxes(TransformationPass):
     :class:`ExtractVerbatimBoxes`.
 
     Args:
-        verbatim_box_name: Label used to identify placeholder barriers.
+        verbatim_box_name: Label used to identify verbatim placeholders.
     """
 
     def __init__(self, verbatim_box_name: str = _BRAKET_VERBATIM_BOX_NAME):
@@ -127,7 +126,7 @@ class RestoreVerbatimBoxes(TransformationPass):
         if verbatim_boxes:
             raise RuntimeError(
                 f"Internal error: stashed verbatim boxes were not restored "
-                f"(no matching barriers found): {list(verbatim_boxes.keys())}. "
-                f"Their barriers may have been removed during transpilation."
+                f"(no matching placeholders found): {list(verbatim_boxes.keys())}. "
+                f"Their placeholders may have been removed during transpilation."
             )
         return dag

--- a/qiskit_braket_provider/providers/passes/verbatim_passes.py
+++ b/qiskit_braket_provider/providers/passes/verbatim_passes.py
@@ -20,24 +20,22 @@ def _is_verbatim_label(label: str | None, base: str) -> bool:
 
 
 class VerbatimPlaceholder(Instruction):
-    """A directive instruction used as a placeholder for verbatim boxes with clbits.
+    """A directive instruction used as a placeholder for verbatim boxes.
 
     Uses the name ``'barrier'`` so the transpiler's basis translator automatically
     allows it without needing explicit registration in the target or basis_gates.
-    Distinguished from real barriers by its label (set to the indexed verbatim label).
     Unlike a real ``Barrier``, this instruction can carry classical bits.
     """
 
     _directive = True
 
-    def __init__(self, num_qubits: int, num_clbits: int, label: str | None = None):
+    def __init__(self, num_qubits: int, num_clbits: int, label: str):
         super().__init__("barrier", num_qubits, num_clbits, [])
-        if label:
-            self.label = label
+        self.label = label
 
 
 class ExtractVerbatimBoxes(TransformationPass):
-    """Swap verbatim ``BoxOp`` nodes for labeled barriers before transpilation.
+    """Swap verbatim ``BoxOp`` nodes for labeled placeholders before transpilation.
 
     The original box circuits are stashed in ``property_set["verbatim_boxes"]``
     as a dict mapping indexed labels to ``QuantumCircuit`` instances for
@@ -52,7 +50,7 @@ class ExtractVerbatimBoxes(TransformationPass):
         self._verbatim_box_name = verbatim_box_name
 
     def run(self, dag: DAGCircuit) -> DAGCircuit:
-        """Replace matching ``BoxOp`` nodes with labeled barriers.
+        """Replace matching ``BoxOp`` nodes with labeled placeholders.
 
         Raises:
             ValueError: If the DAG already contains a barrier whose label
@@ -75,15 +73,9 @@ class ExtractVerbatimBoxes(TransformationPass):
             if getattr(node.op, "label", None) != self._verbatim_box_name:
                 continue
             label = _indexed_label(self._verbatim_box_name, index)
-            verbatim_boxes[label] = (node.op.blocks[0], [dag.find_bit(c).index for c in node.cargs])
-            if node.cargs:
-                # Use a VerbatimPlaceholder that can carry both qubits and
-                # clbits. A plain Barrier cannot carry clbits.
-                placeholder = VerbatimPlaceholder(len(node.qargs), len(node.cargs), label=label)
-                dag.substitute_node(node, placeholder)
-            else:
-                barrier = Barrier(len(node.qargs), label=label)
-                dag.substitute_node(node, barrier)
+            verbatim_boxes[label] = node.op.blocks[0]
+            placeholder = VerbatimPlaceholder(len(node.qargs), len(node.cargs), label=label)
+            dag.substitute_node(node, placeholder)
             index += 1
 
         self.property_set["verbatim_boxes"] = verbatim_boxes
@@ -91,7 +83,7 @@ class ExtractVerbatimBoxes(TransformationPass):
 
 
 class RestoreVerbatimBoxes(TransformationPass):
-    """Replace labeled barriers with the original verbatim gate sequences.
+    """Replace labeled placeholders with the original verbatim gate sequences.
 
     Reads ``property_set["verbatim_boxes"]`` populated by
     :class:`ExtractVerbatimBoxes`.
@@ -105,10 +97,10 @@ class RestoreVerbatimBoxes(TransformationPass):
         self._verbatim_box_name = verbatim_box_name
 
     def run(self, dag: DAGCircuit) -> DAGCircuit:
-        """Splice stashed gate sequences back in place of labeled barriers.
+        """Splice stashed gate sequences back in place of labeled placeholders.
 
         Raises:
-            RuntimeError: If a labeled barrier has no matching stashed box.
+            RuntimeError: If a labeled placeholder has no matching stashed box.
             RuntimeError: If stashed boxes remain unconsumed after processing.
         """
         verbatim_boxes = self.property_set.get("verbatim_boxes", {})
@@ -116,27 +108,21 @@ class RestoreVerbatimBoxes(TransformationPass):
             return dag
 
         for node in dag.topological_op_nodes():
-            is_barrier = isinstance(node.op, Barrier)
-            is_placeholder = isinstance(node.op, VerbatimPlaceholder)
-            if not is_barrier and not is_placeholder:
+            if not isinstance(node.op, VerbatimPlaceholder):
                 continue
             label = getattr(node.op, "label", None)
             if not _is_verbatim_label(label, self._verbatim_box_name):
                 continue
             if label not in verbatim_boxes:
                 raise RuntimeError(
-                    f"Internal error: verbatim barrier '{label}' has no matching box. "
+                    f"Internal error: verbatim placeholder '{label}' has no matching box. "
                     f"This is a bug in the verbatim pass pipeline."
                 )
-            box_circuit, _clbit_indices = verbatim_boxes.pop(label)
+            box_circuit = verbatim_boxes.pop(label)
             box_dag = circuit_to_dag(box_circuit)
-            if is_placeholder:
-                # Placeholder carries both qubits and clbits — map both.
-                qubit_map = dict(zip(box_dag.qubits, node.qargs, strict=True))
-                clbit_map = dict(zip(box_dag.clbits, node.cargs, strict=True))
-                dag.substitute_node_with_dag(node, box_dag, wires={**qubit_map, **clbit_map})
-            else:
-                dag.substitute_node_with_dag(node, box_dag)
+            qubit_map = dict(zip(box_dag.qubits, node.qargs, strict=True))
+            clbit_map = dict(zip(box_dag.clbits, node.cargs, strict=True))
+            dag.substitute_node_with_dag(node, box_dag, wires={**qubit_map, **clbit_map})
 
         if verbatim_boxes:
             raise RuntimeError(

--- a/qiskit_braket_provider/providers/passes/verbatim_passes.py
+++ b/qiskit_braket_provider/providers/passes/verbatim_passes.py
@@ -1,6 +1,6 @@
 """Transpiler passes for preserving verbatim boxes through compilation."""
 
-from qiskit.circuit import Barrier, BoxOp, Instruction, QuantumCircuit
+from qiskit.circuit import Barrier, BoxOp, Instruction
 from qiskit.converters import circuit_to_dag
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler.basepasses import TransformationPass
@@ -130,7 +130,7 @@ class RestoreVerbatimBoxes(TransformationPass):
                     f"Internal error: verbatim barrier '{label}' has no matching box. "
                     f"This is a bug in the verbatim pass pipeline."
                 )
-            box_circuit, clbit_indices = verbatim_boxes.pop(label)
+            box_circuit, _clbit_indices = verbatim_boxes.pop(label)
             box_dag = circuit_to_dag(box_circuit)
             if is_placeholder:
                 # Placeholder carries both qubits and clbits — map both.

--- a/qiskit_braket_provider/providers/passes/verbatim_passes.py
+++ b/qiskit_braket_provider/providers/passes/verbatim_passes.py
@@ -78,9 +78,7 @@ class ExtractVerbatimBoxes(TransformationPass):
             verbatim_boxes[label] = (node.op.blocks[0], [dag.find_bit(c).index for c in node.cargs])
             if node.cargs:
                 # Use a VerbatimPlaceholder that can carry both qubits and
-                # clbits. A plain Barrier cannot carry clbits, and the Rust
-                # substitute_node_with_dag panics when trying to route clbit
-                # wires through a barrier node that has no clbit edges.
+                # clbits. A plain Barrier cannot carry clbits.
                 placeholder = VerbatimPlaceholder(len(node.qargs), len(node.cargs), label=label)
                 dag.substitute_node(node, placeholder)
             else:

--- a/qiskit_braket_provider/providers/passes/verbatim_passes.py
+++ b/qiskit_braket_provider/providers/passes/verbatim_passes.py
@@ -1,6 +1,6 @@
 """Transpiler passes for preserving verbatim boxes through compilation."""
 
-from qiskit.circuit import Barrier, BoxOp, QuantumCircuit
+from qiskit.circuit import Barrier, BoxOp, Instruction, QuantumCircuit
 from qiskit.converters import circuit_to_dag
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler.basepasses import TransformationPass
@@ -17,6 +17,23 @@ def _is_verbatim_label(label: str | None, base: str) -> bool:
     if label is None:
         return False
     return label == base or (label.startswith(f"{base}__") and label[len(base) + 2 :].isdigit())
+
+
+class VerbatimPlaceholder(Instruction):
+    """A directive instruction used as a placeholder for verbatim boxes with clbits.
+
+    Uses the name ``'barrier'`` so the transpiler's basis translator automatically
+    allows it without needing explicit registration in the target or basis_gates.
+    Distinguished from real barriers by its label (set to the indexed verbatim label).
+    Unlike a real ``Barrier``, this instruction can carry classical bits.
+    """
+
+    _directive = True
+
+    def __init__(self, num_qubits: int, num_clbits: int, label: str | None = None):
+        super().__init__("barrier", num_qubits, num_clbits, [])
+        if label:
+            self.label = label
 
 
 class ExtractVerbatimBoxes(TransformationPass):
@@ -59,14 +76,15 @@ class ExtractVerbatimBoxes(TransformationPass):
                 continue
             label = _indexed_label(self._verbatim_box_name, index)
             verbatim_boxes[label] = (node.op.blocks[0], [dag.find_bit(c).index for c in node.cargs])
-            barrier = Barrier(len(node.qargs), label=label)
             if node.cargs:
-                # BoxOp has clbits — substitute_node requires matching width,
-                # so replace with a sub-DAG containing only the barrier on qubits.
-                qc = QuantumCircuit(len(node.qargs), len(node.cargs))
-                qc.append(barrier, list(range(len(node.qargs))))
-                dag.substitute_node_with_dag(node, circuit_to_dag(qc))
+                # Use a VerbatimPlaceholder that can carry both qubits and
+                # clbits. A plain Barrier cannot carry clbits, and the Rust
+                # substitute_node_with_dag panics when trying to route clbit
+                # wires through a barrier node that has no clbit edges.
+                placeholder = VerbatimPlaceholder(len(node.qargs), len(node.cargs), label=label)
+                dag.substitute_node(node, placeholder)
             else:
+                barrier = Barrier(len(node.qargs), label=label)
                 dag.substitute_node(node, barrier)
             index += 1
 
@@ -100,7 +118,9 @@ class RestoreVerbatimBoxes(TransformationPass):
             return dag
 
         for node in dag.topological_op_nodes():
-            if not isinstance(node.op, Barrier):
+            is_barrier = isinstance(node.op, Barrier)
+            is_placeholder = isinstance(node.op, VerbatimPlaceholder)
+            if not is_barrier and not is_placeholder:
                 continue
             label = getattr(node.op, "label", None)
             if not _is_verbatim_label(label, self._verbatim_box_name):
@@ -112,16 +132,10 @@ class RestoreVerbatimBoxes(TransformationPass):
                 )
             box_circuit, clbit_indices = verbatim_boxes.pop(label)
             box_dag = circuit_to_dag(box_circuit)
-            if clbit_indices:
-                # Build a replacement DAG that includes the box's clbits.
+            if is_placeholder:
+                # Placeholder carries both qubits and clbits — map both.
                 qubit_map = dict(zip(box_dag.qubits, node.qargs, strict=True))
-                clbit_map = dict(
-                    zip(
-                        box_dag.clbits,
-                        [dag.clbits[i] for i in clbit_indices],
-                        strict=True,
-                    )
-                )
+                clbit_map = dict(zip(box_dag.clbits, node.cargs, strict=True))
                 dag.substitute_node_with_dag(node, box_dag, wires={**qubit_map, **clbit_map})
             else:
                 dag.substitute_node_with_dag(node, box_dag)

--- a/test/unit_tests/test_adapter_to_braket_verbatim.py
+++ b/test/unit_tests/test_adapter_to_braket_verbatim.py
@@ -2,10 +2,10 @@
 
 import pytest
 from qiskit import QuantumCircuit
-from qiskit.circuit import Barrier, BoxOp
-from qiskit.circuit.library import CXGate, HGate, Measure, XGate
+from qiskit.circuit import Barrier, BoxOp, Parameter
+from qiskit.circuit.library import CXGate, CZGate, HGate, Measure, RXGate, XGate
 from qiskit.converters import circuit_to_dag, dag_to_circuit
-from qiskit.transpiler import PassManager, Target
+from qiskit.transpiler import InstructionProperties, PassManager, Target
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.passes import Optimize1qGates
 
@@ -793,3 +793,93 @@ def test_verbatim_box_preserves_non_contiguous_qubit_order():
     out = _compile(qc, basis_gates={"cx"}).circuits[0]
     cx = next(i for i in out.data if i.operation.name == "cx")
     assert [out.find_bit(q).index for q in cx.qubits] == [2, 0]
+
+
+def _build_target_2q():
+    """Helper to build a minimal 2-qubit target with rx/h/cz/measure."""
+    target = Target(num_qubits=2)
+    theta = Parameter("theta")
+    target.add_instruction(RXGate(theta), {(i,): InstructionProperties() for i in range(2)})
+    target.add_instruction(HGate(), {(i,): InstructionProperties() for i in range(2)})
+    target.add_instruction(
+        CZGate(), {(0, 1): InstructionProperties(), (1, 0): InstructionProperties()}
+    )
+    target.add_instruction(Measure(), {(i,): InstructionProperties() for i in range(2)})
+    return target
+
+
+@pytest.mark.parametrize(
+    "compile_kwargs",
+    [
+        pytest.param(
+            {"target": _build_target_2q(), "optimization_level": 3, "seed_transpiler": 42},
+            id="target_opt3",
+        ),
+        pytest.param(
+            {
+                "basis_gates": ["rx", "cz", "h", "measure"],
+                "optimization_level": 3,
+                "seed_transpiler": 42,
+            },
+            id="basis_gates_opt3",
+        ),
+    ],
+)
+def test_verbatim_box_with_clbits_no_panic(compile_kwargs):
+    """Verbatim BoxOp with clbits does not panic during extract/restore pipeline."""
+    body = QuantumCircuit(2, 2)
+    body.rx(0.5, 0)
+    body.cz(0, 1)
+
+    qc = QuantumCircuit(2, 2)
+    qc.h(0)
+    qc.append(BoxOp(body, label=VERBATIM_LABEL), qc.qubits, qc.clbits)
+    qc.measure(0, 0)
+    qc.measure(1, 1)
+
+    result = _compile(qc, **compile_kwargs)
+    circ = result.circuits[0]
+    ops = [instr.operation.name for instr in circ.data]
+    assert "rx" in ops
+    assert "cz" in ops
+    assert ops.count("measure") == 2
+
+
+@pytest.mark.parametrize(
+    "compile_kwargs",
+    [
+        pytest.param(
+            {"target": _build_target_2q(), "optimization_level": 3, "seed_transpiler": 42},
+            id="target_opt3",
+        ),
+        pytest.param(
+            {
+                "basis_gates": ["rx", "cz", "h", "measure"],
+                "optimization_level": 3,
+                "seed_transpiler": 42,
+            },
+            id="basis_gates_opt3",
+        ),
+    ],
+)
+def test_verbatim_box_with_mcm_preserves_order(compile_kwargs):
+    """Verbatim BoxOp with mid-circuit measurement preserves operation order.
+
+    Ensures measurements inside verbatim boxes remain in the correct position
+    relative to surrounding quantum gates after the extract/restore pipeline.
+    """
+    body = QuantumCircuit(2, 2)
+    body.rx(0.5, 0)
+    body.measure(0, 0)
+    body.h(0)
+    body.cz(0, 1)
+
+    qc = QuantumCircuit(2, 2)
+    qc.h(0)
+    qc.append(BoxOp(body, label=VERBATIM_LABEL), qc.qubits, qc.clbits)
+    qc.measure(1, 1)
+
+    result = _compile(qc, **compile_kwargs)
+    circ = result.circuits[0]
+    ops = [instr.operation.name for instr in circ.data]
+    assert ops == ["h", "rx", "measure", "h", "cz", "measure"]

--- a/test/unit_tests/test_adapter_to_braket_verbatim.py
+++ b/test/unit_tests/test_adapter_to_braket_verbatim.py
@@ -886,15 +886,20 @@ c[1] = measure q[1];
 
 def test_restore_skips_placeholder_with_non_matching_label():
     """RestoreVerbatimBoxes ignores placeholders whose label doesn't match the verbatim pattern."""
+    label = _indexed_label(VERBATIM_LABEL, 0)
     qc = QuantumCircuit(NUM_QUBITS)
     qc.append(VerbatimPlaceholder(NUM_QUBITS, 0, label="unrelated_label"), QUBIT_PAIR)
+    qc.append(VerbatimPlaceholder(NUM_QUBITS, 0, label=label), QUBIT_PAIR)
+
+    body = QuantumCircuit(NUM_QUBITS)
+    body.h(0)
 
     restore_pass = RestoreVerbatimBoxes(VERBATIM_LABEL)
-    restore_pass.property_set["verbatim_boxes"] = {}
+    restore_pass.property_set["verbatim_boxes"] = {label: body}
 
     dag = circuit_to_dag(qc)
     restored = dag_to_circuit(restore_pass.run(dag))
 
-    assert len(restored.data) == 1
-    assert restored.data[0].operation.name == "barrier"
-    assert restored.data[0].operation.label == "unrelated_label"
+    ops = [(instr.operation.name, getattr(instr.operation, "label", None)) for instr in restored.data]
+    assert ("barrier", "unrelated_label") in ops
+    assert ("h", None) in ops

--- a/test/unit_tests/test_adapter_to_braket_verbatim.py
+++ b/test/unit_tests/test_adapter_to_braket_verbatim.py
@@ -20,7 +20,10 @@ from qiskit_braket_provider.providers.passes import (
     ExtractVerbatimBoxes,
     RestoreVerbatimBoxes,
 )
-from qiskit_braket_provider.providers.passes.verbatim_passes import _indexed_label
+from qiskit_braket_provider.providers.passes.verbatim_passes import (
+    VerbatimPlaceholder,
+    _indexed_label,
+)
 
 VERBATIM_LABEL = "verbatim"
 NUM_QUBITS = 2
@@ -135,12 +138,12 @@ def test_verbatim_box_extraction(
     modified = pm.run(main)
 
     assert len(modified.data) == 1
-    assert isinstance(modified.data[0].operation, Barrier)
+    assert isinstance(modified.data[0].operation, VerbatimPlaceholder)
     assert modified.data[0].operation.label.startswith(VERBATIM_LABEL)
 
     verbatim_boxes = pm.property_set["verbatim_boxes"]
     assert len(verbatim_boxes) == 1
-    box_circuit, _clbits = next(iter(verbatim_boxes.values()))
+    box_circuit = next(iter(verbatim_boxes.values()))
     assert [d.operation.name for d in box_circuit.data] == expected_gate_names
 
     barrier_qubits = [modified.find_bit(q).index for q in modified.data[0].qubits]
@@ -156,7 +159,7 @@ def test_multiple_verbatim_boxes_extraction(h_circuit: QuantumCircuit, cx_circui
     pm = PassManager([ExtractVerbatimBoxes(VERBATIM_LABEL)])
     modified = pm.run(main)
 
-    barriers = [i for i in modified.data if isinstance(i.operation, Barrier)]
+    barriers = [i for i in modified.data if isinstance(i.operation, VerbatimPlaceholder)]
     assert len(barriers) == 2
     assert all(b.operation.label.startswith(VERBATIM_LABEL) for b in barriers)
     assert len([i for i in modified.data if i.operation.name == "x"]) == 1
@@ -167,7 +170,7 @@ def test_multiple_verbatim_boxes_extraction(h_circuit: QuantumCircuit, cx_circui
 
     verbatim_boxes = pm.property_set["verbatim_boxes"]
     assert len(verbatim_boxes) == 2
-    box_circuits = [circ for circ, _clbits in verbatim_boxes.values()]
+    box_circuits = list(verbatim_boxes.values())
     assert box_circuits[0].data[0].operation.name == "h"
     assert box_circuits[1].data[0].operation.name == "cx"
 
@@ -196,13 +199,13 @@ def test_non_verbatim_boxop_not_extracted(h_circuit: QuantumCircuit):
 
 
 def test_single_verbatim_box_restoration(h_cx_circuit: QuantumCircuit):
-    """RestoreVerbatimBoxes replaces a labeled barrier with stashed box contents."""
+    """RestoreVerbatimBoxes replaces a labeled placeholder with stashed box contents."""
     label = _indexed_label(VERBATIM_LABEL, 0)
     transpiled = QuantumCircuit(NUM_QUBITS)
-    transpiled.append(Barrier(NUM_QUBITS, label=label), QUBIT_PAIR)
+    transpiled.append(VerbatimPlaceholder(NUM_QUBITS, 0, label=label), QUBIT_PAIR)
 
     restore_pass = RestoreVerbatimBoxes(VERBATIM_LABEL)
-    restore_pass.property_set["verbatim_boxes"] = {label: (h_cx_circuit, [])}
+    restore_pass.property_set["verbatim_boxes"] = {label: h_cx_circuit}
 
     dag = circuit_to_dag(transpiled)
     restored = dag_to_circuit(restore_pass.run(dag))
@@ -216,18 +219,18 @@ def test_single_verbatim_box_restoration(h_cx_circuit: QuantumCircuit):
 
 
 def test_multiple_verbatim_boxes_restoration(h_circuit: QuantumCircuit, cx_circuit: QuantumCircuit):
-    """RestoreVerbatimBoxes replaces multiple labeled barriers with stashed box contents."""
+    """RestoreVerbatimBoxes replaces multiple labeled placeholders with stashed box contents."""
     label_0 = _indexed_label(VERBATIM_LABEL, 0)
     label_1 = _indexed_label(VERBATIM_LABEL, 1)
     transpiled = QuantumCircuit(NUM_QUBITS)
-    transpiled.append(Barrier(NUM_QUBITS, label=label_0), QUBIT_PAIR)
+    transpiled.append(VerbatimPlaceholder(NUM_QUBITS, 0, label=label_0), QUBIT_PAIR)
     transpiled.x(1)
-    transpiled.append(Barrier(NUM_QUBITS, label=label_1), QUBIT_PAIR)
+    transpiled.append(VerbatimPlaceholder(NUM_QUBITS, 0, label=label_1), QUBIT_PAIR)
 
     restore_pass = RestoreVerbatimBoxes(VERBATIM_LABEL)
     restore_pass.property_set["verbatim_boxes"] = {
-        label_0: (h_circuit, []),
-        label_1: (cx_circuit, []),
+        label_0: h_circuit,
+        label_1: cx_circuit,
     }
 
     dag = circuit_to_dag(transpiled)
@@ -664,18 +667,18 @@ def test_restore_without_extract_is_noop():
 
 
 def test_restore_raises_on_mismatched_barrier_label():
-    """RestoreVerbatimBoxes raises when a verbatim barrier has no matching box."""
+    """RestoreVerbatimBoxes raises when a verbatim placeholder has no matching box."""
 
     qc = QuantumCircuit(NUM_QUBITS)
     label = _indexed_label(VERBATIM_LABEL, 0)
-    qc.append(Barrier(NUM_QUBITS, label=label), QUBIT_PAIR)
+    qc.append(VerbatimPlaceholder(NUM_QUBITS, 0, label=label), QUBIT_PAIR)
 
     restore_pass = RestoreVerbatimBoxes(VERBATIM_LABEL)
     # Set verbatim_boxes with a different label than what's in the circuit
     different_label = _indexed_label(VERBATIM_LABEL, 99)
     body = QuantumCircuit(NUM_QUBITS)
     body.h(0)
-    restore_pass.property_set["verbatim_boxes"] = {different_label: (body, [])}
+    restore_pass.property_set["verbatim_boxes"] = {different_label: body}
 
     dag = circuit_to_dag(qc)
     with pytest.raises(RuntimeError, match="has no matching box"):
@@ -693,7 +696,7 @@ def test_restore_raises_on_leftover_boxes():
     label = _indexed_label(VERBATIM_LABEL, 0)
     body = QuantumCircuit(NUM_QUBITS)
     body.h(0)
-    restore_pass.property_set["verbatim_boxes"] = {label: (body, [])}
+    restore_pass.property_set["verbatim_boxes"] = {label: body}
 
     dag = circuit_to_dag(qc)
     with pytest.raises(RuntimeError, match="stashed verbatim boxes were not restored"):
@@ -826,17 +829,18 @@ def _build_target_2q() -> Target:
     ],
 )
 def test_verbatim_box_with_clbits_no_panic(compile_kwargs: dict):
-    """Verbatim BoxOp with clbits does not panic during extract/restore pipeline."""
-    body = QuantumCircuit(2, 2)
-    body.rx(0.5, 0)
-    body.cz(0, 1)
-
-    qc = QuantumCircuit(2, 2)
-    qc.h(0)
-    qc.append(BoxOp(body, label=VERBATIM_LABEL), qc.qubits, qc.clbits)
-    qc.measure(0, 0)
-    qc.measure(1, 1)
-
+    """OQ3 verbatim box with classical registers does not panic during compilation."""
+    source = """\
+OPENQASM 3.0;
+bit[2] c;
+qubit[2] q;
+h q[0];
+#pragma braket verbatim
+box { rx(0.5) q[0]; cz q[0], q[1]; }
+c[0] = measure q[0];
+c[1] = measure q[1];
+"""
+    qc = to_qiskit(source)
     result = _compile(qc, **compile_kwargs)
     circ = result.circuits[0]
     ops = [instr.operation.name for instr in circ.data]
@@ -863,22 +867,17 @@ def test_verbatim_box_with_clbits_no_panic(compile_kwargs: dict):
     ],
 )
 def test_verbatim_box_with_mcm_preserves_order(compile_kwargs: dict):
-    """Verbatim BoxOp with mid-circuit measurement preserves operation order.
-
-    Ensures measurements inside verbatim boxes remain in the correct position
-    relative to surrounding quantum gates after the extract/restore pipeline.
-    """
-    body = QuantumCircuit(2, 2)
-    body.rx(0.5, 0)
-    body.measure(0, 0)
-    body.h(0)
-    body.cz(0, 1)
-
-    qc = QuantumCircuit(2, 2)
-    qc.h(0)
-    qc.append(BoxOp(body, label=VERBATIM_LABEL), qc.qubits, qc.clbits)
-    qc.measure(1, 1)
-
+    """OQ3 verbatim box with mid-circuit measurement preserves operation order."""
+    source = """\
+OPENQASM 3.0;
+bit[2] c;
+qubit[2] q;
+h q[0];
+#pragma braket verbatim
+box { rx(0.5) q[0]; c[0] = measure q[0]; h q[0]; cz q[0], q[1]; }
+c[1] = measure q[1];
+"""
+    qc = to_qiskit(source)
     result = _compile(qc, **compile_kwargs)
     circ = result.circuits[0]
     ops = [instr.operation.name for instr in circ.data]

--- a/test/unit_tests/test_adapter_to_braket_verbatim.py
+++ b/test/unit_tests/test_adapter_to_braket_verbatim.py
@@ -795,7 +795,7 @@ def test_verbatim_box_preserves_non_contiguous_qubit_order():
     assert [out.find_bit(q).index for q in cx.qubits] == [2, 0]
 
 
-def _build_target_2q():
+def _build_target_2q() -> Target:
     """Helper to build a minimal 2-qubit target with rx/h/cz/measure."""
     target = Target(num_qubits=2)
     theta = Parameter("theta")
@@ -825,7 +825,7 @@ def _build_target_2q():
         ),
     ],
 )
-def test_verbatim_box_with_clbits_no_panic(compile_kwargs):
+def test_verbatim_box_with_clbits_no_panic(compile_kwargs: dict):
     """Verbatim BoxOp with clbits does not panic during extract/restore pipeline."""
     body = QuantumCircuit(2, 2)
     body.rx(0.5, 0)
@@ -862,7 +862,7 @@ def test_verbatim_box_with_clbits_no_panic(compile_kwargs):
         ),
     ],
 )
-def test_verbatim_box_with_mcm_preserves_order(compile_kwargs):
+def test_verbatim_box_with_mcm_preserves_order(compile_kwargs: dict):
     """Verbatim BoxOp with mid-circuit measurement preserves operation order.
 
     Ensures measurements inside verbatim boxes remain in the correct position

--- a/test/unit_tests/test_adapter_to_braket_verbatim.py
+++ b/test/unit_tests/test_adapter_to_braket_verbatim.py
@@ -900,6 +900,8 @@ def test_restore_skips_placeholder_with_non_matching_label():
     dag = circuit_to_dag(qc)
     restored = dag_to_circuit(restore_pass.run(dag))
 
-    ops = [(instr.operation.name, getattr(instr.operation, "label", None)) for instr in restored.data]
+    ops = [
+        (instr.operation.name, getattr(instr.operation, "label", None)) for instr in restored.data
+    ]
     assert ("barrier", "unrelated_label") in ops
     assert ("h", None) in ops

--- a/test/unit_tests/test_adapter_to_braket_verbatim.py
+++ b/test/unit_tests/test_adapter_to_braket_verbatim.py
@@ -882,3 +882,19 @@ c[1] = measure q[1];
     circ = result.circuits[0]
     ops = [instr.operation.name for instr in circ.data]
     assert ops == ["h", "rx", "measure", "h", "cz", "measure"]
+
+
+def test_restore_skips_placeholder_with_non_matching_label():
+    """RestoreVerbatimBoxes ignores placeholders whose label doesn't match the verbatim pattern."""
+    qc = QuantumCircuit(NUM_QUBITS)
+    qc.append(VerbatimPlaceholder(NUM_QUBITS, 0, label="unrelated_label"), QUBIT_PAIR)
+
+    restore_pass = RestoreVerbatimBoxes(VERBATIM_LABEL)
+    restore_pass.property_set["verbatim_boxes"] = {}
+
+    dag = circuit_to_dag(qc)
+    restored = dag_to_circuit(restore_pass.run(dag))
+
+    assert len(restored.data) == 1
+    assert restored.data[0].operation.name == "barrier"
+    assert restored.data[0].operation.label == "unrelated_label"

--- a/test/unit_tests/test_adapter_to_braket_verbatim.py
+++ b/test/unit_tests/test_adapter_to_braket_verbatim.py
@@ -43,6 +43,19 @@ def _make_box_circuit(num_qubits: int, gates: list[tuple[str, list[int]]]) -> Qu
     return qc
 
 
+def _build_target_2q() -> Target:
+    """Helper to build a minimal 2-qubit target with rx/h/cz/measure."""
+    target = Target(num_qubits=2)
+    theta = Parameter("theta")
+    target.add_instruction(RXGate(theta), {(i,): InstructionProperties() for i in range(2)})
+    target.add_instruction(HGate(), {(i,): InstructionProperties() for i in range(2)})
+    target.add_instruction(
+        CZGate(), {(0, 1): InstructionProperties(), (1, 0): InstructionProperties()}
+    )
+    target.add_instruction(Measure(), {(i,): InstructionProperties() for i in range(2)})
+    return target
+
+
 def _gate_info(braket_circuit: Circuit) -> list[tuple[str, list[int]]]:
     """Extract (name, target) list from a Braket circuit."""
     return [(instr.operator.name, instr.target) for instr in braket_circuit.instructions]
@@ -796,19 +809,6 @@ def test_verbatim_box_preserves_non_contiguous_qubit_order():
     out = _compile(qc, basis_gates={"cx"}).circuits[0]
     cx = next(i for i in out.data if i.operation.name == "cx")
     assert [out.find_bit(q).index for q in cx.qubits] == [2, 0]
-
-
-def _build_target_2q() -> Target:
-    """Helper to build a minimal 2-qubit target with rx/h/cz/measure."""
-    target = Target(num_qubits=2)
-    theta = Parameter("theta")
-    target.add_instruction(RXGate(theta), {(i,): InstructionProperties() for i in range(2)})
-    target.add_instruction(HGate(), {(i,): InstructionProperties() for i in range(2)})
-    target.add_instruction(
-        CZGate(), {(0, 1): InstructionProperties(), (1, 0): InstructionProperties()}
-    )
-    target.add_instruction(Measure(), {(i,): InstructionProperties() for i in range(2)})
-    return target
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
  
  Fixes a `PanicException` (`Option::unwrap() on None`) in `RestoreVerbatimBoxes` when compiling circuits containing verbatim `BoxOp` nodes with
  classical bits through either the `target=` or `basis_gates=` transpile path.
  
  ## Root Cause
  
  `ExtractVerbatimBoxes` replaced `BoxOp` nodes (which carry both qubits and clbits) with a `Barrier` placeholder. However, Qiskit's `Barrier`
  cannot carry classical bits. When `RestoreVerbatimBoxes` later called `substitute_node_with_dag(node, box_dag, wires={qubit_map + clbit_map})`,
  the Rust implementation panicked because it tried to route clbit wires through a node that had no clbit edges.
  
  ## Fix
  
  Introduce `VerbatimPlaceholder` — a custom `Instruction` subclass with `_directive = True` that can carry both qubits and clbits. It uses the name
  `'barrier'` so Qiskit's transpiler auto-allows it on both `target=` and `basis_gates=` paths without explicit registration. On restoration,
  `substitute_node_with_dag` succeeds because the placeholder node has matching qubit and clbit edges.
  
  ## Trigger Conditions (all required)
  
  1. A verbatim `BoxOp` with classical bits attached (arises from OQ3 `bit[N] c;` at top-level scope + `#pragma braket verbatim box{...}`)
  2. Compilation via `_compile()` with either `target=` or `basis_gates=` (any optimization level)
  
  ## Testing
  
  - Added parametrized regression test covering both `target=` and `basis_gates=` paths
  - Added mid-circuit measurement ordering test (both paths)
  - All 46 verbatim tests pass; full test suite has zero new failures
  
  ## Reproducer
  
  ```python
  from qiskit_braket_provider import to_qiskit, to_braket
  
  source = """OPENQASM 3.0;
  bit[2] c;
  qubit[2] q;
  h q[0];
  #pragma braket verbatim
  box { rx(0.5) q[0]; cz q[0], q[1]; }
  c[0] = measure q[0];
  c[1] = measure q[1];
  """
  
  qc = to_qiskit(source)
  bc = to_braket(qc, basis_gates=["rx", "cz", "h", "measure"])  # was: PanicException
```

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md) doc
- [ ] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md#pr-title-format)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/README.md) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
