### PR TITLE
fix: remove NotImplemented error for basis-invariant result types

### DIFF
--- a/qiskit_braket_provider/providers/passes/basis_rotation_pass.py
+++ b/qiskit_braket_provider/providers/passes/basis_rotation_pass.py
@@ -286,10 +286,7 @@ class AddBasisRotationAndMeasurement(TransformationPass):
 
         for result in result_pragmas:
             if isinstance(result, _BASIS_INVARIANT_RESULT_TYPES):
-                raise NotImplementedError(
-                    f"{type(result).__name__} result types are not yet supported "
-                    "end-to-end. Support will be added in a future release."
-                )
+                continue
 
             if isinstance(result, _Z_BASIS_RESULT_TYPES):
                 qubits = _qubits_for_z_basis_type(result, num_qubits)

--- a/test/unit_tests/test_basis_rotation_pass.py
+++ b/test/unit_tests/test_basis_rotation_pass.py
@@ -388,12 +388,13 @@ def test_fresh_clbits_allocated():
     ],
     ids=["state_vector", "density_matrix", "amplitude"],
 )
-def test_basis_invariant_raises_not_implemented(pragmas: list):
-    """Basis-invariant types raise NotImplementedError until end-to-end support lands."""
+def test_basis_invariant_is_noop(pragmas: list):
+    """Basis-invariant types are skipped — no gates or measurements added."""
     qc = _circuit_with_result_pragmas(2, pragmas)
 
-    with pytest.raises(NotImplementedError, match="not yet supported end-to-end"):
-        _run_pragma_handling_pass(qc)
+    result = _run_pragma_handling_pass(qc)
+    ops = [instr.operation.name for instr in result.data]
+    assert "measure" not in ops
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
 ## Summary
  
  Removes the `NotImplementedError` for basis-invariant result types (`state_vector`, `density_matrix`, `amplitude`) in the
  `AddBasisRotationAndMeasurement` pass, allowing these result types to flow through the compilation pipeline without crashing.
  
  ## Changes
  
  - **`basis_rotation_pass.py`**: Replace `raise NotImplementedError(...)` with `continue` for basis-invariant result types. These types don't require rotation gates or measurements since they are computed directly from the quantum state.
  - **`test_basis_rotation_pass.py`**: Update the corresponding test from expecting `NotImplementedError` to verifying the pass is a no-op (no measurements added).
  
  ## Rationale
  
  Basis-invariant result types (state_vector, density_matrix, amplitude) are simulator-only constructs computed analytically from the final quantum state — they don't need measurement collapse. The pass correctly leaves the circuit unchanged for these types, and stores the result types requested in the metadata for the Qiskit `QuantumCircuit` object. The previous `NotImplementedError` was a temporary placeholder that is no longer needed.
  
  ## Testing
  
  - Updated parametrized test covering state_vector, density_matrix, and amplitude
  - Full test suite passes with no regressions (375 passed)
  - Ruff format and lint checks pass
*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md) doc
- [ ] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md#pr-title-format)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/README.md) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
