### PR TITLE
fix: scope 'all' to touched qubits for physical-qubit sources

### DIFF
--- a/qiskit_braket_provider/providers/passes/basis_rotation_pass.py
+++ b/qiskit_braket_provider/providers/passes/basis_rotation_pass.py
@@ -11,7 +11,6 @@ from qiskit.transpiler.basepasses import TransformationPass
 
 from braket.ir.jaqcd import (
     Expectation,
-    Probability,
     Sample,
     Variance,
 )
@@ -266,9 +265,9 @@ class AddBasisRotationAndMeasurement(TransformationPass):
         # For physical-qubit sources ($N), Qiskit widens the register to the max
         # index; 'all' should skip gap qubits the customer never referenced.
         if any(q._register is None for q in dag.qubits):
-            all_qubits = sorted(
-                {dag.find_bit(q).index for node in dag.op_nodes() for q in node.qargs}
-            )
+            all_qubits = sorted({
+                dag.find_bit(q).index for node in dag.op_nodes() for q in node.qargs
+            })
         else:
             all_qubits = list(range(num_qubits))
         all_rotation_ops: list[RotationOp] = []

--- a/qiskit_braket_provider/providers/passes/basis_rotation_pass.py
+++ b/qiskit_braket_provider/providers/passes/basis_rotation_pass.py
@@ -95,22 +95,6 @@ def _rotation_gates_for_hermitian(
     return [(UnitaryGate(unitary), targets)], eigenvalues
 
 
-def _qubits_for_z_basis_type(result: Probability, num_qubits: int) -> set[int]:
-    """Return the set of qubit indices to measure for a Z-basis result type.
-
-    Args:
-        result: A Probability result type.
-        num_qubits: Total number of qubits in the circuit.
-
-    Returns:
-        Set of qubit indices to measure. No rotation is needed for Z-basis types.
-    """
-    targets = result.targets
-    if targets is not None:
-        return set(targets)
-    return set(range(num_qubits))
-
-
 def _check_basis_conflict(
     qubit_bases: dict[int, Hashable], qubit: int, basis_key: Hashable
 ) -> bool:
@@ -157,13 +141,13 @@ def _check_basis_conflict(
 
 
 def _plan_for_observable_type(
-    result: Expectation | Sample | Variance, num_qubits: int
+    result: Expectation | Sample | Variance, targets: list[int]
 ) -> tuple[list[RotationOp], dict[int, Hashable], dict[tuple[int, ...], np.ndarray]]:
     """Compute the rotation/measurement plan for an observable result type.
 
     Args:
         result: An Expectation, Sample, or Variance result type.
-        num_qubits: Total number of qubits in the circuit.
+        targets: The qubit indices this observable applies to.
 
     Returns:
         Tuple of (rotation_ops, qubit_bases, eigenvalues_by_qubits) where:
@@ -176,7 +160,6 @@ def _plan_for_observable_type(
             there are more observables than target qubits.
     """
     observable = result.observable
-    targets = result.targets if result.targets is not None else list(range(num_qubits))
 
     if len(set(targets)) != len(targets):
         raise ValueError(f"All targets in a result-type pragma must be unique: {targets}")
@@ -280,6 +263,14 @@ class AddBasisRotationAndMeasurement(TransformationPass):
             )
 
         num_qubits = dag.num_qubits()
+        # For physical-qubit sources ($N), Qiskit widens the register to the max
+        # index; 'all' should skip gap qubits the customer never referenced.
+        if any(q._register is None for q in dag.qubits):
+            all_qubits = sorted(
+                {dag.find_bit(q).index for node in dag.op_nodes() for q in node.qargs}
+            )
+        else:
+            all_qubits = list(range(num_qubits))
         all_rotation_ops: list[RotationOp] = []
         all_qubit_bases: dict[int, Hashable] = {}
         all_eigenvalues: dict[tuple[int, ...], np.ndarray] = {}
@@ -289,14 +280,14 @@ class AddBasisRotationAndMeasurement(TransformationPass):
                 continue
 
             if isinstance(result, _Z_BASIS_RESULT_TYPES):
-                qubits = _qubits_for_z_basis_type(result, num_qubits)
-                for qubit in qubits:
+                for qubit in result.targets if result.targets is not None else all_qubits:
                     _check_basis_conflict(all_qubit_bases, qubit, "z")
                 continue
 
             if isinstance(result, _OBSERVABLE_RESULT_TYPES):
+                targets = result.targets if result.targets is not None else all_qubits
                 rotation_ops, qubit_bases, eigenvalues_by_qubits = _plan_for_observable_type(
-                    result, num_qubits
+                    result, targets
                 )
                 for qubit_group, eigenvalues in eigenvalues_by_qubits.items():
                     if qubit_group not in all_eigenvalues:

--- a/test/unit_tests/test_basis_rotation_pass.py
+++ b/test/unit_tests/test_basis_rotation_pass.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pytest
 from qiskit import QuantumCircuit
+from qiskit.circuit import Qubit
 from qiskit.transpiler import PassManager
 
 from braket.ir.jaqcd import (
@@ -245,6 +246,23 @@ def test_multi_qubit_cases(pragmas: list, num_qubits: int, expected_ops: list):
     added = _get_ops_after_base(result, base_count)
 
     assert added == expected_ops
+
+
+def test_orphan_qubits_all_target_covers_only_touched():
+    """'all' targets should skip qubits the customer never referenced on
+    orphan-qubit sources (physical qubit references)."""
+    qc = QuantumCircuit()
+    for _ in range(4):
+        qc.add_bits([Qubit()])
+    qc.z(1)
+    qc.z(3)
+    qc.metadata = {"braket_result_pragmas": [Probability(targets=None)]}
+
+    result = _run_pragma_handling_pass(qc)
+    added = _get_ops_after_base(result, len(qc.data) - 2)
+
+    measured = sorted(op[1][0] for op in added if op[0] == "measure")
+    assert measured == [1, 3]
 
 
 def test_hermitian_observable_applies_unitary():


### PR DESCRIPTION
  ### Description of changes
  
  **Problem.** When a source uses physical qubit references (`$N`), `to_qiskit` widens the `QuantumCircuit` register to fit the max physical index — Qiskit doesn't allow sparse qubit lists. For `z $1; z $3;` this produces a 4-qubit circuit with gap qubits at positions `0` and `2` that were never referenced.
  
  `AddBasisRotationAndMeasurement` then expanded `targets: None` via `range(num_qubits)`, so `probability all` (and other `all` targets) measured those gap qubits — physical qubits the device may not even have.
  
  **Example.** Given:
  
  ```qasm
  z $1;
  z $3;
  #pragma braket result probability all
  ```
  - Before: measures $0, $1, $2, $3
  - After: measures $1, $3
  
  Fix. Scope all targets to the qubits actually touched by circuit ops when the source uses orphan qubits; otherwise fall back to range(num_qubits). No behaviour change for virtual-register sources.
  
  As a small cleanup, the `trivial _qubits_for_z_basis_type` helper was inlined, and `_plan_for_observable_type` now takes an explicit targets: list[int] argument instead of resolving `num_qubits` internally.
## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md#pr-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/README.md) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
